### PR TITLE
Fix HTML chunker: oversized content splitting, title separators

### DIFF
--- a/src/__tests__/html-chunker.test.ts
+++ b/src/__tests__/html-chunker.test.ts
@@ -39,7 +39,7 @@ describe('chunkHtml', () => {
             </article>
         </body></html>`;
         const chunks = chunkHtml(html, 'docs/test.html', htmlConfig);
-        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks.length).toBe(3);
         expect(chunks[0].title).toBe('Test Page');
         const allText = chunks.map(c => c.content).join('\n');
         expect(allText).toContain('Welcome to the docs');
@@ -200,7 +200,7 @@ describe('chunkHtml', () => {
             <article><h1>My Page Title</h1><p>Content.</p></article>
         </body></html>`;
         const chunks = chunkHtml(html, 'docs/notitle.html', htmlConfig);
-        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks.length).toBe(1);
         expect(chunks[0].title).toBe('My Page Title');
     });
 
@@ -209,7 +209,7 @@ describe('chunkHtml', () => {
             <article><p>Just a paragraph.</p></article>
         </body></html>`;
         const chunks = chunkHtml(html, 'docs/notitle.html', htmlConfig);
-        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks.length).toBe(1);
         expect(chunks[0].title).toBe('notitle.html');
     });
 
@@ -247,13 +247,62 @@ describe('chunkHtml', () => {
             </main>
         </body></html>`;
         const chunks = chunkHtml(html, 'docs/nested.html', htmlConfig);
-        expect(chunks.length).toBeGreaterThanOrEqual(2);
+        expect(chunks.length).toBe(2);
         const first = chunks.find(c => c.content.includes('First content'));
         const second = chunks.find(c => c.content.includes('Second content'));
         expect(first).toBeDefined();
         expect(second).toBeDefined();
         expect(first!.headingPath).toEqual(['First Section']);
         expect(second!.headingPath).toEqual(['Second Section']);
+    });
+
+    it('splits oversized content without headings into multiple chunks', () => {
+        // Generate content larger than targetChars (600 tokens * 4 = 2400 chars)
+        const paragraphs = Array.from({ length: 30 }, (_, i) =>
+            `<p>Paragraph ${i + 1} with enough text to take up some space in the chunk. ${'Lorem ipsum dolor sit amet consectetur adipiscing elit. '.repeat(5)}</p>`
+        ).join('');
+        const html = `<!DOCTYPE html><html><head><title>Large</title></head><body>
+            <article>${paragraphs}</article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/large.html', htmlConfig);
+        expect(chunks.length).toBeGreaterThan(1);
+        // All chunks should have empty headingPath
+        for (const chunk of chunks) {
+            expect(chunk.headingPath).toEqual([]);
+        }
+    });
+
+    it('strips site name suffix with hyphen separator', () => {
+        const html = `<!DOCTYPE html><html><head><title>Getting Started - My Docs</title></head><body>
+            <article><p>Content.</p></article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/start.html', htmlConfig);
+        expect(chunks[0].title).toBe('Getting Started');
+    });
+
+    it('strips site name suffix with pipe separator', () => {
+        const html = `<!DOCTYPE html><html><head><title>API Reference | My Docs</title></head><body>
+            <article><p>Content.</p></article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/api.html', htmlConfig);
+        expect(chunks[0].title).toBe('API Reference');
+    });
+
+    it('splits oversized sections between headings', () => {
+        const longContent = Array.from({ length: 20 }, (_, i) =>
+            `<p>Section content paragraph ${i + 1}. ${'Lorem ipsum dolor sit amet consectetur. '.repeat(5)}</p>`
+        ).join('');
+        const html = `<!DOCTYPE html><html><head><title>Big Section</title></head><body>
+            <article>
+                <h2>Small Section</h2>
+                <p>Brief content.</p>
+                <h2>Large Section</h2>
+                ${longContent}
+            </article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/bigsection.html', htmlConfig);
+        // Should have more than 2 chunks (the large section should be split)
+        expect(chunks.length).toBeGreaterThan(2);
     });
 
     it('returns single chunk with empty headingPath when no headings present', () => {

--- a/src/__tests__/html-chunker.test.ts
+++ b/src/__tests__/html-chunker.test.ts
@@ -288,6 +288,14 @@ describe('chunkHtml', () => {
         expect(chunks[0].title).toBe('API Reference');
     });
 
+    it('preserves multi-segment title with greedy match', () => {
+        const html = `<!DOCTYPE html><html><head><title>CLI - Command Reference - My Docs</title></head><body>
+            <article><p>Content.</p></article>
+        </body></html>`;
+        const chunks = chunkHtml(html, 'docs/cli.html', htmlConfig);
+        expect(chunks[0].title).toBe('CLI - Command Reference');
+    });
+
     it('splits oversized sections between headings', () => {
         const longContent = Array.from({ length: 20 }, (_, i) =>
             `<p>Section content paragraph ${i + 1}. ${'Lorem ipsum dolor sit amet consectetur. '.repeat(5)}</p>`

--- a/src/indexing/chunking/html.ts
+++ b/src/indexing/chunking/html.ts
@@ -210,7 +210,7 @@ function splitLargeText(text: string, targetChars: number): string[] {
     // Fall back to line boundaries
     const lines = text.split('\n');
     if (lines.length > 1) {
-        return mergeSmallParts(lines, targetChars);
+        return mergeSmallParts(lines, targetChars, '\n');
     }
 
     // Single long line — return as-is
@@ -218,11 +218,11 @@ function splitLargeText(text: string, targetChars: number): string[] {
 }
 
 /** Merge adjacent small parts until they approach target size. */
-function mergeSmallParts(parts: string[], targetSize: number): string[] {
+function mergeSmallParts(parts: string[], targetSize: number, separator: string = '\n\n'): string[] {
     const merged: string[] = [];
     let current = '';
     for (const part of parts) {
-        const sep = current ? '\n\n' : '';
+        const sep = current ? separator : '';
         if (current && (current.length + sep.length + part.length) > targetSize) {
             merged.push(current);
             current = part;
@@ -312,7 +312,7 @@ function extractTitle($: CheerioAPI, filePath: string): string {
     const titleTag = $('title').first().text().trim();
     if (titleTag) {
         // Strip " — SiteName", " - SiteName", " | SiteName" suffixes common in doc sites
-        const match = titleTag.match(/^(.+?)(?:\s+[—\-|]\s+.+)$/);
+        const match = titleTag.match(/^(.+)(?:\s+[—\-|]\s+.+)$/);
         return match ? match[1] : titleTag;
     }
 

--- a/src/indexing/chunking/html.ts
+++ b/src/indexing/chunking/html.ts
@@ -194,6 +194,47 @@ function buildHeadingPath(sections: HtmlSection[], upToIndex: number): string[] 
 }
 
 /**
+ * Recursively split oversized text on paragraph then line boundaries.
+ * Ensures no chunk exceeds targetChars (best-effort — a single very long
+ * line will be returned as-is).
+ */
+function splitLargeText(text: string, targetChars: number): string[] {
+    if (text.length <= targetChars) return [text];
+
+    // Try paragraph boundaries first
+    const paragraphs = text.split(/\n\n+/);
+    if (paragraphs.length > 1) {
+        return mergeSmallParts(paragraphs, targetChars).flatMap(p => splitLargeText(p, targetChars));
+    }
+
+    // Fall back to line boundaries
+    const lines = text.split('\n');
+    if (lines.length > 1) {
+        return mergeSmallParts(lines, targetChars);
+    }
+
+    // Single long line — return as-is
+    return [text];
+}
+
+/** Merge adjacent small parts until they approach target size. */
+function mergeSmallParts(parts: string[], targetSize: number): string[] {
+    const merged: string[] = [];
+    let current = '';
+    for (const part of parts) {
+        const sep = current ? '\n\n' : '';
+        if (current && (current.length + sep.length + part.length) > targetSize) {
+            merged.push(current);
+            current = part;
+        } else {
+            current = current ? current + sep + part : part;
+        }
+    }
+    if (current) merged.push(current);
+    return merged;
+}
+
+/**
  * Merge small consecutive sections that share the same heading context,
  * then apply overlap between chunks.
  *
@@ -232,21 +273,36 @@ function mergeAndOverlap(sections: HtmlSection[], targetChars: number, overlapCh
     }
 
     // Apply overlap
-    if (merged.length <= 1 || overlapChars <= 0) return merged;
-
-    const result: { content: string; sectionIndex: number }[] = [merged[0]];
-    for (let i = 1; i < merged.length; i++) {
-        const prev = merged[i - 1].content;
-        const overlapText = prev.slice(-overlapChars);
-        const breakPoint = overlapText.lastIndexOf('\n');
-        const cleanOverlap = breakPoint > 0 ? overlapText.slice(breakPoint) : overlapText;
-        result.push({
-            content: cleanOverlap + '\n\n' + merged[i].content,
-            sectionIndex: merged[i].sectionIndex,
-        });
+    let result: { content: string; sectionIndex: number }[];
+    if (merged.length <= 1 || overlapChars <= 0) {
+        result = merged;
+    } else {
+        result = [merged[0]];
+        for (let i = 1; i < merged.length; i++) {
+            const prev = merged[i - 1].content;
+            const overlapText = prev.slice(-overlapChars);
+            const breakPoint = overlapText.lastIndexOf('\n');
+            const cleanOverlap = breakPoint > 0 ? overlapText.slice(breakPoint) : overlapText;
+            result.push({
+                content: cleanOverlap + '\n\n' + merged[i].content,
+                sectionIndex: merged[i].sectionIndex,
+            });
+        }
     }
 
-    return result;
+    // Post-pass: split any chunks that still exceed target
+    const final: { content: string; sectionIndex: number }[] = [];
+    for (const chunk of result) {
+        if (chunk.content.length > targetChars) {
+            const parts = splitLargeText(chunk.content, targetChars);
+            for (const part of parts) {
+                final.push({ content: part, sectionIndex: chunk.sectionIndex });
+            }
+        } else {
+            final.push(chunk);
+        }
+    }
+    return final;
 }
 
 /**
@@ -255,9 +311,9 @@ function mergeAndOverlap(sections: HtmlSection[], targetChars: number, overlapCh
 function extractTitle($: CheerioAPI, filePath: string): string {
     const titleTag = $('title').first().text().trim();
     if (titleTag) {
-        // Strip " — SiteName" suffixes common in doc sites
-        const dashIdx = titleTag.indexOf(' — ');
-        return dashIdx > 0 ? titleTag.slice(0, dashIdx) : titleTag;
+        // Strip " — SiteName", " - SiteName", " | SiteName" suffixes common in doc sites
+        const match = titleTag.match(/^(.+?)(?:\s+[—\-|]\s+.+)$/);
+        return match ? match[1] : titleTag;
     }
 
     const h1 = $('h1').first().text().trim();
@@ -305,15 +361,16 @@ export function chunkHtml(content: string, filePath: string, config: SourceConfi
     const sections = splitOnHeadings($, container);
 
     if (sections.length === 0) {
-        // No headings — treat entire content as one section
+        // No headings — treat entire content as one or more chunks
         const text = extractText($, container);
         if (!text.trim()) return [];
-        return [{
-            content: text.trim(),
+        const parts = splitLargeText(text.trim(), targetChars);
+        return parts.map((content, i) => ({
+            content,
             title,
             headingPath: [],
-            chunkIndex: 0,
-        }];
+            chunkIndex: i,
+        }));
     }
 
     // Merge small sections and apply overlap


### PR DESCRIPTION
## Summary

- **Oversized content splitting**: Pages without h1-h3 headings or with very large sections between headings now get split on paragraph/line boundaries instead of producing a single arbitrarily large chunk. Adds `splitLargeText` and `mergeSmallParts` helpers (same pattern as the markdown chunker's `recursiveSplit`).
- **Title separator handling**: `extractTitle` now strips ` - ` (hyphen) and ` | ` (pipe) site name suffixes in addition to ` — ` (em-dash). Covers the majority of real-world doc sites.
- **Test tightening**: 4 weak `toBeGreaterThanOrEqual` assertions replaced with exact counts. 4 new tests added for oversized content splitting (with/without headings), hyphen separators, and pipe separators. 23 total HTML chunker tests pass.

Fixes CR findings from PR #11 review.

## Test plan

- [x] 23 HTML chunker tests pass
- [x] TypeScript compiles clean
- [x] New tests verify oversized content (no headings) splits into multiple chunks
- [x] New tests verify oversized section between headings splits
- [x] New tests verify title stripping with `-` and `|` separators

🤖 Generated with [Claude Code](https://claude.com/claude-code)