### PR TITLE
v1.4: HTML source type + dogfooding config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # Changelog
 
+## 1.4.0
+
+### Minor Changes
+
+- Add HTML source type for indexing static HTML documentation sites (cheerio-based parser)
+- Strip non-content elements (script, style, nav, footer, header, svg, noscript)
+- Content container auto-detection (main, article, [role="main"], .content, #content)
+- Heading-boundary chunking with headingPath tracking (h1-h3)
+- Code block preservation, list formatting, table formatting
+- Add pathfinder-docs.yaml for dogfooding Pathfinder on its own documentation
+- Dockerfile updated to support multi-config deployments
+
 ## 1.1.0
 
 ### Minor Changes

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,6 +23,7 @@ COPY package.json package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=build /app/dist/ ./dist/
 COPY pathfinder.yaml ./pathfinder.yaml
+COPY pathfinder-docs.yaml ./pathfinder-docs.yaml
 COPY pathfinder.example.yaml ./pathfinder.example.yaml
 COPY .env.example ./.env.example
 CMD ["node", "dist/cli.js", "serve"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
             "version": "1.1.0",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.25.2",
+                "cheerio": "^1.2.0",
                 "commander": "^14.0.3",
                 "cors": "^2.8.5",
                 "dotenv": "^17.3.1",
@@ -20,6 +21,9 @@
                 "simple-git": "^3.27.0",
                 "yaml": "^2.8.3",
                 "zod": "^3.23.8"
+            },
+            "bin": {
+                "pathfinder": "dist/cli.js"
             },
             "devDependencies": {
                 "@electric-sql/pglite": "^0.4.2",
@@ -1425,6 +1429,12 @@
                 "url": "https://opencollective.com/express"
             }
         },
+        "node_modules/boolbase": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolbase/-/boolbase-1.0.0.tgz",
+            "integrity": "sha512-JZOSA7Mo9sNGB8+UjSgzdLtokWAky1zbztM3WRLCbZ70/3cTANmQmOdR7y2g+J0e2WXywy1yS468tY+IruqEww==",
+            "license": "ISC"
+        },
         "node_modules/brace-expansion": {
             "version": "5.0.5",
             "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
@@ -1508,6 +1518,48 @@
             "license": "MIT",
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/cheerio": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+            "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
+            "license": "MIT",
+            "dependencies": {
+                "cheerio-select": "^2.1.0",
+                "dom-serializer": "^2.0.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "encoding-sniffer": "^0.2.1",
+                "htmlparser2": "^10.1.0",
+                "parse5": "^7.3.0",
+                "parse5-htmlparser2-tree-adapter": "^7.1.0",
+                "parse5-parser-stream": "^7.1.2",
+                "undici": "^7.19.0",
+                "whatwg-mimetype": "^4.0.0"
+            },
+            "engines": {
+                "node": ">=20.18.1"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/cheerio?sponsor=1"
+            }
+        },
+        "node_modules/cheerio-select": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/cheerio-select/-/cheerio-select-2.1.0.tgz",
+            "integrity": "sha512-9v9kG0LvzrlcungtnJtpGNxY+fzECQKhK4EGJX2vByejiMX84MFNQw4UxPJl3bFbTMw+Dfs37XaIkCwTZfLh4g==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-select": "^5.1.0",
+                "css-what": "^6.1.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
             }
         },
         "node_modules/chownr": {
@@ -1641,6 +1693,34 @@
                 "node": ">= 8"
             }
         },
+        "node_modules/css-select": {
+            "version": "5.2.2",
+            "resolved": "https://registry.npmjs.org/css-select/-/css-select-5.2.2.tgz",
+            "integrity": "sha512-TizTzUddG/xYLA3NXodFM0fSbNizXjOKhqiQQwvhlspadZokn1KDy0NZFS0wuEubIYAV5/c1/lAr0TaaFXEXzw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0",
+                "css-what": "^6.1.0",
+                "domhandler": "^5.0.2",
+                "domutils": "^3.0.1",
+                "nth-check": "^2.0.1"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/css-what": {
+            "version": "6.2.2",
+            "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
+            "integrity": "sha512-u/O3vwbptzhMs3L1fQE82ZSLHQQfto5gyZzwteVIEyeaY5Fc7R4dapF/BvRoSYFeqfBk4m0V1Vafq5Pjv25wvA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">= 6"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/fb55"
+            }
+        },
         "node_modules/debug": {
             "version": "4.4.3",
             "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
@@ -1721,6 +1801,61 @@
                 "node": ">=0.3.1"
             }
         },
