### PR TITLE
Fix Docker startup failures and MCP server instability

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
         volumes:
             - pgdata:/var/lib/postgresql/data
         healthcheck:
-            test: ["CMD-SHELL", "pg_isready -U mcp"]
+            test: ["CMD-SHELL", "pg_isready -U mcp -d mcp_docs"]
             interval: 5s
             retries: 5
 
@@ -20,7 +20,7 @@ services:
             dockerfile: Dockerfile
             target: dev
         ports:
-            - "3001:3001"
+            - "3002:3001"
         environment:
             DATABASE_URL: postgresql://mcp:mcp_local@db:5432/mcp_docs
             OPENAI_API_KEY: ${OPENAI_API_KEY}
@@ -37,7 +37,8 @@ services:
         depends_on:
             db:
                 condition: service_healthy
-        command: npx tsx watch src/index.ts
+        restart: unless-stopped
+        command: npx tsx src/index.ts
 
 volumes:
     pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,7 +20,7 @@ services:
             dockerfile: Dockerfile
             target: dev
         ports:
-            - "3002:3001"
+            - "${APP_PORT:-3001}:3001"
         environment:
             DATABASE_URL: postgresql://mcp:mcp_local@db:5432/mcp_docs
             OPENAI_API_KEY: ${OPENAI_API_KEY}

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -31,9 +31,10 @@ export async function initializeSchema(): Promise<void> {
 
     const dimensions = getServerConfig().embedding.dimensions;
 
-    // Register pgvector types on a dedicated client first
+    // Ensure the vector extension exists before registering types
     const setupClient = await p.connect();
     try {
+        await setupClient.query('CREATE EXTENSION IF NOT EXISTS vector');
         await pgvector.registerType(setupClient);
     } finally {
         setupClient.release();

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -34,6 +34,8 @@ export async function initializeSchema(): Promise<void> {
     // Ensure the vector extension exists before registering types
     const setupClient = await p.connect();
     try {
+        // Requires superuser or pg_extension_owner — works with the default Docker image
+        // but will fail on locked-down setups (e.g. RDS) without explicit grants
         await setupClient.query('CREATE EXTENSION IF NOT EXISTS vector');
         await pgvector.registerType(setupClient);
     } finally {


### PR DESCRIPTION
Fix local Docker setup for first-time runs and connection stability

The server crashed on first boot because the pgvector extension wasn't created before type registration. It also restarted frequently during normal development because `tsx watch` restarts on any save to `src/`, `scripts/`, or `mcp-docs.yaml`. This PR fixes both.

**Changes:**
- Create the `vector` extension before registering pgvector types so fresh databases initialize correctly
- Remove `tsx watch` so saves to `src/`, `scripts/`, or `mcp-docs.yaml` don't restart the MCP server mid-session
- Add `restart: unless-stopped` so the container recovers automatically if it crashes
- Fix the healthcheck database name to avoid FATAL log noise on startup