### PR TITLE
Fix silent port conflict on server startup

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
         "test-search": "tsx scripts/test-search.ts",
         "integration-test": "tsx scripts/integration-test.ts",
         "fixture:breeze-api": "node fixtures/breeze-api/server.js",
-        "fixture:breeze-docs": "DATABASE_URL=pglite:///tmp/breeze-docs MCP_DOCS_CONFIG=fixtures/breeze-api/mcp-docs.yaml tsx watch src/index.ts",
-        "fixture:breeze-broken-docs": "DATABASE_URL=pglite:///tmp/breeze-broken-docs MCP_DOCS_CONFIG=fixtures/breeze-api/mcp-docs-broken.yaml tsx watch src/index.ts",
+        "fixture:breeze-docs": "DATABASE_URL=pglite:///tmp/breeze-docs MCP_DOCS_CONFIG=fixtures/breeze-api/mcp-docs.yaml tsx src/index.ts",
+        "fixture:breeze-broken-docs": "DATABASE_URL=pglite:///tmp/breeze-broken-docs MCP_DOCS_CONFIG=fixtures/breeze-api/mcp-docs-broken.yaml tsx src/index.ts",
         "claude": "TMPDIR=$(mktemp -d) && echo '{\"mcpServers\":{\"mcp-docs\":{\"type\":\"http\",\"url\":\"http://localhost:3001/mcp\"}}}' > \"$TMPDIR/mcp.json\" && (cd \"$TMPDIR\" && claude --strict-mcp-config --mcp-config \"$TMPDIR/mcp.json\"); rm -rf \"$TMPDIR\"",
         "test": "vitest run"
     },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "fixture:breeze-api": "node fixtures/breeze-api/server.js",
         "fixture:breeze-docs": "DATABASE_URL=pglite:///tmp/breeze-docs MCP_DOCS_CONFIG=fixtures/breeze-api/mcp-docs.yaml tsx src/index.ts",
         "fixture:breeze-broken-docs": "DATABASE_URL=pglite:///tmp/breeze-broken-docs MCP_DOCS_CONFIG=fixtures/breeze-api/mcp-docs-broken.yaml tsx src/index.ts",
-        "claude": "TMPDIR=$(mktemp -d) && echo '{\"mcpServers\":{\"mcp-docs\":{\"type\":\"http\",\"url\":\"http://localhost:3001/mcp\"}}}' > \"$TMPDIR/mcp.json\" && (cd \"$TMPDIR\" && claude --strict-mcp-config --mcp-config \"$TMPDIR/mcp.json\"); rm -rf \"$TMPDIR\"",
+        "claude": "_MCP_PORT=${PORT:-3001} && _MCP_TMPDIR=$(mktemp -d) && echo \"{\\\"mcpServers\\\":{\\\"mcp-docs\\\":{\\\"type\\\":\\\"http\\\",\\\"url\\\":\\\"http://localhost:${_MCP_PORT}/mcp\\\"}}}\" > \"$_MCP_TMPDIR/mcp.json\" && (cd \"$_MCP_TMPDIR\" && claude --strict-mcp-config --mcp-config \"$_MCP_TMPDIR/mcp.json\"); rm -rf \"$_MCP_TMPDIR\"",
         "test": "vitest run"
     },
     "dependencies": {

--- a/src/index.ts
+++ b/src/index.ts
@@ -258,9 +258,17 @@ async function start(): Promise<void> {
     orchestrator.startNightlyReindex();
 
     const serverName = serverCfg.server.name;
-    app.listen(cfg.port, () => {
+    const server = app.listen(cfg.port, () => {
         console.log(`[${serverName}] Running at http://localhost:${cfg.port}/mcp`);
         console.log(`[health] http://localhost:${cfg.port}/health`);
+    });
+    server.on("error", (err: NodeJS.ErrnoException) => {
+        if (err.code === "EADDRINUSE") {
+            console.error(`[startup] Port ${cfg.port} is already in use. Set PORT env var to use a different port.`);
+        } else {
+            console.error(`[startup] Server error:`, err);
+        }
+        process.exit(1);
     });
 }
 


### PR DESCRIPTION
## Summary
- Add EADDRINUSE error handler to `app.listen()` so the server crashes with a clear message instead of silently failing to bind while the process stays alive doing indexing work
- Remove `tsx watch` from fixture scripts so `process.exit(1)` actually terminates the process
- Allow `PORT` env var override in `npm run claude` script (defaults to 3001)

## Test plan
- [ ] Run `npm run fixture:breeze-docs` while port 3001 is occupied — should exit with clear error
- [ ] Run `PORT=3002 npm run fixture:breeze-docs` — should start on 3002
- [ ] Run `PORT=3002 npm run claude` — should connect to MCP server on 3002