+        "node_modules/dom-serializer": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/dom-serializer/-/dom-serializer-2.0.0.tgz",
+            "integrity": "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==",
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.2",
+                "entities": "^4.2.0"
+            },
+            "funding": {
+                "url": "https://github.com/cheeriojs/dom-serializer?sponsor=1"
+            }
+        },
+        "node_modules/domelementtype": {
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/domelementtype/-/domelementtype-2.3.0.tgz",
+            "integrity": "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==",
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "BSD-2-Clause"
+        },
+        "node_modules/domhandler": {
+            "version": "5.0.3",
+            "resolved": "https://registry.npmjs.org/domhandler/-/domhandler-5.0.3.tgz",
+            "integrity": "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "domelementtype": "^2.3.0"
+            },
+            "engines": {
+                "node": ">= 4"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domhandler?sponsor=1"
+            }
+        },
+        "node_modules/domutils": {
+            "version": "3.2.2",
+            "resolved": "https://registry.npmjs.org/domutils/-/domutils-3.2.2.tgz",
+            "integrity": "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "dom-serializer": "^2.0.0",
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/domutils?sponsor=1"
+            }
+        },
         "node_modules/dotenv": {
             "version": "17.3.1",
             "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
@@ -1762,6 +1897,31 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/encoding-sniffer": {
+            "version": "0.2.1",
+            "resolved": "https://registry.npmjs.org/encoding-sniffer/-/encoding-sniffer-0.2.1.tgz",
+            "integrity": "sha512-5gvq20T6vfpekVtqrYQsSCFZ1wEg5+wW0/QaZMWkFr6BqD3NfKs0rLCx4rrVlSWJeZb5NBJgVLswK/w2MWU+Gw==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "whatwg-encoding": "^3.1.1"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/encoding-sniffer?sponsor=1"
+            }
+        },
+        "node_modules/encoding-sniffer/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/end-of-stream": {
             "version": "1.4.5",
             "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
@@ -1770,6 +1930,18 @@
             "optional": true,
             "dependencies": {
                 "once": "^1.4.0"
+            }
+        },
+        "node_modules/entities": {
+            "version": "4.5.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+            "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/es-define-property": {
@@ -2342,6 +2514,37 @@
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"
+            }
+        },
+        "node_modules/htmlparser2": {
+            "version": "10.1.0",
+            "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+            "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
+            "funding": [
+                "https://github.com/fb55/htmlparser2?sponsor=1",
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/fb55"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "domelementtype": "^2.3.0",
+                "domhandler": "^5.0.3",
+                "domutils": "^3.2.2",
+                "entities": "^7.0.1"
+            }
+        },
+        "node_modules/htmlparser2/node_modules/entities": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+            "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
             }
         },
         "node_modules/http-errors": {
@@ -3024,6 +3227,18 @@
                 "url": "https://github.com/sponsors/oorabona"
             }
         },
+        "node_modules/nth-check": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/nth-check/-/nth-check-2.1.1.tgz",
+            "integrity": "sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==",
+            "license": "BSD-2-Clause",
+            "dependencies": {
+                "boolbase": "^1.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/nth-check?sponsor=1"
+            }
+        },
         "node_modules/object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -3127,6 +3342,55 @@
             "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
             "integrity": "sha512-5QvjGxYVjxO59MGU2lHVYpRWBBtKHnlIAcSe1uNFCkkptUh63NFRj0FJQm7nR67puEruUci/ZkjmEFrjCAyP4A==",
             "license": "MIT"
+        },
+        "node_modules/parse5": {
+            "version": "7.3.0",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+            "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^6.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-htmlparser2-tree-adapter": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/parse5-htmlparser2-tree-adapter/-/parse5-htmlparser2-tree-adapter-7.1.0.tgz",
+            "integrity": "sha512-ruw5xyKs6lrpo9x9rCZqZZnIUntICjQAd0Wsmp396Ul9lN/h+ifgVV1x1gZHi8euej6wTfpqX8j+BFQxF0NS/g==",
+            "license": "MIT",
+            "dependencies": {
+                "domhandler": "^5.0.3",
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5-parser-stream": {
+            "version": "7.1.2",
+            "resolved": "https://registry.npmjs.org/parse5-parser-stream/-/parse5-parser-stream-7.1.2.tgz",
+            "integrity": "sha512-JyeQc9iwFLn5TbvvqACIF/VXG6abODeB3Fwmv/TGdLk2LfbWkaySGY72at4+Ty7EkPZj854u4CrICqNk2qIbow==",
+            "license": "MIT",
+            "dependencies": {
+                "parse5": "^7.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/parse5/node_modules/entities": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+            "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=0.12"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
         },
         "node_modules/parseurl": {
             "version": "1.3.3",
@@ -4170,6 +4434,15 @@
                 "url": "https://github.com/sponsors/sindresorhus"
             }
         },
+        "node_modules/undici": {
+            "version": "7.24.7",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.7.tgz",
+            "integrity": "sha512-H/nlJ/h0ggGC+uRL3ovD+G0i4bqhvsDOpbDv7At5eFLlj2b41L8QliGbnl2H7SnDiYhENphh1tQFJZf+MyfLsQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.18.1"
+            }
+        },
         "node_modules/undici-types": {
             "version": "7.18.2",
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
@@ -4375,6 +4648,40 @@
             "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
             "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
             "license": "BSD-2-Clause"
+        },
+        "node_modules/whatwg-encoding": {
+            "version": "3.1.1",
+            "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+            "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+            "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "0.6.3"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/whatwg-encoding/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/whatwg-mimetype": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+            "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
+            }
         },
         "node_modules/whatwg-url": {
             "version": "5.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.1.0",
+    "version": "1.4.0",
     "description": "Agentic docs retrieval for AI agents — semantic search and filesystem exploration over your documentation and code via MCP.",
     "type": "module",
     "repository": {
@@ -33,6 +33,7 @@
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
+        "cheerio": "^1.2.0",
         "commander": "^14.0.3",
         "cors": "^2.8.5",
         "dotenv": "^17.3.1",

--- a/pathfinder-docs.yaml
+++ b/pathfinder-docs.yaml
@@ -1,0 +1,54 @@
+server:
+  name: pathfinder-docs
+  version: "1.4.0"
+
+sources:
+  - name: pathfinder-docs
+    type: html
+    repo: https://github.com/CopilotKit/pathfinder.git
+    path: docs/
+    base_url: https://pathfinder.copilotkit.dev/
+    url_derivation:
+      strip_prefix: "docs/"
+      strip_suffix: ".html"
+    file_patterns:
+      - "**/*.html"
+    chunk:
+      target_tokens: 600
+      overlap_tokens: 50
+
+tools:
+  - name: search-docs
+    type: search
+    description: "Search Pathfinder documentation for configuration, deployment, client setup, and usage guides."
+    source: pathfinder-docs
+    default_limit: 5
+    max_limit: 20
+    result_format: docs
+
+  - name: explore-docs
+    type: bash
+    description: "Explore Pathfinder documentation files using bash commands (find, grep, cat, ls, head)."
+    sources: [pathfinder-docs]
+    bash:
+      session_state: true
+      grep_strategy: hybrid
+      virtual_files: true
+
+embedding:
+  provider: openai
+  model: text-embedding-3-small
+  dimensions: 1536
+
+indexing:
+  auto_reindex: true
+  reindex_hour_utc: 3
+  stale_threshold_hours: 24
+
+webhook:
+  repo_sources:
+    "CopilotKit/pathfinder":
+      - pathfinder-docs
+  path_triggers:
+    pathfinder-docs:
+      - "docs/"

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -1,5 +1,5 @@
 #!/usr/bin/env bash
-# Smoke test for Pathfinder production
+# Smoke test for any Pathfinder instance.
 # Run BEFORE and AFTER merge to compare results.
 #
 # Usage:
@@ -67,7 +67,7 @@ mcp_call() {
       -d "$1" | parse_sse
 }
 
-# 3. List tools
+# 3. List tools — discover what's available
 echo ""
 echo "--- Tools ---"
 TOOLS_JSON=$(mcp_call '{"jsonrpc":"2.0","method":"tools/list","id":2}')
@@ -81,14 +81,39 @@ for t in sorted(tools, key=lambda x: x['name']):
 print(f\"Total: {len(tools)} tools\")
 " 2>/dev/null || echo "FAILED: tools/list"
 
-# 4. Search tests — 3 queries, capture top result title
+# Discover the first search tool and first bash tool from the tools list
+SEARCH_TOOL=$(echo "$TOOLS_JSON" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+tools = d.get('result', {}).get('tools', [])
+for t in sorted(tools, key=lambda x: x['name']):
+    props = t.get('inputSchema', {}).get('properties', {})
+    if 'query' in props:
+        print(t['name'])
+        break
+" 2>/dev/null || true)
+
+BASH_TOOL=$(echo "$TOOLS_JSON" | python3 -c "
+import sys, json
+d = json.load(sys.stdin)
+tools = d.get('result', {}).get('tools', [])
+for t in sorted(tools, key=lambda x: x['name']):
+    props = t.get('inputSchema', {}).get('properties', {})
+    if 'command' in props:
+        print(t['name'])
+        break
+" 2>/dev/null || true)
+
+# 4. Search tests — use discovered search tool with generic queries
 echo ""
 echo "--- Search Results ---"
-for QUERY in "how to use useCopilotAction" "authentication setup" "streaming response handling"; do
-    BODY="{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"search-docs\",\"arguments\":{\"query\":\"$QUERY\",\"limit\":3}},\"id\":3}"
-    SEARCH_JSON=$(mcp_call "$BODY")
-    echo "Query: \"$QUERY\""
-    echo "$SEARCH_JSON" | python3 -c "
+if [ -n "$SEARCH_TOOL" ]; then
+    echo "Using tool: $SEARCH_TOOL"
+    for QUERY in "getting started" "configuration" "how to install"; do
+        BODY="{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"$SEARCH_TOOL\",\"arguments\":{\"query\":\"$QUERY\",\"limit\":3}},\"id\":3}"
+        SEARCH_JSON=$(mcp_call "$BODY")
+        echo "Query: \"$QUERY\""
+        echo "$SEARCH_JSON" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 text = d.get('result', {}).get('content', [{}])[0].get('text', '')
@@ -99,44 +124,53 @@ for line in lines:
 if 'No results' in text:
     print('  No results found')
 " 2>/dev/null || echo "  FAILED"
-done
+    done
+else
+    echo "No search tool found — skipping"
+fi
 
-# 5. Bash tool — find and grep
+# 5. Bash tool — generic filesystem exploration
 echo ""
 echo "--- Bash Tool ---"
-BASH_JSON=$(mcp_call '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"explore-docs","arguments":{"command":"find / -name \"*.mdx\" | head -5"}},"id":4}')
-echo "find / -name '*.mdx' | head -5:"
-echo "$BASH_JSON" | python3 -c "
+if [ -n "$BASH_TOOL" ]; then
+    echo "Using tool: $BASH_TOOL"
+
+    FIND_JSON=$(mcp_call "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"$BASH_TOOL\",\"arguments\":{\"command\":\"find / -maxdepth 2 -type f | head -10\"}},\"id\":4}")
+    echo "find / -maxdepth 2 -type f | head -10:"
+    echo "$FIND_JSON" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 text = d.get('result', {}).get('content', [{}])[0].get('text', '')
-for line in text.split('\n')[1:6]:
+for line in text.split('\n')[1:11]:
     if line.strip():
         print(f\"  {line}\")
 " 2>/dev/null || echo "  FAILED"
 
-GREP_JSON=$(mcp_call '{"jsonrpc":"2.0","method":"tools/call","params":{"name":"explore-docs","arguments":{"command":"grep -rl \"useCopilotAction\" /docs | head -3"}},"id":5}')
-echo ""
-echo "grep -rl 'useCopilotAction' /docs | head -3:"
-echo "$GREP_JSON" | python3 -c "
+    echo ""
+    GREP_JSON=$(mcp_call "{\"jsonrpc\":\"2.0\",\"method\":\"tools/call\",\"params\":{\"name\":\"$BASH_TOOL\",\"arguments\":{\"command\":\"ls -la /\"}},\"id\":5}")
+    echo "ls -la /:"
+    echo "$GREP_JSON" | python3 -c "
 import sys, json
 d = json.load(sys.stdin)
 text = d.get('result', {}).get('content', [{}])[0].get('text', '')
-for line in text.split('\n')[1:4]:
+for line in text.split('\n')[1:11]:
     if line.strip():
         print(f\"  {line}\")
 " 2>/dev/null || echo "  FAILED"
+else
+    echo "No bash tool found — skipping"
+fi
 
-# 6. New endpoints (v1.3)
+# 6. Endpoints
 echo ""
-echo "--- New Endpoints (v1.3) ---"
+echo "--- Endpoints ---"
 echo -n "GET /llms.txt: "
 LLMS_STATUS=$(curl -so /dev/null -w "%{http_code}" "$BASE_URL/llms.txt" 2>/dev/null || echo "000")
 if [ "$LLMS_STATUS" = "200" ]; then
     LLMS_LINES=$(curl -sf "$BASE_URL/llms.txt" 2>/dev/null | wc -l | tr -d ' ')
     echo "OK ($LLMS_LINES lines)"
 else
-    echo "HTTP $LLMS_STATUS (not deployed yet — expected before merge)"
+    echo "HTTP $LLMS_STATUS"
 fi
 
 echo -n "GET /llms-full.txt: "
@@ -145,7 +179,7 @@ if [ "$FULL_STATUS" = "200" ]; then
     FULL_SIZE=$(curl -sf "$BASE_URL/llms-full.txt" 2>/dev/null | wc -c | tr -d ' ')
     echo "OK ($FULL_SIZE bytes)"
 else
-    echo "HTTP $FULL_STATUS (not deployed yet — expected before merge)"
+    echo "HTTP $FULL_STATUS"
 fi
 
 echo -n "GET /.well-known/skills/default/skill.md: "
@@ -153,7 +187,7 @@ SKILL_STATUS=$(curl -so /dev/null -w "%{http_code}" "$BASE_URL/.well-known/skill
 if [ "$SKILL_STATUS" = "200" ]; then
     echo "OK"
 else
-    echo "HTTP $SKILL_STATUS (not deployed yet — expected before merge)"
+    echo "HTTP $SKILL_STATUS"
 fi
 
 echo -n "Link header: "
@@ -161,7 +195,7 @@ LINK_HEADER=$(curl -sI "$BASE_URL/health" 2>/dev/null | grep -i "^link:" | tr -d
 if [ -n "$LINK_HEADER" ]; then
     echo "$LINK_HEADER"
 else
-    echo "not present (not deployed yet — expected before merge)"
+    echo "not present"
 fi
 
 # 7. Clean up

--- a/src/__tests__/html-chunker.test.ts
+++ b/src/__tests__/html-chunker.test.ts
@@ -1,0 +1,275 @@
+import { describe, it, expect } from 'vitest';
+import { SourceConfigSchema } from '../types.js';
+import { chunkHtml } from '../indexing/chunking/html.js';
+import { getChunker } from '../indexing/chunking/index.js';
+import type { SourceConfig } from '../types.js';
+
+describe('html source type schema', () => {
+    it('accepts type: html in source config', () => {
+        const config = {
+            name: 'test-html',
+            type: 'html',
+            path: 'docs/',
+            file_patterns: ['**/*.html'],
+            chunk: { target_tokens: 600, overlap_tokens: 50 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+});
+
+const htmlConfig: SourceConfig = {
+    name: 'test',
+    type: 'html',
+    path: 'docs/',
+    file_patterns: ['**/*.html'],
+    chunk: { target_tokens: 600, overlap_tokens: 50 },
+};
+
+describe('chunkHtml', () => {
+    it('extracts text from basic HTML with heading sections', () => {
+        const html = `<!DOCTYPE html><html><head><title>Test Page</title></head><body>
+            <article>
+                <h1>Introduction</h1>
+                <p>Welcome to the docs.</p>
+                <h2>Getting Started</h2>
+                <p>Install the package.</p>
+                <h2>Configuration</h2>
+                <p>Edit your config file.</p>
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/test.html', htmlConfig);
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks[0].title).toBe('Test Page');
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('Welcome to the docs');
+        expect(allText).toContain('Install the package');
+        expect(allText).toContain('Edit your config file');
+    });
+
+    it('strips script, style, nav, footer, header, svg, noscript elements', () => {
+        const html = `<!DOCTYPE html><html><head><title>Strip Test</title></head><body>
+            <nav><a href="/">Home</a></nav>
+            <header><h1>Site Header</h1></header>
+            <article>
+                <h2>Real Content</h2>
+                <p>This should appear.</p>
+                <script>alert('evil')</script>
+                <style>.hidden { display: none; }</style>
+                <svg><text>svg-leak-marker</text></svg>
+                <noscript>Enable JS</noscript>
+            </article>
+            <footer>Copyright 2026</footer>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/strip.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('This should appear');
+        expect(allText).not.toContain('alert');
+        expect(allText).not.toContain('display: none');
+        expect(allText).not.toContain('Home');
+        expect(allText).not.toContain('Site Header');
+        expect(allText).not.toContain('Copyright');
+        expect(allText).not.toContain('Enable JS');
+        expect(allText).not.toContain('svg-leak-marker');
+    });
+
+    it('prefers article over body as content container', () => {
+        const html = `<!DOCTYPE html><html><head><title>Container</title></head><body>
+            <p>Body noise outside article.</p>
+            <article>
+                <h2>Article Content</h2>
+                <p>Inside article.</p>
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/container.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('Inside article');
+        expect(allText).not.toContain('Body noise');
+    });
+
+    it('falls back to body when no content container found', () => {
+        const html = `<!DOCTYPE html><html><head><title>Fallback</title></head><body>
+            <h2>Just Body</h2>
+            <p>Body content directly.</p>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/fallback.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('Body content directly');
+    });
+
+    it('returns empty array for empty body', () => {
+        const html = `<!DOCTYPE html><html><head><title>Empty</title></head><body></body></html>`;
+        const chunks = chunkHtml(html, 'docs/empty.html', htmlConfig);
+        expect(chunks).toHaveLength(0);
+    });
+
+    it('returns empty array for empty string', () => {
+        const chunks = chunkHtml('', 'docs/empty.html', htmlConfig);
+        expect(chunks).toHaveLength(0);
+    });
+
+    it('preserves code blocks with whitespace intact', () => {
+        const html = `<!DOCTYPE html><html><head><title>Code</title></head><body>
+            <article>
+                <h2>Example</h2>
+                <pre><code>function hello() {
+    return "world";
+}</code></pre>
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/code.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('function hello()');
+        expect(allText).toContain('return "world"');
+        // Should have code fence markers
+        expect(allText).toContain('```');
+    });
+
+    it('formats unordered lists with dash prefix', () => {
+        const html = `<!DOCTYPE html><html><head><title>Lists</title></head><body>
+            <article>
+                <h2>Features</h2>
+                <ul><li>Fast</li><li>Reliable</li><li>Simple</li></ul>
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/lists.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('- Fast');
+        expect(allText).toContain('- Reliable');
+        expect(allText).toContain('- Simple');
+    });
+
+    it('formats ordered lists with numbers', () => {
+        const html = `<!DOCTYPE html><html><head><title>Steps</title></head><body>
+            <article>
+                <h2>Steps</h2>
+                <ol><li>Install</li><li>Configure</li><li>Deploy</li></ol>
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/steps.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('1. Install');
+        expect(allText).toContain('2. Configure');
+        expect(allText).toContain('3. Deploy');
+    });
+
+    it('formats table rows with pipe separators', () => {
+        const html = `<!DOCTYPE html><html><head><title>Table</title></head><body>
+            <article>
+                <h2>Comparison</h2>
+                <table>
+                    <tr><th>Feature</th><th>Pathfinder</th></tr>
+                    <tr><td>Search</td><td>Yes</td></tr>
+                    <tr><td>Bash</td><td>Yes</td></tr>
+                </table>
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/table.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('Feature | Pathfinder');
+        expect(allText).toContain('Search | Yes');
+    });
+
+    it('builds correct headingPath from heading hierarchy', () => {
+        const html = `<!DOCTYPE html><html><head><title>Hierarchy</title></head><body>
+            <article>
+                <h1>Top Level</h1>
+                <p>Intro text.</p>
+                <h2>Section A</h2>
+                <p>Section A content.</p>
+                <h3>Subsection A1</h3>
+                <p>Subsection content.</p>
+                <h2>Section B</h2>
+                <p>Section B content.</p>
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/hierarchy.html', htmlConfig);
+        // Find the chunk containing "Subsection content"
+        const subsectionChunk = chunks.find(c => c.content.includes('Subsection content'));
+        expect(subsectionChunk).toBeDefined();
+        expect(subsectionChunk!.headingPath).toEqual(['Top Level', 'Section A', 'Subsection A1']);
+
+        // Section B should not include Section A in its path
+        const sectionBChunk = chunks.find(c => c.content.includes('Section B content'));
+        expect(sectionBChunk).toBeDefined();
+        expect(sectionBChunk!.headingPath).toEqual(['Top Level', 'Section B']);
+    });
+
+    it('uses first h1 as title when no title tag', () => {
+        const html = `<!DOCTYPE html><html><head></head><body>
+            <article><h1>My Page Title</h1><p>Content.</p></article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/notitle.html', htmlConfig);
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks[0].title).toBe('My Page Title');
+    });
+
+    it('uses filename as title when no title tag and no h1', () => {
+        const html = `<!DOCTYPE html><html><head></head><body>
+            <article><p>Just a paragraph.</p></article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/notitle.html', htmlConfig);
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks[0].title).toBe('notitle.html');
+    });
+
+    it('strips site name suffix from title tag', () => {
+        const html = `<!DOCTYPE html><html><head><title>Getting Started \u2014 My Docs</title></head><body>
+            <article><p>Content here.</p></article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/start.html', htmlConfig);
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks[0].title).toBe('Getting Started');
+    });
+
+    it('prefers main over article as content container', () => {
+        const html = `<!DOCTYPE html><html><head><title>Priority</title></head><body>
+            <article><p>Article content.</p></article>
+            <main><p>Main content.</p></main>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/priority.html', htmlConfig);
+        const allText = chunks.map(c => c.content).join('\n');
+        expect(allText).toContain('Main content');
+        expect(allText).not.toContain('Article content');
+    });
+
+    it('detects headings nested inside section and div elements', () => {
+        const html = `<!DOCTYPE html><html><head><title>Nested</title></head><body>
+            <main>
+                <section>
+                    <h2>First Section</h2>
+                    <p>First content.</p>
+                </section>
+                <div class="block">
+                    <h2>Second Section</h2>
+                    <p>Second content.</p>
+                </div>
+            </main>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/nested.html', htmlConfig);
+        expect(chunks.length).toBeGreaterThanOrEqual(2);
+        const first = chunks.find(c => c.content.includes('First content'));
+        const second = chunks.find(c => c.content.includes('Second content'));
+        expect(first).toBeDefined();
+        expect(second).toBeDefined();
+        expect(first!.headingPath).toEqual(['First Section']);
+        expect(second!.headingPath).toEqual(['Second Section']);
+    });
+
+    it('returns single chunk with empty headingPath when no headings present', () => {
+        const html = `<!DOCTYPE html><html><head><title>No Headings</title></head><body>
+            <article><p>Just paragraphs.</p><p>More text.</p></article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/noheadings.html', htmlConfig);
+        expect(chunks.length).toBe(1);
+        expect(chunks[0].headingPath).toEqual([]);
+        expect(chunks[0].content).toContain('Just paragraphs');
+    });
+});
+
+describe('html chunker registration', () => {
+    it('getChunker returns the html chunker function', () => {
+        const chunker = getChunker('html');
+        expect(chunker).toBe(chunkHtml);
+    });
+});

--- a/src/indexing/chunking/html.ts
+++ b/src/indexing/chunking/html.ts
@@ -1,0 +1,328 @@
+// HTML chunker — extracts semantic text content from HTML documents
+// using cheerio for DOM traversal, splits on heading boundaries.
+
+import * as cheerio from 'cheerio';
+import type { CheerioAPI, Cheerio } from 'cheerio';
+import type { Element, Text, AnyNode } from 'domhandler';
+import { type ChunkOutput, type SourceConfig } from '../../types.js';
+
+const DEFAULT_TARGET_TOKENS = 600;
+const DEFAULT_OVERLAP_TOKENS = 50;
+
+/** Elements to remove entirely before content extraction. */
+const STRIP_SELECTORS = 'script, style, nav, footer, header, svg, noscript';
+
+/** Selectors to try for the main content container, in priority order. */
+const CONTENT_SELECTORS = ['main', 'article', '[role="main"]', '.content', '#content'];
+
+/**
+ * Extract text from a cheerio element, converting block elements to newlines
+ * and preserving code blocks.
+ */
+function extractText($: CheerioAPI, el: Cheerio<AnyNode>): string {
+    const lines: string[] = [];
+
+    el.contents().each((_, node) => {
+        if (node.type === 'text') {
+            const text = (node as Text).data?.trim();
+            if (text) lines.push(text);
+            return;
+        }
+
+        if (node.type !== 'tag') return;
+        const tagNode = node as Element;
+        const tag = tagNode.tagName?.toLowerCase();
+        const child = $(tagNode);
+
+        if (tag === 'pre') {
+            // Preserve code blocks with whitespace intact
+            lines.push('\n```\n' + child.text() + '\n```\n');
+        } else if (tag === 'ul') {
+            child.children('li').each((_, li) => {
+                lines.push('- ' + extractText($, $(li)));
+            });
+        } else if (tag === 'ol') {
+            child.children('li').each((i, li) => {
+                lines.push(`${i + 1}. ` + extractText($, $(li)));
+            });
+        } else if (tag === 'table') {
+            child.find('tr').each((_, tr) => {
+                const cells: string[] = [];
+                $(tr).find('th, td').each((_, cell) => {
+                    cells.push($(cell).text().trim());
+                });
+                if (cells.length > 0) lines.push(cells.join(' | '));
+            });
+        } else if (tag === 'img') {
+            const alt = child.attr('alt');
+            if (alt) lines.push(`[image: ${alt}]`);
+        } else if (['p', 'div', 'blockquote', 'dd', 'section', 'figcaption'].includes(tag)) {
+            const text = extractText($, child);
+            if (text) lines.push(text);
+        } else if (['h1', 'h2', 'h3', 'h4', 'h5', 'h6'].includes(tag)) {
+            // Headings are split by the section splitter at the top level; here we just extract text content
+            lines.push(child.text().trim());
+        } else {
+            // Recurse into other elements (spans, links, etc.)
+            const text = extractText($, child);
+            if (text) lines.push(text);
+        }
+    });
+
+    return lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+}
+
+/**
+ * Split content container into sections by heading elements (h1-h3).
+ * Returns an array of { heading, level, content } objects.
+ */
+interface HtmlSection {
+    heading: string | null;
+    level: number;
+    content: string;
+}
+
+function splitOnHeadings($: CheerioAPI, container: Cheerio<AnyNode>): HtmlSection[] {
+    const sections: HtmlSection[] = [];
+    let currentHeading: string | null = null;
+    let currentLevel = 0;
+    let currentContent: string[] = [];
+
+    function flush() {
+        const text = currentContent.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+        if (text) {
+            sections.push({ heading: currentHeading, level: currentLevel, content: text });
+        }
+        currentContent = [];
+    }
+
+    // Walk all descendant nodes in document order, splitting on h1/h2/h3
+    function walk(el: Cheerio<AnyNode>) {
+        el.contents().each((_, node) => {
+            if (node.type === 'text') {
+                const text = (node as Text).data?.trim();
+                if (text) currentContent.push(text);
+                return;
+            }
+            if (node.type !== 'tag') return;
+            const tagNode = node as Element;
+            const tag = tagNode.tagName?.toLowerCase();
+
+            if (tag && /^h[123]$/.test(tag)) {
+                flush();
+                currentHeading = $(tagNode).text().trim();
+                currentLevel = parseInt(tag[1]);
+                return; // Don't recurse into the heading
+            }
+
+            // h4-h6 are not section boundaries but should stand out in text
+            if (tag && /^h[456]$/.test(tag)) {
+                const text = $(tagNode).text().trim();
+                if (text) currentContent.push('\n' + text);
+                return;
+            }
+
+            // Block elements with special formatting — keep in sync with extractText
+            if (tag === 'pre') {
+                currentContent.push('\n```\n' + $(tagNode).text() + '\n```\n');
+                return;
+            }
+            if (tag === 'ul') {
+                $(tagNode).children('li').each((_, li) => {
+                    currentContent.push('- ' + extractText($, $(li)));
+                });
+                return;
+            }
+            if (tag === 'ol') {
+                $(tagNode).children('li').each((i, li) => {
+                    currentContent.push(`${i + 1}. ` + extractText($, $(li)));
+                });
+                return;
+            }
+            if (tag === 'table') {
+                $(tagNode).find('tr').each((_, tr) => {
+                    const cells: string[] = [];
+                    $(tr).find('th, td').each((_, cell) => {
+                        cells.push($(cell).text().trim());
+                    });
+                    if (cells.length > 0) currentContent.push(cells.join(' | '));
+                });
+                return;
+            }
+            if (tag === 'img') {
+                const alt = $(tagNode).attr('alt');
+                if (alt) currentContent.push(`[image: ${alt}]`);
+                return;
+            }
+
+            // Other block content elements — delegate to extractText
+            if (['p', 'blockquote', 'dd', 'figcaption', 'dl', 'figure'].includes(tag)) {
+                const text = extractText($, $(tagNode));
+                if (text) currentContent.push(text);
+                return;
+            }
+
+            // Recurse into container elements (section, div, article, etc.)
+            walk($(tagNode));
+        });
+    }
+
+    walk(container);
+    flush();
+    return sections;
+}
+
+/**
+ * Build heading path from sections up to a given index.
+ * Tracks h1 > h2 > h3 hierarchy (same concept as markdown chunker).
+ */
+function buildHeadingPath(sections: HtmlSection[], upToIndex: number): string[] {
+    const stack: { level: number; text: string }[] = [];
+
+    for (let i = 0; i <= upToIndex; i++) {
+        const section = sections[i];
+        if (!section.heading) continue;
+
+        // Pop headings at same or deeper level
+        while (stack.length > 0 && stack[stack.length - 1].level >= section.level) {
+            stack.pop();
+        }
+        stack.push({ level: section.level, text: section.heading });
+    }
+
+    return stack.map(h => h.text);
+}
+
+/**
+ * Merge small consecutive sections that share the same heading context,
+ * then apply overlap between chunks.
+ *
+ * Sections with distinct headings are never merged — each heading-bearing
+ * section becomes its own chunk so that headingPath stays accurate.
+ * Only headingless content following the same heading gets merged.
+ */
+function mergeAndOverlap(sections: HtmlSection[], targetChars: number, overlapChars: number): { content: string; sectionIndex: number }[] {
+    const merged: { content: string; sectionIndex: number }[] = [];
+    let current = '';
+    let currentIdx = 0;
+
+    for (let i = 0; i < sections.length; i++) {
+        const section = sections[i];
+        const text = section.content;
+        const separator = current ? '\n\n' : '';
+
+        // Start a new chunk when the section has its own heading
+        // (preserves headingPath per-section) or when size exceeds target
+        const sizeExceeded = current && (current.length + separator.length + text.length) > targetChars;
+        const hasNewHeading = section.heading !== null && current.length > 0;
+
+        if (sizeExceeded || hasNewHeading) {
+            if (current.trim()) {
+                merged.push({ content: current, sectionIndex: currentIdx });
+            }
+            current = text;
+            currentIdx = i;
+        } else {
+            if (!current) currentIdx = i;
+            current = current ? current + separator + text : text;
+        }
+    }
+    if (current.trim()) {
+        merged.push({ content: current, sectionIndex: currentIdx });
+    }
+
+    // Apply overlap
+    if (merged.length <= 1 || overlapChars <= 0) return merged;
+
+    const result: { content: string; sectionIndex: number }[] = [merged[0]];
+    for (let i = 1; i < merged.length; i++) {
+        const prev = merged[i - 1].content;
+        const overlapText = prev.slice(-overlapChars);
+        const breakPoint = overlapText.lastIndexOf('\n');
+        const cleanOverlap = breakPoint > 0 ? overlapText.slice(breakPoint) : overlapText;
+        result.push({
+            content: cleanOverlap + '\n\n' + merged[i].content,
+            sectionIndex: merged[i].sectionIndex,
+        });
+    }
+
+    return result;
+}
+
+/**
+ * Extract title from HTML: <title> tag, then first <h1>, then filename.
+ */
+function extractTitle($: CheerioAPI, filePath: string): string {
+    const titleTag = $('title').first().text().trim();
+    if (titleTag) {
+        // Strip " — SiteName" suffixes common in doc sites
+        const dashIdx = titleTag.indexOf(' — ');
+        return dashIdx > 0 ? titleTag.slice(0, dashIdx) : titleTag;
+    }
+
+    const h1 = $('h1').first().text().trim();
+    if (h1) return h1;
+
+    return filePath.split('/').pop() ?? filePath;
+}
+
+/**
+ * Chunk HTML content into embedding-friendly chunks.
+ * Follows the ChunkerFn signature: (content, filePath, config) => ChunkOutput[]
+ */
+export function chunkHtml(content: string, filePath: string, config: SourceConfig): ChunkOutput[] {
+    if (!content || !content.trim()) {
+        return [];
+    }
+
+    const $ = cheerio.load(content);
+
+    // Strip non-content elements
+    $(STRIP_SELECTORS).remove();
+
+    // Find the main content container
+    let container: Cheerio<AnyNode> | null = null;
+    for (const selector of CONTENT_SELECTORS) {
+        const found = $(selector).first();
+        if (found.length > 0) {
+            container = found;
+            break;
+        }
+    }
+    if (!container) {
+        container = $('body');
+    }
+
+    if (!container || container.length === 0) {
+        return [];
+    }
+
+    const title = extractTitle($, filePath);
+    const targetChars = (config.chunk?.target_tokens ?? DEFAULT_TARGET_TOKENS) * 4;
+    const overlapChars = (config.chunk?.overlap_tokens ?? DEFAULT_OVERLAP_TOKENS) * 4;
+
+    // Split content on heading boundaries
+    const sections = splitOnHeadings($, container);
+
+    if (sections.length === 0) {
+        // No headings — treat entire content as one section
+        const text = extractText($, container);
+        if (!text.trim()) return [];
+        return [{
+            content: text.trim(),
+            title,
+            headingPath: [],
+            chunkIndex: 0,
+        }];
+    }
+
+    // Merge small sections and apply overlap
+    const merged = mergeAndOverlap(sections, targetChars, overlapChars);
+
+    return merged.map((chunk, i) => ({
+        content: chunk.content,
+        title,
+        headingPath: buildHeadingPath(sections, chunk.sectionIndex),
+        chunkIndex: i,
+    }));
+}

--- a/src/indexing/chunking/index.ts
+++ b/src/indexing/chunking/index.ts
@@ -20,7 +20,9 @@ export function getChunker(type: string): ChunkerFn {
 import { chunkMarkdown } from './markdown.js';
 import { chunkCode } from './code.js';
 import { chunkRawText } from './raw-text.js';
+import { chunkHtml } from './html.js';
 
 registerChunker('markdown', chunkMarkdown);
 registerChunker('code', chunkCode);
 registerChunker('raw-text', chunkRawText);
+registerChunker('html', chunkHtml);

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,8 +13,8 @@ export const UrlDerivationConfigSchema = z.object({
 });
 
 // ChunkConfig field applicability by source type:
-//   markdown/raw-text: target_tokens, overlap_tokens
-//   code:              target_lines, overlap_lines
+//   markdown/raw-text/html: target_tokens, overlap_tokens
+//   code:                   target_lines, overlap_lines
 export const ChunkConfigSchema = z.object({
     target_tokens: z.number().int().positive().optional(),
     overlap_tokens: z.number().int().nonnegative().optional(),
@@ -24,7 +24,7 @@ export const ChunkConfigSchema = z.object({
 
 export const SourceConfigSchema = z.object({
     name: z.string().min(1),
-    type: z.enum(['markdown', 'code', 'raw-text']),
+    type: z.enum(['markdown', 'code', 'raw-text', 'html']),
     repo: z.string().url().optional(),
     branch: z.string().optional(),
     path: z.string().min(1),


### PR DESCRIPTION
## Summary

- Add `html` as a fourth built-in source type (cheerio-based parser) for indexing static HTML documentation sites
- Recursive DOM walk extracts semantic text, splits on h1-h3 heading boundaries, preserves code blocks/lists/tables, tracks heading hierarchy
- Auto-detects content container (`main`, `article`, `[role="main"]`, `.content`, `#content`)
- Add `pathfinder-docs.yaml` for dogfooding Pathfinder on its own HTML docs (separate Postgres on Railway)
- 19 new tests (484 total), 2 rounds of CR clean
- Version bump to 1.4.0

## Deployment

After merge, create a second Railway service (`pathfinder-docs`) in the mcp-docs project:
- Same GitHub repo/branch, same Dockerfile
- `PATHFINDER_CONFIG=pathfinder-docs.yaml`
- Own Postgres instance (not shared with CopilotKit production)
- Same `OPENAI_API_KEY` and `GITHUB_TOKEN`

**Prerequisite:** Verify `pathfinder.copilotkit.dev` HTTPS is live (GitHub Pages cert).

## Test plan

- [x] 484 tests passing (`npx vitest run`)
- [x] Build clean (`npm run build`)
- [x] Zod schema accepts `type: 'html'`
- [x] Chunker registry returns html chunker
- [x] Nested headings in section/div wrappers correctly detected
- [x] 2 rounds of 7-agent CR — clean
- [ ] Deploy dogfooding service on Railway after merge
- [ ] Run smoke test against dogfooding endpoint

## Spec

[Notion: Pathfinder v1.4](https://www.notion.so/33b3aa38185281b4977ef1d4b5646223)