### PR TITLE
Add Slack + Discord data providers with LLM distillation and FAQ system

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,14 @@
             "version": "1.4.0",
             "license": "MIT",
             "dependencies": {
+                "@discordjs/rest": "^2.6.1",
                 "@modelcontextprotocol/sdk": "^1.25.2",
                 "@slack/web-api": "^7.15.0",
                 "cheerio": "^1.2.0",
                 "commander": "^14.0.3",
                 "cors": "^2.8.5",
+                "discord-api-types": "^0.38.44",
+                "discord-interactions": "^4.4.0",
                 "dotenv": "^17.3.1",
                 "express": "^5.2.1",
                 "just-bash": "^2.14.0",
@@ -46,6 +49,65 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@discordjs/collection": {
+            "version": "2.1.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/collection/-/collection-2.1.1.tgz",
+            "integrity": "sha512-LiSusze9Tc7qF03sLCujF5iZp7K+vRNEDBZ86FT9aQAv3vxMLihUvKvpsCWiQ2DJq1tVckopKm1rxomgNUc9hg==",
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/rest": {
+            "version": "2.6.1",
+            "resolved": "https://registry.npmjs.org/@discordjs/rest/-/rest-2.6.1.tgz",
+            "integrity": "sha512-wwQdgjeaoYFiaG+atbqx6aJDpqW7JHAo0HrQkBTbYzM3/PJ3GweQIpgElNcGZ26DCUOXMyawYd0YF7vtr+fZXg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "@discordjs/collection": "^2.1.1",
+                "@discordjs/util": "^1.2.0",
+                "@sapphire/async-queue": "^1.5.3",
+                "@sapphire/snowflake": "^3.5.5",
+                "@vladfrangu/async_event_emitter": "^2.4.6",
+                "discord-api-types": "^0.38.40",
+                "magic-bytes.js": "^1.13.0",
+                "tslib": "^2.6.3",
+                "undici": "6.24.1"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
+            }
+        },
+        "node_modules/@discordjs/rest/node_modules/undici": {
+            "version": "6.24.1",
+            "resolved": "https://registry.npmjs.org/undici/-/undici-6.24.1.tgz",
+            "integrity": "sha512-sC+b0tB1whOCzbtlx20fx3WgCXwkW627p4EA9uM+/tNNPkSS+eSEld6pAs9nDv7WbY1UUljBMYPtu9BCOrCWKA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.17"
+            }
+        },
+        "node_modules/@discordjs/util": {
+            "version": "1.2.0",
+            "resolved": "https://registry.npmjs.org/@discordjs/util/-/util-1.2.0.tgz",
+            "integrity": "sha512-3LKP7F2+atl9vJFhaBjn4nOaSWahZ/yWjOvA4e5pnXkt2qyXRCHLxoBQy81GFtLGCq7K9lPm9R517M1U+/90Qg==",
+            "license": "Apache-2.0",
+            "dependencies": {
+                "discord-api-types": "^0.38.33"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "funding": {
+                "url": "https://github.com/discordjs/discord.js?sponsor"
             }
         },
         "node_modules/@electric-sql/pglite": {
@@ -962,6 +1024,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@sapphire/async-queue": {
+            "version": "1.5.5",
+            "resolved": "https://registry.npmjs.org/@sapphire/async-queue/-/async-queue-1.5.5.tgz",
+            "integrity": "sha512-cvGzxbba6sav2zZkH8GPf2oGk9yYoD5qrNWdu9fRehifgnFZJMV+nuy2nON2roRO4yQQ+v7MK/Pktl/HgfsUXg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
+        "node_modules/@sapphire/snowflake": {
+            "version": "3.5.5",
+            "resolved": "https://registry.npmjs.org/@sapphire/snowflake/-/snowflake-3.5.5.tgz",
+            "integrity": "sha512-xzvBr1Q1c4lCe7i6sRnrofxeO1QTP/LKQ6A6qy0iB4x5yfiSfARMEQEghojzTNALDTcv8En04qYNIco9/K9eZQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
+            }
+        },
         "node_modules/@slack/logger": {
             "version": "4.0.1",
             "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
@@ -1321,6 +1403,16 @@
             },
             "funding": {
                 "url": "https://opencollective.com/vitest"
+            }
+        },
+        "node_modules/@vladfrangu/async_event_emitter": {
+            "version": "2.4.7",
+            "resolved": "https://registry.npmjs.org/@vladfrangu/async_event_emitter/-/async_event_emitter-2.4.7.tgz",
+            "integrity": "sha512-Xfe6rpCTxSxfbswi/W/Pz7zp1WWSNn4A0eW4mLkQUewCrXXtMj31lCg+iQyTkh/CkusZSq9eDflu7tjEDXUY6g==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=v14.0.0",
+                "npm": ">=7.0.0"
             }
         },
         "node_modules/abort-controller": {
@@ -1865,6 +1957,24 @@
             "license": "BSD-3-Clause",
             "engines": {
                 "node": ">=0.3.1"
+            }
+        },
+        "node_modules/discord-api-types": {
+            "version": "0.38.44",
+            "resolved": "https://registry.npmjs.org/discord-api-types/-/discord-api-types-0.38.44.tgz",
+            "integrity": "sha512-q91MgBzP/gRaCLIbQTaOrOhbD8uVIaPKxpgX2sfFB2nZ9nSiTYM9P3NFQ7cbO6NCxctI6ODttc67MI+YhIfILg==",
+            "license": "MIT",
+            "workspaces": [
+                "scripts/actions/documentation"
+            ]
+        },
+        "node_modules/discord-interactions": {
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/discord-interactions/-/discord-interactions-4.4.0.tgz",
+            "integrity": "sha512-jjJx8iwAeJcj8oEauV43fue9lNqkf38fy60aSs2+G8D1nJmDxUIrk08o3h0F3wgwuBWWJUZO+X/VgfXsxpCiJA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18.4.0"
             }
         },
         "node_modules/dom-serializer": {
@@ -3079,6 +3189,12 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/parcel"
             }
+        },
+        "node_modules/magic-bytes.js": {
+            "version": "1.13.0",
+            "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
+            "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
+            "license": "MIT"
         },
         "node_modules/magic-string": {
             "version": "0.30.21",
@@ -4528,9 +4644,7 @@
             "version": "2.8.1",
             "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
             "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-            "dev": true,
-            "license": "0BSD",
-            "optional": true
+            "license": "0BSD"
         },
         "node_modules/tsx": {
             "version": "4.21.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,16 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.1.0",
+    "version": "1.4.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@copilotkit/pathfinder",
-            "version": "1.1.0",
+            "version": "1.4.0",
+            "license": "MIT",
             "dependencies": {
                 "@modelcontextprotocol/sdk": "^1.25.2",
+                "@slack/web-api": "^7.15.0",
                 "cheerio": "^1.2.0",
                 "commander": "^14.0.3",
                 "cors": "^2.8.5",
@@ -960,6 +962,53 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@slack/logger": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@slack/logger/-/logger-4.0.1.tgz",
+            "integrity": "sha512-6cmdPrV/RYfd2U0mDGiMK8S7OJqpCTm7enMLRR3edccsPX8j7zXTLnaEF4fhxxJJTAIOil6+qZrnUPTuaLvwrQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": ">=18"
+            },
+            "engines": {
+                "node": ">= 18",
+                "npm": ">= 8.6.0"
+            }
+        },
+        "node_modules/@slack/types": {
+            "version": "2.20.1",
+            "resolved": "https://registry.npmjs.org/@slack/types/-/types-2.20.1.tgz",
+            "integrity": "sha512-eWX2mdt1ktpn8+40iiMc404uGrih+2fxiky3zBcPjtXKj6HLRdYlmhrPkJi7JTJm8dpXR6BWVWEDBXtaWMKD6A==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 12.13.0",
+                "npm": ">= 6.12.0"
+            }
+        },
+        "node_modules/@slack/web-api": {
+            "version": "7.15.0",
+            "resolved": "https://registry.npmjs.org/@slack/web-api/-/web-api-7.15.0.tgz",
+            "integrity": "sha512-va7zYIt3QHG1x9M/jqXXRPFMoOVlVSSRHC5YH+DzKYsrz5xUKOA3lR4THsu/Zxha9N1jOndbKFKLtr0WOPW1Vw==",
+            "license": "MIT",
+            "dependencies": {
+                "@slack/logger": "^4.0.1",
+                "@slack/types": "^2.20.1",
+                "@types/node": ">=18",
+                "@types/retry": "0.12.0",
+                "axios": "^1.13.5",
+                "eventemitter3": "^5.0.1",
+                "form-data": "^4.0.4",
+                "is-electron": "2.2.2",
+                "is-stream": "^2",
+                "p-queue": "^6",
+                "p-retry": "^4",
+                "retry": "^0.13.1"
+            },
+            "engines": {
+                "node": ">= 18",
+                "npm": ">= 8.6.0"
+            }
+        },
         "node_modules/@standard-schema/spec": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
@@ -1132,6 +1181,12 @@
             "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@types/retry": {
+            "version": "0.12.0",
+            "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.0.tgz",
+            "integrity": "sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==",
             "license": "MIT"
         },
         "node_modules/@types/send": {
@@ -1362,6 +1417,17 @@
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
             "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
             "license": "MIT"
+        },
+        "node_modules/axios": {
+            "version": "1.14.0",
+            "resolved": "https://registry.npmjs.org/axios/-/axios-1.14.0.tgz",
+            "integrity": "sha512-3Y8yrqLSwjuzpXuZ0oIYZ/XGgLwUIBU3uLvbcpb0pidD9ctpShJd43KSlEEkVQg6DS0G9NKyzOvBfUtDKEyHvQ==",
+            "license": "MIT",
+            "dependencies": {
+                "follow-redirects": "^1.15.11",
+                "form-data": "^4.0.5",
+                "proxy-from-env": "^2.1.0"
+            }
         },
         "node_modules/balanced-match": {
             "version": "4.0.4",
@@ -2072,6 +2138,12 @@
                 "node": ">=6"
             }
         },
+        "node_modules/eventemitter3": {
+            "version": "5.0.4",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+            "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+            "license": "MIT"
+        },
         "node_modules/eventsource": {
             "version": "3.0.7",
             "resolved": "https://registry.npmjs.org/eventsource/-/eventsource-3.0.7.tgz",
@@ -2286,6 +2358,26 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/follow-redirects": {
+            "version": "1.15.11",
+            "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
+            "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+            "funding": [
+                {
+                    "type": "individual",
+                    "url": "https://github.com/sponsors/RubenVerborgh"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=4.0"
+            },
+            "peerDependenciesMeta": {
+                "debug": {
+                    "optional": true
+                }
             }
         },
         "node_modules/form-data": {
@@ -2645,11 +2737,29 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/is-electron": {
+            "version": "2.2.2",
+            "resolved": "https://registry.npmjs.org/is-electron/-/is-electron-2.2.2.tgz",
+            "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
+            "license": "MIT"
+        },
         "node_modules/is-promise": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
             "integrity": "sha512-hvpoI6korhJMnej285dSg6nu1+e6uxs7zG3BYAm5byqDsgJNWwxzM6z6iZiAgQR4TJ30JmBTOwqZUw3WlyH3AQ==",
             "license": "MIT"
+        },
+        "node_modules/is-stream": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+            "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/isexe": {
             "version": "2.0.0",
@@ -3337,6 +3447,62 @@
             "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
             "license": "MIT"
         },
+        "node_modules/p-finally": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-1.0.0.tgz",
+            "integrity": "sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/p-queue": {
+            "version": "6.6.2",
+            "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-6.6.2.tgz",
+            "integrity": "sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==",
+            "license": "MIT",
+            "dependencies": {
+                "eventemitter3": "^4.0.4",
+                "p-timeout": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=8"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/p-queue/node_modules/eventemitter3": {
+            "version": "4.0.7",
+            "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "license": "MIT"
+        },
+        "node_modules/p-retry": {
+            "version": "4.6.2",
+            "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-4.6.2.tgz",
+            "integrity": "sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "@types/retry": "0.12.0",
+                "retry": "^0.13.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/p-timeout": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-3.2.0.tgz",
+            "integrity": "sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==",
+            "license": "MIT",
+            "dependencies": {
+                "p-finally": "^1.0.0"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/papaparse": {
             "version": "5.5.3",
             "resolved": "https://registry.npmjs.org/papaparse/-/papaparse-5.5.3.tgz",
@@ -3678,6 +3844,15 @@
                 "node": ">= 0.10"
             }
         },
+        "node_modules/proxy-from-env": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+            "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/pump": {
             "version": "3.0.4",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
@@ -3814,6 +3989,15 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
+            }
+        },
+        "node_modules/retry": {
+            "version": "0.13.1",
+            "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+            "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4"
             }
         },
         "node_modules/rolldown": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,16 @@
         "url": "https://github.com/CopilotKit/pathfinder"
     },
     "homepage": "https://pathfinder.copilotkit.dev",
-    "keywords": ["mcp", "ai", "agents", "documentation", "search", "rag", "embeddings", "copilotkit"],
+    "keywords": [
+        "mcp",
+        "ai",
+        "agents",
+        "documentation",
+        "search",
+        "rag",
+        "embeddings",
+        "copilotkit"
+    ],
     "license": "MIT",
     "main": "dist/index.js",
     "bin": {
@@ -34,6 +43,7 @@
     },
     "dependencies": {
         "@modelcontextprotocol/sdk": "^1.25.2",
+        "@slack/web-api": "^7.15.0",
         "cheerio": "^1.2.0",
         "commander": "^14.0.3",
         "cors": "^2.8.5",

--- a/package.json
+++ b/package.json
@@ -42,11 +42,14 @@
         "test": "vitest run"
     },
     "dependencies": {
+        "@discordjs/rest": "^2.6.1",
         "@modelcontextprotocol/sdk": "^1.25.2",
         "@slack/web-api": "^7.15.0",
         "cheerio": "^1.2.0",
         "commander": "^14.0.3",
         "cors": "^2.8.5",
+        "discord-api-types": "^0.38.44",
+        "discord-interactions": "^4.4.0",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
         "just-bash": "^2.14.0",

--- a/scripts/test-path-filter.ts
+++ b/scripts/test-path-filter.ts
@@ -3,7 +3,7 @@
 // Usage: npx tsx scripts/test-path-filter.ts
 
 import { globToRegex, matchesPatterns, hasLowSemanticValue } from '../src/indexing/utils.js';
-import type { SourceConfig } from '../src/types.js';
+import type { FileSourceConfig } from '../src/types.js';
 
 let passed = 0;
 let failed = 0;
@@ -19,13 +19,13 @@ function assert(condition: boolean, description: string): void {
 }
 
 // ---------------------------------------------------------------------------
-// Helper: build a minimal SourceConfig for testing patterns
+// Helper: build a minimal FileSourceConfig for testing patterns
 // ---------------------------------------------------------------------------
 
-function makeSourceConfig(
+function makeFileSourceConfig(
     filePatterns: string[],
     excludePatterns?: string[],
-): SourceConfig {
+): FileSourceConfig {
     return {
         name: 'test',
         type: 'code',
@@ -38,7 +38,7 @@ function makeSourceConfig(
 }
 
 // Code source config — matches the real mcp-docs.yaml code source patterns
-const codeConfig = makeSourceConfig(
+const codeConfig = makeFileSourceConfig(
     ['**/*.ts', '**/*.tsx', '**/*.js', '**/*.jsx', '**/*.py'],
     [
         'packages/v1/**',
@@ -52,7 +52,7 @@ const codeConfig = makeSourceConfig(
 );
 
 // Docs source config — only *.mdx, no excludes
-const docsConfig = makeSourceConfig(['**/*.mdx']);
+const docsConfig = makeFileSourceConfig(['**/*.mdx']);
 
 console.log('=== Path Filter Tests ===\n');
 

--- a/src/__tests__/discord-api.test.ts
+++ b/src/__tests__/discord-api.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordApiClient } from '../indexing/providers/discord-api.js';
+
+// Mock @discordjs/rest
+const mockGet = vi.fn();
+
+vi.mock('@discordjs/rest', () => {
+    class MockREST {
+        get = mockGet;
+        setToken(_token: string) { return this; }
+        constructor(_options?: any) {}
+    }
+    return { REST: MockREST };
+});
+
+// Mock discord-api-types
+vi.mock('discord-api-types/v10', () => ({
+    Routes: {
+        channelMessages: (channelId: string) => `/channels/${channelId}/messages`,
+        guildActiveThreads: (guildId: string) => `/guilds/${guildId}/threads/active`,
+        channelThreads: (channelId: string, archivedType: string) => `/channels/${channelId}/threads/archived/${archivedType}`,
+        user: (userId: string) => `/users/${userId}`,
+        channel: (channelId: string) => `/channels/${channelId}`,
+    },
+}));
+
+describe('DiscordApiClient', () => {
+    let client: DiscordApiClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        client = new DiscordApiClient({ token: 'test-bot-token' });
+    });
+
+    describe('fetchChannelMessages', () => {
+        it('fetches messages from a text channel', async () => {
+            mockGet.mockResolvedValueOnce([
+                { id: '1001', author: { id: 'U1', username: 'alice', global_name: 'Alice' }, content: 'Hello', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '1002', author: { id: 'U2', username: 'bob' }, content: 'World', timestamp: '2024-01-01T00:01:00Z' },
+            ]);
+
+            const messages = await client.fetchChannelMessages('C001');
+            expect(messages).toHaveLength(2);
+            expect(messages[0].content).toBe('Hello');
+            expect(messages[1].author.username).toBe('bob');
+        });
+
+        it('paginates using after parameter', async () => {
+            mockGet
+                .mockResolvedValueOnce([
+                    { id: '1001', author: { id: 'U1', username: 'a' }, content: 'P1', timestamp: '2024-01-01T00:00:00Z' },
+                    { id: '1002', author: { id: 'U1', username: 'a' }, content: 'P1b', timestamp: '2024-01-01T00:00:01Z' },
+                ])
+                .mockResolvedValueOnce([
+                    { id: '1003', author: { id: 'U1', username: 'a' }, content: 'P2', timestamp: '2024-01-01T00:00:02Z' },
+                ])
+                .mockResolvedValueOnce([]);
+
+            // Set page size to 2 to force pagination
+            const messages = await client.fetchChannelMessages('C001', undefined, 2);
+            expect(messages).toHaveLength(3);
+        });
+
+        it('respects after parameter for incremental fetch', async () => {
+            mockGet.mockResolvedValueOnce([]);
+
+            await client.fetchChannelMessages('C001', '999');
+            expect(mockGet).toHaveBeenCalledWith(
+                expect.any(String),
+                expect.objectContaining({
+                    query: expect.any(URLSearchParams),
+                }),
+            );
+            const callQuery = mockGet.mock.calls[0][1].query as URLSearchParams;
+            expect(callQuery.get('after')).toBe('999');
+        });
+
+        it('stops at MAX_PAGES safety bound', async () => {
+            // Return full pages forever to test the safety bound
+            const fullPage = Array.from({ length: 100 }, (_, i) => ({
+                id: String(i),
+                author: { id: 'U1', username: 'a' },
+                content: 'msg',
+                timestamp: '2024-01-01T00:00:00Z',
+            }));
+            mockGet.mockResolvedValue(fullPage);
+
+            const messages = await client.fetchChannelMessages('C001');
+            // Should stop at MAX_PAGES (100), not run forever
+            expect(mockGet.mock.calls.length).toBeLessThanOrEqual(100);
+        });
+    });
+
+    describe('fetchForumThreads', () => {
+        it('combines active and archived threads, deduplicates', async () => {
+            // Active threads (guild-level, filtered by parent_id)
+            mockGet.mockResolvedValueOnce({
+                threads: [
+                    { id: 'T1', name: 'Thread 1', parent_id: 'C001', message_count: 5, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '2001', archived: false },
+                    { id: 'T2', name: 'Thread 2', parent_id: 'C999', message_count: 3, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '2002', archived: false },
+                ],
+            });
+            // Public archived
+            mockGet.mockResolvedValueOnce({
+                threads: [
+                    { id: 'T3', name: 'Thread 3', parent_id: 'C001', message_count: 4, owner_id: 'U2', created_timestamp: '2024-01-01', last_message_id: '2003', archived: true },
+                ],
+                has_more: false,
+            });
+            // Private archived
+            mockGet.mockResolvedValueOnce({
+                threads: [
+                    { id: 'T1', name: 'Thread 1 dup', parent_id: 'C001', message_count: 5, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '2001', archived: true },
+                ],
+                has_more: false,
+            });
+
+            const threads = await client.fetchForumThreads('C001', 'G001');
+            // T2 excluded (wrong parent_id), T1 deduped
+            expect(threads).toHaveLength(2);
+            expect(threads.map(t => t.id).sort()).toEqual(['T1', 'T3']);
+        });
+
+        it('paginates archived threads when has_more is true', async () => {
+            // Active threads (empty)
+            mockGet.mockResolvedValueOnce({ threads: [] });
+            // Public archived — page 1 with has_more
+            mockGet.mockResolvedValueOnce({
+                threads: [
+                    { id: 'T1', name: 'Thread 1', parent_id: 'C001', message_count: 5, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '2001', archived: true },
+                ],
+                has_more: true,
+            });
+            // Public archived — page 2
+            mockGet.mockResolvedValueOnce({
+                threads: [
+                    { id: 'T2', name: 'Thread 2', parent_id: 'C001', message_count: 3, owner_id: 'U2', created_timestamp: '2024-01-02', last_message_id: '2002', archived: true },
+                ],
+                has_more: false,
+            });
+            // Private archived (empty)
+            mockGet.mockResolvedValueOnce({ threads: [], has_more: false });
+
+            const threads = await client.fetchForumThreads('C001', 'G001');
+            expect(threads).toHaveLength(2);
+            expect(threads.map(t => t.id).sort()).toEqual(['T1', 'T2']);
+            // Verify 4 API calls: active + 2 public archived pages + 1 private archived
+            expect(mockGet).toHaveBeenCalledTimes(4);
+        });
+    });
+
+    describe('fetchThreadMessages', () => {
+        it('returns messages in a thread', async () => {
+            mockGet.mockResolvedValueOnce([
+                { id: '3001', author: { id: 'U1', username: 'alice' }, content: 'OP', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '3002', author: { id: 'U2', username: 'bob' }, content: 'Reply', timestamp: '2024-01-01T00:01:00Z' },
+            ]);
+
+            const messages = await client.fetchThreadMessages('T001');
+            expect(messages).toHaveLength(2);
+            expect(messages[0].content).toBe('OP');
+        });
+    });
+
+    describe('fetchUser', () => {
+        it('fetches user with display name', async () => {
+            mockGet.mockResolvedValueOnce({
+                id: 'U1',
+                username: 'alice',
+                global_name: 'Alice Smith',
+            });
+
+            const user = await client.fetchUser('U1');
+            expect(user.displayName).toBe('Alice Smith');
+        });
+
+        it('falls back to username when global_name is absent', async () => {
+            mockGet.mockResolvedValueOnce({
+                id: 'U1',
+                username: 'alice',
+            });
+
+            const user = await client.fetchUser('U1');
+            expect(user.displayName).toBe('alice');
+        });
+
+        it('caches user results', async () => {
+            mockGet.mockResolvedValueOnce({
+                id: 'U1',
+                username: 'alice',
+                global_name: 'Alice',
+            });
+
+            await client.fetchUser('U1');
+            await client.fetchUser('U1');
+            // Only one API call — second was cached
+            expect(mockGet).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    describe('getMessageUrl', () => {
+        it('generates correct Discord message URL', () => {
+            const url = client.getMessageUrl('G001', 'C001', 'M001');
+            expect(url).toBe('https://discord.com/channels/G001/C001/M001');
+        });
+    });
+
+    describe('rate limit handling', () => {
+        it('retries on 429 with retry_after', async () => {
+            const rateLimitError: any = new Error('Rate limited');
+            rateLimitError.status = 429;
+            rateLimitError.retryAfter = 10; // 10ms — will be clamped to 1000ms minimum
+
+            mockGet
+                .mockRejectedValueOnce(rateLimitError)
+                .mockResolvedValueOnce([
+                    { id: '1001', author: { id: 'U1', username: 'a' }, content: 'OK', timestamp: '2024-01-01T00:00:00Z' },
+                ]);
+
+            const messages = await client.fetchChannelMessages('C001');
+            expect(messages).toHaveLength(1);
+            expect(mockGet).toHaveBeenCalledTimes(2);
+        });
+
+        it('throws after max retries exceeded', async () => {
+            const rateLimitError: any = new Error('Rate limited');
+            rateLimitError.status = 429;
+            rateLimitError.retryAfter = 1; // 1ms — will be clamped to 1000ms minimum
+
+            const limitedClient = new DiscordApiClient({ token: 'test', maxRetries: 2 });
+            mockGet.mockRejectedValue(rateLimitError);
+
+            await expect(limitedClient.fetchChannelMessages('C001')).rejects.toThrow();
+        });
+    });
+});

--- a/src/__tests__/discord-config.test.ts
+++ b/src/__tests__/discord-config.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import { SourceConfigSchema, DiscordSourceConfigSchema, DiscordChannelConfigSchema } from '../types.js';
+
+describe('DiscordChannelConfigSchema', () => {
+    it('accepts valid text channel', () => {
+        const result = DiscordChannelConfigSchema.safeParse({ id: '111', type: 'text' });
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts valid forum channel', () => {
+        const result = DiscordChannelConfigSchema.safeParse({ id: '222', type: 'forum' });
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects empty id', () => {
+        const result = DiscordChannelConfigSchema.safeParse({ id: '', type: 'text' });
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects invalid channel type', () => {
+        const result = DiscordChannelConfigSchema.safeParse({ id: '111', type: 'voice' });
+        expect(result.success).toBe(false);
+    });
+});
+
+describe('DiscordSourceConfigSchema', () => {
+    it('accepts valid discord source config', () => {
+        const config = {
+            name: 'discord-test',
+            type: 'discord',
+            guild_id: '123456789012345678',
+            channels: [
+                { id: '111111111111111111', type: 'text' },
+                { id: '222222222222222222', type: 'forum' },
+            ],
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success && result.data.type === 'discord') {
+            expect(result.data.guild_id).toBe('123456789012345678');
+            expect(result.data.channels).toHaveLength(2);
+            expect(result.data.confidence_threshold).toBe(0.7); // default
+            expect(result.data.min_thread_replies).toBe(2); // default
+            expect(result.data.category).toBe('faq'); // default
+        }
+    });
+
+    it('accepts discord source with all optional fields', () => {
+        const config = {
+            name: 'discord-full',
+            type: 'discord',
+            guild_id: '123456789012345678',
+            channels: [{ id: '111', type: 'text' }],
+            confidence_threshold: 0.5,
+            min_thread_replies: 3,
+            distiller_model: 'gpt-4o',
+            chunk: { target_tokens: 800 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success && result.data.type === 'discord') {
+            expect(result.data.confidence_threshold).toBe(0.5);
+            expect(result.data.min_thread_replies).toBe(3);
+            expect(result.data.distiller_model).toBe('gpt-4o');
+        }
+    });
+
+    it('rejects missing guild_id', () => {
+        const config = {
+            name: 'discord-bad',
+            type: 'discord',
+            channels: [{ id: '111', type: 'text' }],
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects empty channels array', () => {
+        const config = {
+            name: 'discord-empty',
+            type: 'discord',
+            guild_id: '123',
+            channels: [],
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects confidence_threshold out of range', () => {
+        const config = {
+            name: 'discord-bad-threshold',
+            type: 'discord',
+            guild_id: '123',
+            channels: [{ id: '111', type: 'text' }],
+            confidence_threshold: 1.5,
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('resolves correctly in discriminated union', () => {
+        const config = {
+            name: 'discord-union',
+            type: 'discord',
+            guild_id: '123',
+            channels: [{ id: '111', type: 'forum' }],
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.type).toBe('discord');
+        }
+    });
+
+    it('does not accept trigger_emoji (Discord-specific exclusion)', () => {
+        const config = {
+            name: 'discord-no-emoji',
+            type: 'discord',
+            guild_id: '123',
+            channels: [{ id: '111', type: 'text' }],
+            trigger_emoji: 'pathfinder',
+            chunk: {},
+        };
+        // Zod strips unknown keys in strict mode, but with passthrough the schema
+        // simply won't include trigger_emoji in the parsed output
+        const result = SourceConfigSchema.safeParse(config);
+        if (result.success && result.data.type === 'discord') {
+            expect('trigger_emoji' in result.data).toBe(false);
+        }
+    });
+
+    it('discord source does not require path or file_patterns', () => {
+        const config = {
+            name: 'discord-minimal',
+            type: 'discord',
+            guild_id: '123',
+            channels: [{ id: '111', type: 'text' }],
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+});

--- a/src/__tests__/discord-provider.test.ts
+++ b/src/__tests__/discord-provider.test.ts
@@ -1,0 +1,419 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { DiscordDataProvider } from '../indexing/providers/discord.js';
+import type { DiscordSourceConfig } from '../types.js';
+
+// Mock dependencies
+vi.mock('../indexing/providers/discord-api.js', () => {
+    const MockDiscordApiClient = vi.fn(function (this: Record<string, unknown>) {
+        this.fetchChannelMessages = vi.fn();
+        this.fetchForumThreads = vi.fn();
+        this.fetchThreadMessages = vi.fn();
+        this.fetchUser = vi.fn();
+        this.getMessageUrl = vi.fn();
+    });
+    return { DiscordApiClient: MockDiscordApiClient };
+});
+
+vi.mock('../indexing/distiller.js', () => ({
+    distillThread: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+    getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: 'test-key',
+        slackBotToken: '',
+        slackSigningSecret: '',
+        discordBotToken: 'test-discord-token',
+        discordPublicKey: 'test-public-key',
+        databaseUrl: 'postgresql://test',
+        githubToken: '',
+        githubWebhookSecret: '',
+        port: 3001,
+        nodeEnv: 'test',
+        logLevel: 'info',
+        cloneDir: '/tmp/test',
+    }),
+}));
+
+import { DiscordApiClient } from '../indexing/providers/discord-api.js';
+import { distillThread } from '../indexing/distiller.js';
+
+const textOnlyConfig: DiscordSourceConfig = {
+    name: 'discord-test',
+    type: 'discord',
+    guild_id: 'G001',
+    channels: [{ id: 'C001', type: 'text' }],
+    confidence_threshold: 0.7,
+    min_thread_replies: 2,
+    chunk: {},
+    category: 'faq',
+};
+
+const forumOnlyConfig: DiscordSourceConfig = {
+    name: 'discord-forum',
+    type: 'discord',
+    guild_id: 'G001',
+    channels: [{ id: 'F001', type: 'forum' }],
+    confidence_threshold: 0.7,
+    min_thread_replies: 2,
+    chunk: {},
+    category: 'faq',
+};
+
+const mixedConfig: DiscordSourceConfig = {
+    name: 'discord-mixed',
+    type: 'discord',
+    guild_id: 'G001',
+    channels: [
+        { id: 'C001', type: 'text' },
+        { id: 'F001', type: 'forum' },
+    ],
+    confidence_threshold: 0.7,
+    min_thread_replies: 2,
+    chunk: {},
+    category: 'faq',
+};
+
+describe('DiscordDataProvider', () => {
+    let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
+
+    function createProvider(config: DiscordSourceConfig) {
+        const provider = new DiscordDataProvider(config, {
+            cloneDir: '/tmp/test',
+            discordBotToken: 'test-discord-token',
+        });
+        mockApiClient = (DiscordApiClient as ReturnType<typeof vi.fn>).mock.results[
+            (DiscordApiClient as ReturnType<typeof vi.fn>).mock.results.length - 1
+        ].value;
+        return provider;
+    }
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    describe('constructor', () => {
+        it('throws for non-discord config', () => {
+            expect(() => new DiscordDataProvider(
+                { name: 'test', type: 'slack', channels: ['C1'], chunk: {}, confidence_threshold: 0.7, trigger_emoji: 'p', min_thread_replies: 2, category: 'faq' } as any,
+                { cloneDir: '/tmp/test', discordBotToken: 'token' },
+            )).toThrow('DiscordDataProvider requires a discord source config');
+        });
+
+        it('throws when discordBotToken is missing', () => {
+            expect(() => new DiscordDataProvider(
+                textOnlyConfig,
+                { cloneDir: '/tmp/test' },
+            )).toThrow('discordBotToken');
+        });
+    });
+
+    describe('fullAcquire — text channels', () => {
+        it('fetches threads and distills Q&A pairs', async () => {
+            const provider = createProvider(textOnlyConfig);
+
+            mockApiClient.fetchChannelMessages.mockResolvedValue([
+                { id: '1001', author: { id: 'U1', username: 'alice' }, content: 'Question?', timestamp: '2024-01-01T00:00:00Z', thread: { id: 'T1', message_count: 5 } },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValue([
+                { id: '1001', author: { id: 'U1', username: 'alice' }, content: 'Question?', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '1002', author: { id: 'U2', username: 'bob', global_name: 'Bob' }, content: 'Answer.', timestamp: '2024-01-01T00:01:00Z' },
+                { id: '1003', author: { id: 'U1', username: 'alice' }, content: 'Thanks!', timestamp: '2024-01-01T00:02:00Z' },
+            ]);
+            mockApiClient.fetchUser
+                .mockResolvedValueOnce({ id: 'U1', displayName: 'Alice' })
+                .mockResolvedValueOnce({ id: 'U2', displayName: 'Bob' })
+                .mockResolvedValueOnce({ id: 'U1', displayName: 'Alice' });
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/C001/1001');
+            (distillThread as ReturnType<typeof vi.fn>).mockResolvedValue({
+                pairs: [{ question: 'What is X?', answer: 'X is Y.', confidence: 0.9 }],
+            });
+
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toHaveLength(1);
+            expect(result.items[0].id).toBe('C001:1001:0');
+            expect(result.items[0].content).toContain('Q: What is X?');
+            expect(result.items[0].content).toContain('A: X is Y.');
+            expect(result.items[0].title).toBe('What is X?');
+            expect(result.items[0].sourceUrl).toBe('https://discord.com/channels/G001/C001/1001');
+            expect(result.items[0].metadata?.confidence).toBe(0.9);
+            expect(result.removedIds).toEqual([]);
+        });
+
+        it('filters threads below min_thread_replies', async () => {
+            const provider = createProvider(textOnlyConfig);
+
+            mockApiClient.fetchChannelMessages.mockResolvedValue([
+                { id: '1001', author: { id: 'U1', username: 'a' }, content: 'Q', timestamp: '2024-01-01T00:00:00Z', thread: { id: 'T1', message_count: 1 } },
+            ]);
+
+            const result = await provider.fullAcquire();
+            expect(result.items).toEqual([]);
+            expect(mockApiClient.fetchThreadMessages).not.toHaveBeenCalled();
+        });
+
+        it('handles empty channel', async () => {
+            const provider = createProvider(textOnlyConfig);
+            mockApiClient.fetchChannelMessages.mockResolvedValue([]);
+            const result = await provider.fullAcquire();
+            expect(result.items).toEqual([]);
+        });
+    });
+
+    describe('fullAcquire — forum channels', () => {
+        it('extracts Q&A directly from forum threads', async () => {
+            const provider = createProvider(forumOnlyConfig);
+
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'How do I install?', parent_id: 'F001', message_count: 3, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '5001', archived: false },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValue([
+                { id: '5000', author: { id: 'U1', username: 'alice', global_name: 'Alice' }, content: 'How do I install? I need help.', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '5001', author: { id: 'U2', username: 'bob', global_name: 'Bob' }, content: 'Run npm install @copilotkit/core', timestamp: '2024-01-01T00:01:00Z' },
+            ]);
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/T1/5000');
+
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toHaveLength(1);
+            expect(result.items[0].id).toBe('F001:T1');
+            expect(result.items[0].content).toContain('Q: How do I install?');
+            expect(result.items[0].content).toContain('A: ');
+            expect(result.items[0].content).toContain('Bob: Run npm install @copilotkit/core');
+            expect(result.items[0].metadata?.confidence).toBe(1.0);
+            expect(result.items[0].metadata?.forumThread).toBe(true);
+            // Distiller should NOT be called for forum channels
+            expect(distillThread).not.toHaveBeenCalled();
+        });
+
+        it('skips first message if it restates the thread title', async () => {
+            const provider = createProvider(forumOnlyConfig);
+
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'How do I install?', parent_id: 'F001', message_count: 3, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '5002', archived: false },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValue([
+                { id: '5000', author: { id: 'U1', username: 'alice' }, content: 'How do I install?', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '5001', author: { id: 'U2', username: 'bob', global_name: 'Bob' }, content: 'Use npm install', timestamp: '2024-01-01T00:01:00Z' },
+                { id: '5002', author: { id: 'U1', username: 'alice' }, content: 'Thanks!', timestamp: '2024-01-01T00:02:00Z' },
+            ]);
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/T1/5000');
+
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toHaveLength(1);
+            // The answer should NOT contain the title-restating first message
+            expect(result.items[0].content).not.toContain('alice: How do I install?');
+            expect(result.items[0].content).toContain('Bob: Use npm install');
+        });
+
+        it('preserves first message when it adds content beyond the title', async () => {
+            const provider = createProvider(forumOnlyConfig);
+
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'How do I install?', parent_id: 'F001', message_count: 3, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '5002', archived: false },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValue([
+                { id: '5000', author: { id: 'U1', username: 'alice', global_name: 'Alice' }, content: 'How do I install? I\'ve been trying for hours and nothing works.', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '5001', author: { id: 'U2', username: 'bob', global_name: 'Bob' }, content: 'Run npm install @copilotkit/core', timestamp: '2024-01-01T00:01:00Z' },
+                { id: '5002', author: { id: 'U1', username: 'alice', global_name: 'Alice' }, content: 'Thanks!', timestamp: '2024-01-01T00:02:00Z' },
+            ]);
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/T1/5000');
+
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toHaveLength(1);
+            // The first message should be preserved because it contains content beyond the title
+            expect(result.items[0].content).toContain('Alice: How do I install?');
+            expect(result.items[0].content).toContain('nothing works');
+            expect(result.items[0].content).toContain('Bob: Run npm install @copilotkit/core');
+        });
+
+        it('truncates long forum answers at MAX_ANSWER_CHARS', async () => {
+            const provider = createProvider(forumOnlyConfig);
+
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'Long thread', parent_id: 'F001', message_count: 100, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '9999', archived: false },
+            ]);
+
+            // Generate many long messages to exceed 8000 chars
+            const longMessages = Array.from({ length: 50 }, (_, i) => ({
+                id: String(6000 + i),
+                author: { id: `U${i}`, username: `user${i}`, global_name: `User ${i}` },
+                content: 'A'.repeat(200),
+                timestamp: `2024-01-01T00:${String(i).padStart(2, '0')}:00Z`,
+            }));
+            mockApiClient.fetchThreadMessages.mockResolvedValue(longMessages);
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/T1/6000');
+
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toHaveLength(1);
+            // Answer portion should be truncated
+            const answerStart = result.items[0].content.indexOf('A: ');
+            const answer = result.items[0].content.slice(answerStart + 3);
+            expect(answer.length).toBeLessThanOrEqual(8100); // 8000 + some tolerance for truncation marker
+            expect(answer).toContain('[truncated]');
+        });
+
+        it('filters forum threads below min_thread_replies', async () => {
+            const provider = createProvider(forumOnlyConfig);
+
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'Too few replies', parent_id: 'F001', message_count: 1, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '5001', archived: false },
+            ]);
+
+            const result = await provider.fullAcquire();
+            expect(result.items).toEqual([]);
+        });
+
+        it('skips forum threads with empty synthesized answer', async () => {
+            const provider = createProvider(forumOnlyConfig);
+
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'Unanswered', parent_id: 'F001', message_count: 2, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '5001', archived: false },
+            ]);
+            // Only embeds, no text content
+            mockApiClient.fetchThreadMessages.mockResolvedValue([
+                { id: '5000', author: { id: 'U1', username: 'alice' }, content: '', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '5001', author: { id: 'U2', username: 'bob' }, content: '', timestamp: '2024-01-01T00:01:00Z' },
+            ]);
+
+            const result = await provider.fullAcquire();
+            expect(result.items).toEqual([]);
+        });
+    });
+
+    describe('fullAcquire — mixed channels', () => {
+        it('processes both text and forum channels', async () => {
+            const provider = createProvider(mixedConfig);
+
+            // Text channel
+            mockApiClient.fetchChannelMessages.mockResolvedValue([
+                { id: '1001', author: { id: 'U1', username: 'a' }, content: 'Q?', timestamp: '2024-01-01T00:00:00Z', thread: { id: 'T1', message_count: 3 } },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValueOnce([
+                { id: '1001', author: { id: 'U1', username: 'a' }, content: 'Q?', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '1002', author: { id: 'U2', username: 'b' }, content: 'A.', timestamp: '2024-01-01T00:01:00Z' },
+            ]);
+            mockApiClient.fetchUser.mockResolvedValue({ id: 'U1', displayName: 'User' });
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/C001/1001');
+            (distillThread as ReturnType<typeof vi.fn>).mockResolvedValue({
+                pairs: [{ question: 'Text Q', answer: 'Text A', confidence: 0.8 }],
+            });
+
+            // Forum channel
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'FT1', name: 'Forum question', parent_id: 'F001', message_count: 3, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '9001', archived: false },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValueOnce([
+                { id: '9000', author: { id: 'U1', username: 'a', global_name: 'UserA' }, content: 'Details here', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '9001', author: { id: 'U2', username: 'b', global_name: 'UserB' }, content: 'The answer', timestamp: '2024-01-01T00:01:00Z' },
+            ]);
+
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toHaveLength(2);
+            // One from text distillation, one from forum extraction
+            const textItem = result.items.find(i => i.id.startsWith('C001:'));
+            const forumItem = result.items.find(i => i.id.startsWith('F001:'));
+            expect(textItem).toBeDefined();
+            expect(forumItem).toBeDefined();
+            expect(forumItem!.metadata?.forumThread).toBe(true);
+            expect(forumItem!.metadata?.confidence).toBe(1.0);
+        });
+    });
+
+    describe('fullAcquire — error handling', () => {
+        it('throws when all channels fail', async () => {
+            const provider = createProvider(textOnlyConfig);
+            mockApiClient.fetchChannelMessages.mockRejectedValue(new Error('channel_not_found'));
+            await expect(provider.fullAcquire()).rejects.toThrow('All 1 channel(s) failed');
+        });
+
+        it('continues when one channel fails in multi-channel config', async () => {
+            const provider = createProvider(mixedConfig);
+
+            // Text channel fails
+            mockApiClient.fetchChannelMessages.mockRejectedValue(new Error('fail'));
+
+            // Forum channel succeeds
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'FT1', name: 'Question', parent_id: 'F001', message_count: 3, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '9001', archived: false },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValue([
+                { id: '9000', author: { id: 'U1', username: 'a', global_name: 'A' }, content: 'Details', timestamp: '2024-01-01T00:00:00Z' },
+                { id: '9001', author: { id: 'U2', username: 'b', global_name: 'B' }, content: 'Answer', timestamp: '2024-01-01T00:01:00Z' },
+            ]);
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/F001/9000');
+
+            const result = await provider.fullAcquire();
+            expect(result.items).toHaveLength(1);
+        });
+    });
+
+    describe('incrementalAcquire', () => {
+        it('passes after parameter for text channels', async () => {
+            const provider = createProvider(textOnlyConfig);
+            mockApiClient.fetchChannelMessages.mockResolvedValue([]);
+
+            await provider.incrementalAcquire('999');
+            expect(mockApiClient.fetchChannelMessages).toHaveBeenCalledWith('C001', '999');
+        });
+
+        it('filters forum threads by last_message_id > lastStateToken via BigInt', async () => {
+            const provider = createProvider(forumOnlyConfig);
+
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'Old thread', parent_id: 'F001', message_count: 5, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '500', archived: false },
+                { id: 'T2', name: 'New thread', parent_id: 'F001', message_count: 3, owner_id: 'U2', created_timestamp: '2024-01-02', last_message_id: '1500', archived: false },
+            ]);
+            mockApiClient.fetchThreadMessages.mockResolvedValue([
+                { id: '1400', author: { id: 'U2', username: 'b', global_name: 'B' }, content: 'Details', timestamp: '2024-01-02T00:00:00Z' },
+                { id: '1500', author: { id: 'U3', username: 'c', global_name: 'C' }, content: 'Reply', timestamp: '2024-01-02T00:01:00Z' },
+            ]);
+            mockApiClient.getMessageUrl.mockReturnValue('https://discord.com/channels/G001/T2/1400');
+
+            const result = await provider.incrementalAcquire('1000');
+
+            expect(result.items).toHaveLength(1);
+            expect(result.items[0].id).toBe('F001:T2');
+        });
+
+        it('returns stateToken >= lastStateToken', async () => {
+            const provider = createProvider(textOnlyConfig);
+            mockApiClient.fetchChannelMessages.mockResolvedValue([]);
+
+            const result = await provider.incrementalAcquire('1500');
+            expect(BigInt(result.stateToken)).toBeGreaterThanOrEqual(BigInt('1500'));
+        });
+    });
+
+    describe('getCurrentStateToken', () => {
+        it('returns max snowflake across text and forum channels', async () => {
+            const provider = createProvider(mixedConfig);
+
+            // Text channel: latest message
+            mockApiClient.fetchChannelMessages.mockResolvedValue([
+                { id: '2000', author: { id: 'U1', username: 'a' }, content: 'msg', timestamp: '2024-01-01T00:00:00Z' },
+            ]);
+
+            // Forum channel: threads
+            mockApiClient.fetchForumThreads.mockResolvedValue([
+                { id: 'T1', name: 'Thread', parent_id: 'F001', message_count: 3, owner_id: 'U1', created_timestamp: '2024-01-01', last_message_id: '3000', archived: false },
+            ]);
+
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBe('3000');
+        });
+
+        it('returns null when no messages found', async () => {
+            const provider = createProvider(textOnlyConfig);
+            mockApiClient.fetchChannelMessages.mockResolvedValue([]);
+
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBeNull();
+        });
+    });
+});

--- a/src/__tests__/discord-webhook.test.ts
+++ b/src/__tests__/discord-webhook.test.ts
@@ -1,0 +1,175 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { verifyDiscordSignature, createDiscordWebhookHandler, type DiscordReindexOrchestrator } from '../webhooks/discord.js';
+
+// Mock discord-interactions
+vi.mock('discord-interactions', () => ({
+    verifyKey: vi.fn(),
+}));
+
+// Mock config
+vi.mock('../config.js', () => ({
+    getConfig: vi.fn().mockReturnValue({
+        discordPublicKey: 'test-public-key-hex',
+        slackBotToken: '',
+        slackSigningSecret: '',
+        discordBotToken: 'test-bot-token',
+        openaiApiKey: 'test-key',
+        databaseUrl: 'postgresql://test',
+        githubToken: '',
+        githubWebhookSecret: '',
+        port: 3001,
+        nodeEnv: 'test',
+        logLevel: 'info',
+        cloneDir: '/tmp/test',
+    }),
+    getServerConfig: vi.fn().mockReturnValue({
+        server: { name: 'test', version: '1.0' },
+        sources: [],
+        tools: [],
+    }),
+}));
+
+import { verifyKey } from 'discord-interactions';
+
+function mockReqRes(body: object, headers: Record<string, string> = {}) {
+    const bodyStr = JSON.stringify(body);
+    const req = {
+        body: Buffer.from(bodyStr),
+        headers: {
+            'x-signature-ed25519': 'valid-sig',
+            'x-signature-timestamp': String(Math.floor(Date.now() / 1000)),
+            ...headers,
+        },
+    } as any;
+
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+        headersSent: false,
+    } as any;
+
+    return { req, res };
+}
+
+describe('verifyDiscordSignature', () => {
+    it('returns true for valid signature', async () => {
+        (verifyKey as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+        const result = await verifyDiscordSignature(
+            Buffer.from('body'),
+            'valid-sig',
+            '12345',
+            'public-key',
+        );
+        expect(result).toBe(true);
+        expect(verifyKey).toHaveBeenCalledWith(
+            Buffer.from('body'),
+            'valid-sig',
+            '12345',
+            'public-key',
+        );
+    });
+
+    it('returns false for invalid signature', async () => {
+        (verifyKey as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+        const result = await verifyDiscordSignature(
+            Buffer.from('body'),
+            'bad-sig',
+            '12345',
+            'public-key',
+        );
+        expect(result).toBe(false);
+    });
+
+    it('returns false when signature is missing', async () => {
+        const result = await verifyDiscordSignature(
+            Buffer.from('body'),
+            undefined,
+            '12345',
+            'public-key',
+        );
+        expect(result).toBe(false);
+    });
+
+    it('returns false when timestamp is missing', async () => {
+        const result = await verifyDiscordSignature(
+            Buffer.from('body'),
+            'sig',
+            undefined,
+            'public-key',
+        );
+        expect(result).toBe(false);
+    });
+
+    it('returns false when verifyKey throws', async () => {
+        const { verifyKey } = await import('discord-interactions');
+        (verifyKey as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error('crypto failure'));
+
+        const result = await verifyDiscordSignature(
+            Buffer.from('body'),
+            'sig',
+            'timestamp',
+            'bad-key',
+        );
+        expect(result).toBe(false);
+    });
+});
+
+describe('createDiscordWebhookHandler', () => {
+    let orchestrator: DiscordReindexOrchestrator;
+    let handler: ReturnType<typeof createDiscordWebhookHandler>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (verifyKey as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+        orchestrator = { queueSourceReindex: vi.fn() };
+        handler = createDiscordWebhookHandler(orchestrator);
+    });
+
+    it('responds to PING interaction with type 1', async () => {
+        const { req, res } = mockReqRes({ type: 1 });
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({ type: 1 });
+    });
+
+    it('acknowledges non-PING interactions with 200', async () => {
+        const { req, res } = mockReqRes({ type: 2, data: { name: 'test' } });
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ok: true }));
+    });
+
+    it('rejects request with invalid signature', async () => {
+        (verifyKey as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+
+        const { req, res } = mockReqRes({ type: 1 });
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it('rejects non-Buffer request body', async () => {
+        const req = { body: '{"type":1}', headers: {} } as any;
+        const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(500);
+    });
+
+    it('handles malformed JSON', async () => {
+        (verifyKey as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+
+        const req = {
+            body: Buffer.from('not json'),
+            headers: {
+                'x-signature-ed25519': 'sig',
+                'x-signature-timestamp': '12345',
+            },
+        } as any;
+        const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(400);
+    });
+});

--- a/src/__tests__/distiller.test.ts
+++ b/src/__tests__/distiller.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { distillThread, type ThreadMessage } from '../indexing/distiller.js';
+
+// Shared mock function accessible in tests
+const mockCreate = vi.fn();
+
+// Mock the openai module — default export must be a class (used with `new`)
+vi.mock('openai', () => {
+    class MockOpenAI {
+        chat = {
+            completions: {
+                create: mockCreate,
+            },
+        };
+        constructor(_opts?: unknown) {}
+    }
+    return { default: MockOpenAI };
+});
+
+describe('distillThread', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    const sampleMessages: ThreadMessage[] = [
+        { author: 'Alice', content: 'How do I set up CopilotKit with Next.js?', timestamp: '2024-01-15 10:00' },
+        { author: 'Bob', content: 'You need to install @copilotkit/react-core and wrap your app with CopilotKit provider.', timestamp: '2024-01-15 10:05', reactions: [{ name: 'thumbsup', count: 3 }] },
+        { author: 'Alice', content: 'Thanks, that worked!', timestamp: '2024-01-15 10:10' },
+    ];
+
+    it('extracts Q&A pairs from a thread', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{
+                message: {
+                    content: JSON.stringify({
+                        pairs: [{
+                            question: 'How do I set up CopilotKit with Next.js?',
+                            answer: 'Install @copilotkit/react-core and wrap your app with the CopilotKit provider component.',
+                            confidence: 0.92,
+                        }],
+                    }),
+                },
+            }],
+        });
+
+        const result = await distillThread(sampleMessages, { apiKey: 'test-key' });
+        expect(result.pairs).toHaveLength(1);
+        expect(result.pairs[0].question).toContain('CopilotKit');
+        expect(result.pairs[0].confidence).toBe(0.92);
+    });
+
+    it('returns multiple pairs for threads with follow-ups', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{
+                message: {
+                    content: JSON.stringify({
+                        pairs: [
+                            { question: 'Q1', answer: 'A1', confidence: 0.9 },
+                            { question: 'Q2', answer: 'A2', confidence: 0.7 },
+                        ],
+                    }),
+                },
+            }],
+        });
+
+        const result = await distillThread(sampleMessages, { apiKey: 'test-key' });
+        expect(result.pairs).toHaveLength(2);
+    });
+
+    it('returns empty pairs for empty message list', async () => {
+        const result = await distillThread([], { apiKey: 'test-key' });
+        expect(result.pairs).toEqual([]);
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('handles LLM returning no pairs', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{
+                message: { content: JSON.stringify({ pairs: [] }) },
+            }],
+        });
+
+        const result = await distillThread(sampleMessages, { apiKey: 'test-key' });
+        expect(result.pairs).toEqual([]);
+    });
+
+    it('handles malformed JSON response gracefully', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{
+                message: { content: 'not valid json {{{' },
+            }],
+        });
+
+        const result = await distillThread(sampleMessages, { apiKey: 'test-key' });
+        expect(result.pairs).toEqual([]);
+    });
+
+    it('handles empty response from LLM', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{ message: { content: null } }],
+        });
+
+        const result = await distillThread(sampleMessages, { apiKey: 'test-key' });
+        expect(result.pairs).toEqual([]);
+    });
+
+    it('filters out malformed pairs', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{
+                message: {
+                    content: JSON.stringify({
+                        pairs: [
+                            { question: 'Valid Q', answer: 'Valid A', confidence: 0.8 },
+                            { question: '', answer: 'No question', confidence: 0.5 },
+                            { question: 'No answer', answer: '', confidence: 0.5 },
+                            { question: 'Bad confidence', answer: 'Answer', confidence: 1.5 },
+                            { question: 'Missing confidence', answer: 'Answer' },
+                        ],
+                    }),
+                },
+            }],
+        });
+
+        const result = await distillThread(sampleMessages, { apiKey: 'test-key' });
+        expect(result.pairs).toHaveLength(1);
+        expect(result.pairs[0].question).toBe('Valid Q');
+    });
+
+    it('handles missing pairs array in response', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{
+                message: { content: JSON.stringify({ data: 'wrong key' }) },
+            }],
+        });
+
+        const result = await distillThread(sampleMessages, { apiKey: 'test-key' });
+        expect(result.pairs).toEqual([]);
+    });
+
+    it('truncates messages to maxMessages', async () => {
+        const manyMessages = Array.from({ length: 150 }, (_, i) => ({
+            author: 'User',
+            content: `Message ${i}`,
+            timestamp: `2024-01-15 ${i}`,
+        }));
+
+        mockCreate.mockResolvedValueOnce({
+            choices: [{ message: { content: JSON.stringify({ pairs: [] }) } }],
+        });
+
+        await distillThread(manyMessages, { apiKey: 'test-key', maxMessages: 50 });
+
+        const callArgs = mockCreate.mock.calls[0][0];
+        const userContent = callArgs.messages[1].content;
+        // Should only contain 50 messages
+        const messageCount = (userContent.match(/User:/g) || []).length;
+        expect(messageCount).toBe(50);
+    });
+
+    it('includes reactions in transcript', async () => {
+        const messagesWithReactions: ThreadMessage[] = [
+            {
+                author: 'Alice',
+                content: 'Question?',
+                timestamp: '2024-01-15',
+                reactions: [{ name: 'eyes', count: 2 }],
+            },
+        ];
+
+        mockCreate.mockResolvedValueOnce({
+            choices: [{ message: { content: JSON.stringify({ pairs: [] }) } }],
+        });
+
+        await distillThread(messagesWithReactions, { apiKey: 'test-key' });
+
+        const callArgs = mockCreate.mock.calls[0][0];
+        const userContent = callArgs.messages[1].content;
+        expect(userContent).toContain(':eyes: x2');
+    });
+
+    it('re-throws API errors (not JSON parse errors)', async () => {
+        const apiError = new Error('API quota exceeded');
+        mockCreate.mockRejectedValueOnce(apiError);
+
+        await expect(distillThread(sampleMessages, { apiKey: 'test-key' })).rejects.toThrow('API quota exceeded');
+    });
+
+    it('uses specified model', async () => {
+        mockCreate.mockResolvedValueOnce({
+            choices: [{ message: { content: JSON.stringify({ pairs: [] }) } }],
+        });
+
+        await distillThread(sampleMessages, { apiKey: 'test-key', model: 'gpt-4o' });
+
+        const callArgs = mockCreate.mock.calls[0][0];
+        expect(callArgs.model).toBe('gpt-4o');
+    });
+});

--- a/src/__tests__/faq-config.test.ts
+++ b/src/__tests__/faq-config.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect } from 'vitest';
+import {
+    SourceConfigSchema,
+    SlackSourceConfigSchema,
+    KnowledgeToolConfigSchema,
+    AnyToolConfigSchema,
+    ServerConfigSchema,
+} from '../types.js';
+
+describe('Source category field', () => {
+    it('accepts file source without category (undefined)', () => {
+        const config = {
+            name: 'test-docs',
+            type: 'markdown',
+            path: 'docs/',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 600, overlap_tokens: 50 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect((result.data as Record<string, unknown>).category).toBeUndefined();
+        }
+    });
+
+    it('accepts file source with explicit faq category', () => {
+        const config = {
+            name: 'test-docs',
+            type: 'markdown',
+            path: 'docs/',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 600 },
+            category: 'faq',
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects file source with invalid category', () => {
+        const config = {
+            name: 'test-docs',
+            type: 'markdown',
+            path: 'docs/',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 600 },
+            category: 'blog',
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('slack source defaults category to faq', () => {
+        const config = {
+            name: 'slack-support',
+            type: 'slack',
+            channels: ['C01234ABCDE'],
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success && result.data.type === 'slack') {
+            expect(result.data.category).toBe('faq');
+        }
+    });
+
+    it('slack source allows explicit category override', () => {
+        const config = {
+            name: 'slack-support',
+            type: 'slack',
+            channels: ['C01234ABCDE'],
+            chunk: {},
+            category: 'faq',
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+});
+
+describe('KnowledgeToolConfigSchema', () => {
+    const validKnowledge = {
+        name: 'get-faq',
+        type: 'knowledge' as const,
+        description: 'Get FAQ',
+        sources: ['slack-support'],
+        min_confidence: 0.7,
+        default_limit: 20,
+        max_limit: 100,
+    };
+
+    it('parses a valid knowledge tool config', () => {
+        const result = KnowledgeToolConfigSchema.safeParse(validKnowledge);
+        expect(result.success).toBe(true);
+    });
+
+    it('applies defaults for optional fields', () => {
+        const minimal = {
+            name: 'get-faq',
+            type: 'knowledge' as const,
+            description: 'Get FAQ',
+            sources: ['slack-support'],
+        };
+        const result = KnowledgeToolConfigSchema.safeParse(minimal);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.min_confidence).toBe(0.7);
+            expect(result.data.default_limit).toBe(20);
+            expect(result.data.max_limit).toBe(100);
+        }
+    });
+
+    it('rejects missing name', () => {
+        const { name, ...rest } = validKnowledge;
+        expect(KnowledgeToolConfigSchema.safeParse(rest).success).toBe(false);
+    });
+
+    it('rejects missing description', () => {
+        const { description, ...rest } = validKnowledge;
+        expect(KnowledgeToolConfigSchema.safeParse(rest).success).toBe(false);
+    });
+
+    it('rejects empty sources array', () => {
+        const config = { ...validKnowledge, sources: [] };
+        expect(KnowledgeToolConfigSchema.safeParse(config).success).toBe(false);
+    });
+
+    it('rejects min_confidence out of range', () => {
+        expect(KnowledgeToolConfigSchema.safeParse({ ...validKnowledge, min_confidence: 1.5 }).success).toBe(false);
+        expect(KnowledgeToolConfigSchema.safeParse({ ...validKnowledge, min_confidence: -0.1 }).success).toBe(false);
+    });
+
+    it('is included in AnyToolConfigSchema union', () => {
+        const result = AnyToolConfigSchema.safeParse(validKnowledge);
+        expect(result.success).toBe(true);
+    });
+});
+
+describe('ServerConfigSchema knowledge tool validation', () => {
+    const baseConfig = {
+        server: { name: 'test', version: '1.0' },
+        sources: [
+            {
+                name: 'slack-support',
+                type: 'slack' as const,
+                channels: ['C01234ABCDE'],
+                chunk: {},
+            },
+        ],
+        embedding: { provider: 'openai' as const, model: 'text-embedding-3-small', dimensions: 1536 },
+        indexing: { auto_reindex: true, reindex_hour_utc: 3, stale_threshold_hours: 24 },
+    };
+
+    it('accepts config with knowledge tool referencing valid source', () => {
+        const config = {
+            ...baseConfig,
+            tools: [{
+                name: 'get-faq',
+                type: 'knowledge' as const,
+                description: 'Get FAQ',
+                sources: ['slack-support'],
+            }],
+        };
+        const result = ServerConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+
+    it('rejects knowledge tool referencing non-existent source', () => {
+        const config = {
+            ...baseConfig,
+            tools: [{
+                name: 'get-faq',
+                type: 'knowledge' as const,
+                description: 'Get FAQ',
+                sources: ['nonexistent'],
+            }],
+        };
+        const result = ServerConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('requires embedding config when knowledge tools are configured', () => {
+        const { embedding, ...rest } = baseConfig;
+        const config = {
+            ...rest,
+            tools: [{
+                name: 'get-faq',
+                type: 'knowledge' as const,
+                description: 'Get FAQ',
+                sources: ['slack-support'],
+            }],
+        };
+        const result = ServerConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects knowledge tool where default_limit > max_limit', () => {
+        const config = {
+            ...baseConfig,
+            tools: [{
+                name: 'get-faq',
+                type: 'knowledge' as const,
+                description: 'Get FAQ',
+                sources: ['slack-support'],
+                default_limit: 200,
+                max_limit: 50,
+            }],
+        };
+        const result = ServerConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+});

--- a/src/__tests__/faq-queries.test.ts
+++ b/src/__tests__/faq-queries.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock the db client to intercept pool.query calls
+const mockQuery = vi.fn();
+vi.mock('../db/client.js', () => ({
+    getPool: () => ({ query: mockQuery }),
+}));
+
+// Import AFTER mocking
+import { getFaqChunks } from '../db/queries.js';
+
+describe('getFaqChunks', () => {
+    beforeEach(() => {
+        mockQuery.mockReset();
+    });
+
+    it('returns empty array for empty sourceNames', async () => {
+        const result = await getFaqChunks([], 0.7);
+        expect(result).toEqual([]);
+        expect(mockQuery).not.toHaveBeenCalled();
+    });
+
+    it('queries with correct source names and confidence threshold', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        await getFaqChunks(['slack-support', 'slack-general'], 0.8);
+
+        expect(mockQuery).toHaveBeenCalledOnce();
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(sql).toContain('source_name IN ($1, $2)');
+        expect(sql).toContain("(metadata->>'confidence')::float >= $3");
+        expect(params).toEqual(['slack-support', 'slack-general', 0.8]);
+    });
+
+    it('applies LIMIT when provided', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        await getFaqChunks(['slack-support'], 0.7, 10);
+
+        const [sql, params] = mockQuery.mock.calls[0];
+        expect(sql).toContain('LIMIT $3');
+        expect(params).toEqual(['slack-support', 0.7, 10]);
+    });
+
+    it('maps rows to FaqChunkResult correctly', async () => {
+        mockQuery.mockResolvedValueOnce({
+            rows: [{
+                id: 42,
+                source_name: 'slack-support',
+                source_url: 'https://slack.com/archives/C123/p456',
+                title: 'How to configure headers?',
+                content: 'Q: How to configure headers?\n\nA: Use the headers property...',
+                repo_url: null,
+                file_path: 'C123:456:0',
+                start_line: null,
+                end_line: null,
+                language: null,
+                similarity: '0',
+                metadata: { channel: 'C123', confidence: 0.85 },
+                confidence: '0.85',
+            }],
+        });
+
+        const results = await getFaqChunks(['slack-support'], 0.7);
+        expect(results).toHaveLength(1);
+        expect(results[0].id).toBe(42);
+        expect(results[0].confidence).toBe(0.85);
+        expect(results[0].metadata).toEqual({ channel: 'C123', confidence: 0.85 });
+        expect(results[0].source_name).toBe('slack-support');
+    });
+
+    it('orders by source_name then indexed_at DESC', async () => {
+        mockQuery.mockResolvedValueOnce({ rows: [] });
+        await getFaqChunks(['slack-support'], 0.5);
+
+        const [sql] = mockQuery.mock.calls[0];
+        expect(sql).toContain('ORDER BY source_name, indexed_at DESC');
+    });
+});

--- a/src/__tests__/faq-txt.test.ts
+++ b/src/__tests__/faq-txt.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from 'vitest';
+import { generateFaqTxt } from '../faq-txt.js';
+import type { FaqChunkResult } from '../types.js';
+
+function makeFaqChunk(overrides: Partial<FaqChunkResult> & { source_name: string; content: string; confidence: number }): FaqChunkResult {
+    return {
+        id: 1,
+        source_url: null,
+        title: null,
+        repo_url: null,
+        file_path: 'test',
+        start_line: null,
+        end_line: null,
+        language: null,
+        similarity: 0,
+        metadata: {},
+        ...overrides,
+    };
+}
+
+describe('generateFaqTxt', () => {
+    it('generates header with server name', () => {
+        const result = generateFaqTxt([], 'TestServer', []);
+        expect(result).toContain('# TestServer — Frequently Asked Questions');
+    });
+
+    it('shows "No FAQ content available" when no chunks', () => {
+        const result = generateFaqTxt([], 'TestServer', [{ name: 'slack-support', confidenceThreshold: 0.7 }]);
+        expect(result).toContain('No FAQ content available yet.');
+    });
+
+    it('groups Q&A pairs by source', () => {
+        const chunks: FaqChunkResult[] = [
+            makeFaqChunk({ source_name: 'slack-support', content: 'Q: Question 1?\n\nA: Answer 1.', confidence: 0.9 }),
+            makeFaqChunk({ source_name: 'slack-general', content: 'Q: Question 2?\n\nA: Answer 2.', confidence: 0.8 }),
+        ];
+        const sources = [
+            { name: 'slack-support', confidenceThreshold: 0.7 },
+            { name: 'slack-general', confidenceThreshold: 0.7 },
+        ];
+        const result = generateFaqTxt(chunks, 'TestServer', sources);
+        expect(result).toContain('## slack-support');
+        expect(result).toContain('## slack-general');
+        expect(result).toContain('Q: Question 1?');
+        expect(result).toContain('Q: Question 2?');
+    });
+
+    it('preserves source order from config', () => {
+        const chunks: FaqChunkResult[] = [
+            makeFaqChunk({ source_name: 'slack-general', content: 'Q: Q2?\n\nA: A2.', confidence: 0.8 }),
+            makeFaqChunk({ source_name: 'slack-support', content: 'Q: Q1?\n\nA: A1.', confidence: 0.9 }),
+        ];
+        const sources = [
+            { name: 'slack-support', confidenceThreshold: 0.7 },
+            { name: 'slack-general', confidenceThreshold: 0.7 },
+        ];
+        const result = generateFaqTxt(chunks, 'TestServer', sources);
+        const supportIdx = result.indexOf('## slack-support');
+        const generalIdx = result.indexOf('## slack-general');
+        expect(supportIdx).toBeLessThan(generalIdx);
+    });
+
+    it('skips sources with no chunks', () => {
+        const chunks: FaqChunkResult[] = [
+            makeFaqChunk({ source_name: 'slack-support', content: 'Q: Q1?\n\nA: A1.', confidence: 0.9 }),
+        ];
+        const sources = [
+            { name: 'slack-support', confidenceThreshold: 0.7 },
+            { name: 'slack-empty', confidenceThreshold: 0.7 },
+        ];
+        const result = generateFaqTxt(chunks, 'TestServer', sources);
+        expect(result).toContain('## slack-support');
+        expect(result).not.toContain('## slack-empty');
+    });
+
+    it('includes multiple Q&A pairs from same source', () => {
+        const chunks: FaqChunkResult[] = [
+            makeFaqChunk({ id: 1, source_name: 'slack-support', content: 'Q: First?\n\nA: First answer.', confidence: 0.9 }),
+            makeFaqChunk({ id: 2, source_name: 'slack-support', content: 'Q: Second?\n\nA: Second answer.', confidence: 0.8 }),
+        ];
+        const sources = [{ name: 'slack-support', confidenceThreshold: 0.7 }];
+        const result = generateFaqTxt(chunks, 'TestServer', sources);
+        expect(result).toContain('Q: First?');
+        expect(result).toContain('Q: Second?');
+    });
+});

--- a/src/__tests__/file-provider.test.ts
+++ b/src/__tests__/file-provider.test.ts
@@ -3,7 +3,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { FileDataProvider } from '../indexing/providers/file.js';
-import type { SourceConfig } from '../types.js';
+import type { FileSourceConfig } from '../types.js';
 
 describe('FileDataProvider', () => {
     let tmpDir: string;
@@ -21,7 +21,7 @@ describe('FileDataProvider', () => {
         await fs.promises.rm(tmpDir, { recursive: true, force: true });
     });
 
-    function makeConfig(overrides?: Partial<SourceConfig>): SourceConfig {
+    function makeConfig(overrides?: Partial<FileSourceConfig>): FileSourceConfig {
         return {
             name: 'test',
             type: 'markdown',

--- a/src/__tests__/knowledge-tool.test.ts
+++ b/src/__tests__/knowledge-tool.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { formatFaqResults } from '../mcp/tools/knowledge.js';
+import type { FaqChunkResult } from '../types.js';
+
+// Test the formatter directly (no need to mock DB for this)
+function makeFaqResult(overrides: Partial<FaqChunkResult>): FaqChunkResult {
+    return {
+        id: 1,
+        source_name: 'slack-support',
+        source_url: 'https://slack.com/archives/C123/p456',
+        title: 'How to configure headers?',
+        content: 'Q: How to configure headers?\n\nA: Use the headers property in the constructor.',
+        repo_url: null,
+        file_path: 'C123:456:0',
+        start_line: null,
+        end_line: null,
+        language: null,
+        similarity: 0.92,
+        metadata: { channel: 'C123', confidence: 0.85 },
+        confidence: 0.85,
+        ...overrides,
+    };
+}
+
+describe('formatFaqResults', () => {
+    it('returns "No FAQ results found." for empty array', () => {
+        expect(formatFaqResults([])).toBe('No FAQ results found.');
+    });
+
+    it('formats a single result with QUESTION/ANSWER/SOURCE/CONFIDENCE', () => {
+        const results = [makeFaqResult({})];
+        const output = formatFaqResults(results);
+        expect(output).toContain('Q&A 1');
+        expect(output).toContain('QUESTION: How to configure headers?');
+        expect(output).toContain('ANSWER: Use the headers property in the constructor.');
+        expect(output).toContain('SOURCE: https://slack.com/archives/C123/p456');
+        expect(output).toContain('CONFIDENCE: 0.85');
+    });
+
+    it('formats multiple results with numbered headers', () => {
+        const results = [
+            makeFaqResult({ id: 1, title: 'Q1', confidence: 0.9 }),
+            makeFaqResult({ id: 2, title: 'Q2', confidence: 0.8 }),
+        ];
+        const output = formatFaqResults(results);
+        expect(output).toContain('Q&A 1');
+        expect(output).toContain('Q&A 2');
+    });
+
+    it('uses file_path as SOURCE fallback when source_url is null', () => {
+        const results = [makeFaqResult({ source_url: null, file_path: 'C123:456:0' })];
+        const output = formatFaqResults(results);
+        expect(output).toContain('SOURCE: C123:456:0');
+    });
+
+    it('uses (untitled) when title is null', () => {
+        const results = [makeFaqResult({ title: null })];
+        const output = formatFaqResults(results);
+        expect(output).toContain('QUESTION: (untitled)');
+    });
+
+    it('extracts answer from Q/A format content', () => {
+        const results = [makeFaqResult({
+            content: 'Q: What is X?\n\nA: X is a thing that does Y and Z.',
+        })];
+        const output = formatFaqResults(results);
+        expect(output).toContain('ANSWER: X is a thing that does Y and Z.');
+    });
+
+    it('falls back to full content when Q/A format not found', () => {
+        const results = [makeFaqResult({
+            content: 'Just some plain text answer.',
+        })];
+        const output = formatFaqResults(results);
+        expect(output).toContain('ANSWER: Just some plain text answer.');
+    });
+});
+
+// Test the tool registration with mocked dependencies
+describe('registerKnowledgeTool', () => {
+    const mockQuery = vi.fn();
+    const mockEmbed = vi.fn();
+
+    beforeEach(() => {
+        vi.resetModules();
+        mockQuery.mockReset();
+        mockEmbed.mockReset();
+    });
+
+    it('registers a tool with the correct name and description', async () => {
+        // Mock DB
+        vi.doMock('../../db/queries.js', () => ({
+            getFaqChunks: mockQuery,
+            searchChunks: vi.fn(),
+        }));
+
+        const { registerKnowledgeTool } = await import('../mcp/tools/knowledge.js');
+
+        const toolArgs: Array<[string, string, unknown, unknown]> = [];
+        const mockServer = {
+            tool: (...args: unknown[]) => { toolArgs.push(args as [string, string, unknown, unknown]); },
+        };
+
+        const toolConfig = {
+            name: 'get-faq',
+            type: 'knowledge' as const,
+            description: 'Get FAQ content',
+            sources: ['slack-support'],
+            min_confidence: 0.7,
+            default_limit: 20,
+            max_limit: 100,
+        };
+
+        const embeddingClient = { embed: mockEmbed };
+
+        registerKnowledgeTool(mockServer as never, embeddingClient as never, toolConfig);
+
+        expect(toolArgs).toHaveLength(1);
+        expect(toolArgs[0][0]).toBe('get-faq');
+        expect(toolArgs[0][1]).toBe('Get FAQ content');
+    });
+});

--- a/src/__tests__/orchestrator-source-reindex.test.ts
+++ b/src/__tests__/orchestrator-source-reindex.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock all external dependencies before importing orchestrator
+vi.mock('../config.js', () => ({
+    getConfig: vi.fn().mockReturnValue({
+        databaseUrl: 'postgresql://test',
+        openaiApiKey: 'test-key',
+        githubToken: '',
+        githubWebhookSecret: '',
+        port: 3001,
+        nodeEnv: 'test',
+        logLevel: 'info',
+        cloneDir: '/tmp/test',
+        slackBotToken: 'xoxb-test',
+        slackSigningSecret: 'test-secret',
+    }),
+    getServerConfig: vi.fn().mockReturnValue({
+        server: { name: 'test', version: '1.0' },
+        sources: [
+            { name: 'slack-support', type: 'slack', channels: ['C001'], confidence_threshold: 0.7, trigger_emoji: 'pathfinder', min_thread_replies: 2, chunk: {} },
+            { name: 'docs', type: 'markdown', path: '/tmp/docs', file_patterns: ['**/*.md'], chunk: {} },
+        ],
+        tools: [{ name: 'search', type: 'search', description: 'Search', source: 'slack-support', default_limit: 5, max_limit: 20, result_format: 'docs' }],
+        embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+        indexing: { auto_reindex: false, reindex_hour_utc: 3, stale_threshold_hours: 24 },
+    }),
+    getIndexableSourceNames: vi.fn().mockReturnValue(new Set(['slack-support', 'docs'])),
+}));
+
+vi.mock('../db/queries.js', () => ({
+    getIndexState: vi.fn().mockResolvedValue(null),
+    upsertIndexState: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('../indexing/embeddings.js', () => {
+    return {
+        EmbeddingClient: class MockEmbeddingClient {
+            embed = vi.fn().mockResolvedValue([0.1, 0.2]);
+            embedBatch = vi.fn().mockResolvedValue([[0.1, 0.2]]);
+        },
+    };
+});
+
+vi.mock('../indexing/pipeline.js', () => {
+    return {
+        IndexingPipeline: class MockIndexingPipeline {
+            indexItems = vi.fn().mockResolvedValue(undefined);
+            removeItems = vi.fn().mockResolvedValue(undefined);
+        },
+    };
+});
+
+vi.mock('../indexing/providers/index.js', () => ({
+    getProvider: vi.fn().mockReturnValue(() => ({
+        fullAcquire: vi.fn().mockResolvedValue({ items: [], removedIds: [], stateToken: 'test-token' }),
+        incrementalAcquire: vi.fn().mockResolvedValue({ items: [], removedIds: [], stateToken: 'test-token' }),
+        getCurrentStateToken: vi.fn().mockResolvedValue('test-token'),
+    })),
+}));
+
+import { IndexingOrchestrator } from '../indexing/orchestrator.js';
+
+describe('IndexingOrchestrator.queueSourceReindex', () => {
+    let orchestrator: IndexingOrchestrator;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        orchestrator = new IndexingOrchestrator();
+    });
+
+    it('queues and executes a source-reindex job', async () => {
+        const completeSpy = vi.fn();
+        orchestrator.onReindexComplete = completeSpy;
+
+        orchestrator.queueSourceReindex('slack-support');
+
+        // Wait for drain to complete
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        expect(completeSpy).toHaveBeenCalledWith(['slack-support']);
+    });
+
+    it('skips unknown source names gracefully', async () => {
+        const completeSpy = vi.fn();
+        orchestrator.onReindexComplete = completeSpy;
+
+        orchestrator.queueSourceReindex('nonexistent');
+
+        await new Promise(resolve => setTimeout(resolve, 100));
+
+        // Should not call onReindexComplete for unknown sources
+        // (the job executes but returns early)
+        expect(completeSpy).not.toHaveBeenCalled();
+    });
+});

--- a/src/__tests__/qa-chunker.test.ts
+++ b/src/__tests__/qa-chunker.test.ts
@@ -1,9 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { chunkSlack } from '../indexing/chunking/slack.js';
+import { chunkQa } from '../indexing/chunking/qa.js';
 import { getChunker } from '../indexing/chunking/index.js';
 import type { SourceConfig } from '../types.js';
 
-// Minimal config for the chunker — Slack chunker doesn't use most fields
+// Minimal config for the chunker — Q&A chunker doesn't use most fields
 const slackConfig = {
     name: 'slack-test',
     type: 'slack' as const,
@@ -12,12 +12,13 @@ const slackConfig = {
     confidence_threshold: 0.7,
     trigger_emoji: 'pathfinder',
     min_thread_replies: 2,
+    category: 'faq',
 } satisfies SourceConfig;
 
-describe('chunkSlack', () => {
+describe('chunkQa', () => {
     it('returns a single chunk for a Q&A pair', () => {
         const content = 'Q: How do I install CopilotKit?\n\nA: Run npm install @copilotkit/react-core and wrap your app with the CopilotKit provider.';
-        const chunks = chunkSlack(content, 'C001:1234.5678:0', slackConfig);
+        const chunks = chunkQa(content, 'C001:1234.5678:0', slackConfig);
 
         expect(chunks).toHaveLength(1);
         expect(chunks[0].content).toBe(content);
@@ -26,28 +27,33 @@ describe('chunkSlack', () => {
 
     it('extracts question as title', () => {
         const content = 'Q: How do I configure SSR?\n\nA: Use the runtime provider with your API key.';
-        const chunks = chunkSlack(content, 'C001:1234.5678:0', slackConfig);
+        const chunks = chunkQa(content, 'C001:1234.5678:0', slackConfig);
 
         expect(chunks[0].title).toBe('How do I configure SSR?');
     });
 
     it('returns empty array for empty content', () => {
-        expect(chunkSlack('', 'C001:1234:0', slackConfig)).toEqual([]);
-        expect(chunkSlack('   ', 'C001:1234:0', slackConfig)).toEqual([]);
+        expect(chunkQa('', 'C001:1234:0', slackConfig)).toEqual([]);
+        expect(chunkQa('   ', 'C001:1234:0', slackConfig)).toEqual([]);
     });
 
     it('handles content without Q: prefix gracefully', () => {
         const content = 'Some content without the expected format';
-        const chunks = chunkSlack(content, 'C001:1234:0', slackConfig);
+        const chunks = chunkQa(content, 'C001:1234:0', slackConfig);
 
         expect(chunks).toHaveLength(1);
         expect(chunks[0].title).toBeUndefined();
     });
 });
 
-describe('slack chunker registration', () => {
-    it('is registered in the chunker registry', () => {
+describe('Q&A chunker registration', () => {
+    it('is registered for slack type', () => {
         const chunker = getChunker('slack');
-        expect(chunker).toBe(chunkSlack);
+        expect(chunker).toBe(chunkQa);
+    });
+
+    it('is registered for discord type', () => {
+        const chunker = getChunker('discord');
+        expect(chunker).toBe(chunkQa);
     });
 });

--- a/src/__tests__/slack-api.test.ts
+++ b/src/__tests__/slack-api.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SlackApiClient } from '../indexing/providers/slack-api.js';
+
+// Mock the @slack/web-api module
+vi.mock('@slack/web-api', () => {
+    const mockConversations = {
+        history: vi.fn(),
+        replies: vi.fn(),
+    };
+    const mockUsers = {
+        info: vi.fn(),
+    };
+    const mockChat = {
+        getPermalink: vi.fn(),
+    };
+    const mockTeam = {
+        info: vi.fn(),
+    };
+
+    class MockWebClient {
+        conversations = mockConversations;
+        users = mockUsers;
+        chat = mockChat;
+        team = mockTeam;
+        constructor(_token: string, _options?: any) {}
+    }
+
+    return {
+        WebClient: MockWebClient,
+    };
+});
+
+describe('SlackApiClient', () => {
+    let client: SlackApiClient;
+    let mockWebClient: any;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        client = new SlackApiClient({ token: 'xoxb-test-token' });
+        mockWebClient = client.webClient;
+    });
+
+    describe('fetchChannelHistory', () => {
+        it('fetches messages from a channel', async () => {
+            mockWebClient.conversations.history.mockResolvedValueOnce({
+                ok: true,
+                messages: [
+                    { ts: '1234.5678', user: 'U001', text: 'Hello' },
+                    { ts: '1234.5679', user: 'U002', text: 'World', thread_ts: '1234.5678', reply_count: 3 },
+                ],
+                response_metadata: {},
+            });
+
+            const messages = await client.fetchChannelHistory('C001');
+            expect(messages).toHaveLength(2);
+            expect(messages[0].text).toBe('Hello');
+            expect(mockWebClient.conversations.history).toHaveBeenCalledWith({
+                channel: 'C001',
+                oldest: undefined,
+                cursor: undefined,
+                limit: 200,
+            });
+        });
+
+        it('paginates through multiple pages', async () => {
+            mockWebClient.conversations.history
+                .mockResolvedValueOnce({
+                    ok: true,
+                    messages: [{ ts: '1', user: 'U001', text: 'Page 1' }],
+                    response_metadata: { next_cursor: 'cursor1' },
+                })
+                .mockResolvedValueOnce({
+                    ok: true,
+                    messages: [{ ts: '2', user: 'U002', text: 'Page 2' }],
+                    response_metadata: {},
+                });
+
+            const messages = await client.fetchChannelHistory('C001');
+            expect(messages).toHaveLength(2);
+            expect(mockWebClient.conversations.history).toHaveBeenCalledTimes(2);
+        });
+
+        it('passes oldest parameter for incremental fetch', async () => {
+            mockWebClient.conversations.history.mockResolvedValueOnce({
+                ok: true,
+                messages: [],
+                response_metadata: {},
+            });
+
+            await client.fetchChannelHistory('C001', '1234.0000');
+            expect(mockWebClient.conversations.history).toHaveBeenCalledWith(
+                expect.objectContaining({ oldest: '1234.0000' }),
+            );
+        });
+    });
+
+    describe('fetchThreadReplies', () => {
+        it('fetches replies for a thread', async () => {
+            mockWebClient.conversations.replies.mockResolvedValueOnce({
+                ok: true,
+                messages: [
+                    { ts: '1234.5678', user: 'U001', text: 'Original' },
+                    { ts: '1234.5679', user: 'U002', text: 'Reply 1' },
+                    { ts: '1234.5680', user: 'U001', text: 'Reply 2' },
+                ],
+                response_metadata: {},
+            });
+
+            const messages = await client.fetchThreadReplies('C001', '1234.5678');
+            expect(messages).toHaveLength(3);
+        });
+    });
+
+    describe('fetchUserInfo', () => {
+        it('fetches user display name', async () => {
+            mockWebClient.users.info.mockResolvedValueOnce({
+                ok: true,
+                user: {
+                    id: 'U001',
+                    team_id: 'T001',
+                    profile: { display_name: 'Alice', real_name: 'Alice Smith' },
+                },
+            });
+            mockWebClient.team.info.mockResolvedValueOnce({
+                ok: true,
+                team: { name: 'Acme Corp' },
+            });
+
+            const user = await client.fetchUserInfo('U001');
+            expect(user.displayName).toBe('Alice (Acme Corp)');
+            expect(user.id).toBe('U001');
+        });
+
+        it('caches user info on subsequent calls', async () => {
+            mockWebClient.users.info.mockResolvedValueOnce({
+                ok: true,
+                user: {
+                    id: 'U001',
+                    profile: { display_name: 'Bob' },
+                },
+            });
+            mockWebClient.team.info.mockResolvedValueOnce({
+                ok: true,
+                team: { name: 'Team' },
+            });
+
+            await client.fetchUserInfo('U001');
+            await client.fetchUserInfo('U001');
+            expect(mockWebClient.users.info).toHaveBeenCalledTimes(1);
+        });
+
+        it('falls back to real_name when display_name is empty', async () => {
+            mockWebClient.users.info.mockResolvedValueOnce({
+                ok: true,
+                user: {
+                    id: 'U001',
+                    profile: { display_name: '', real_name: 'Charlie' },
+                },
+            });
+
+            const user = await client.fetchUserInfo('U001');
+            expect(user.displayName).toContain('Charlie');
+        });
+
+        it('falls back to user ID when no name available', async () => {
+            mockWebClient.users.info.mockResolvedValueOnce({
+                ok: true,
+                user: {
+                    id: 'U001',
+                    profile: { display_name: '', real_name: '' },
+                },
+            });
+
+            const user = await client.fetchUserInfo('U001');
+            expect(user.displayName).toContain('U001');
+        });
+    });
+
+    describe('getChannelPermalink', () => {
+        it('returns permalink URL', async () => {
+            mockWebClient.chat.getPermalink.mockResolvedValueOnce({
+                ok: true,
+                permalink: 'https://workspace.slack.com/archives/C001/p1234567890',
+            });
+
+            const url = await client.getChannelPermalink('C001', '1234.5678');
+            expect(url).toBe('https://workspace.slack.com/archives/C001/p1234567890');
+        });
+    });
+
+    describe('rate limit handling', () => {
+        it('retries on rate limit with backoff', async () => {
+            const rateLimitError = new Error('Rate limited');
+            (rateLimitError as any).code = 'slack_webapi_rate_limited_error';
+            (rateLimitError as any).data = { retryAfter: 0.01 }; // 10ms for test speed
+
+            mockWebClient.conversations.history
+                .mockRejectedValueOnce(rateLimitError)
+                .mockResolvedValueOnce({
+                    ok: true,
+                    messages: [{ ts: '1', text: 'Success' }],
+                    response_metadata: {},
+                });
+
+            const messages = await client.fetchChannelHistory('C001');
+            expect(messages).toHaveLength(1);
+            expect(mockWebClient.conversations.history).toHaveBeenCalledTimes(2);
+        });
+
+        it('throws after max retries exceeded', async () => {
+            const rateLimitError = new Error('Rate limited');
+            (rateLimitError as any).code = 'slack_webapi_rate_limited_error';
+            (rateLimitError as any).data = { retryAfter: 0.001 };
+
+            // Create client with maxRetries=2
+            const limitedClient = new SlackApiClient({ token: 'xoxb-test', maxRetries: 2 });
+            const mock = limitedClient.webClient as any;
+            mock.conversations = { history: vi.fn().mockRejectedValue(rateLimitError) };
+
+            await expect(limitedClient.fetchChannelHistory('C001')).rejects.toThrow();
+        });
+    });
+});

--- a/src/__tests__/slack-chunker.test.ts
+++ b/src/__tests__/slack-chunker.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect } from 'vitest';
+import { chunkSlack } from '../indexing/chunking/slack.js';
+import { getChunker } from '../indexing/chunking/index.js';
+import type { SourceConfig } from '../types.js';
+
+// Minimal config for the chunker — Slack chunker doesn't use most fields
+const slackConfig = {
+    name: 'slack-test',
+    type: 'slack' as const,
+    channels: ['C001'],
+    chunk: { target_tokens: 600, overlap_tokens: 0 },
+    confidence_threshold: 0.7,
+    trigger_emoji: 'pathfinder',
+    min_thread_replies: 2,
+} satisfies SourceConfig;
+
+describe('chunkSlack', () => {
+    it('returns a single chunk for a Q&A pair', () => {
+        const content = 'Q: How do I install CopilotKit?\n\nA: Run npm install @copilotkit/react-core and wrap your app with the CopilotKit provider.';
+        const chunks = chunkSlack(content, 'C001:1234.5678:0', slackConfig);
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].content).toBe(content);
+        expect(chunks[0].chunkIndex).toBe(0);
+    });
+
+    it('extracts question as title', () => {
+        const content = 'Q: How do I configure SSR?\n\nA: Use the runtime provider with your API key.';
+        const chunks = chunkSlack(content, 'C001:1234.5678:0', slackConfig);
+
+        expect(chunks[0].title).toBe('How do I configure SSR?');
+    });
+
+    it('returns empty array for empty content', () => {
+        expect(chunkSlack('', 'C001:1234:0', slackConfig)).toEqual([]);
+        expect(chunkSlack('   ', 'C001:1234:0', slackConfig)).toEqual([]);
+    });
+
+    it('handles content without Q: prefix gracefully', () => {
+        const content = 'Some content without the expected format';
+        const chunks = chunkSlack(content, 'C001:1234:0', slackConfig);
+
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].title).toBeUndefined();
+    });
+});
+
+describe('slack chunker registration', () => {
+    it('is registered in the chunker registry', () => {
+        const chunker = getChunker('slack');
+        expect(chunker).toBe(chunkSlack);
+    });
+});

--- a/src/__tests__/slack-config.test.ts
+++ b/src/__tests__/slack-config.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import { SourceConfigSchema, FileSourceConfigSchema, SlackSourceConfigSchema } from '../types.js';
+
+describe('SourceConfig discriminated union', () => {
+    it('accepts file-based source configs (backward compatible)', () => {
+        const config = {
+            name: 'test-docs',
+            type: 'markdown',
+            path: 'docs/',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 600, overlap_tokens: 50 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts html source type', () => {
+        const config = {
+            name: 'test-html',
+            type: 'html',
+            path: 'docs/',
+            file_patterns: ['**/*.html'],
+            chunk: { target_tokens: 600, overlap_tokens: 50 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts code source type', () => {
+        const config = {
+            name: 'test-code',
+            type: 'code',
+            path: 'src/',
+            file_patterns: ['**/*.ts'],
+            chunk: { target_lines: 100, overlap_lines: 10 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+
+    it('accepts slack source config with channels', () => {
+        const config = {
+            name: 'slack-support',
+            type: 'slack',
+            channels: ['C01234ABCDE', 'C05678FGHIJ'],
+            chunk: { target_tokens: 600, overlap_tokens: 0 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            const data = result.data;
+            expect(data.type).toBe('slack');
+            if (data.type === 'slack') {
+                expect(data.channels).toEqual(['C01234ABCDE', 'C05678FGHIJ']);
+                expect(data.confidence_threshold).toBe(0.7); // default
+                expect(data.trigger_emoji).toBe('pathfinder'); // default
+                expect(data.min_thread_replies).toBe(2); // default
+            }
+        }
+    });
+
+    it('accepts slack source config with all optional fields', () => {
+        const config = {
+            name: 'slack-full',
+            type: 'slack',
+            channels: ['C01234ABCDE'],
+            confidence_threshold: 0.5,
+            trigger_emoji: 'docs',
+            min_thread_replies: 3,
+            distiller_model: 'gpt-4o',
+            chunk: { target_tokens: 800 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success && result.data.type === 'slack') {
+            expect(result.data.confidence_threshold).toBe(0.5);
+            expect(result.data.trigger_emoji).toBe('docs');
+            expect(result.data.min_thread_replies).toBe(3);
+            expect(result.data.distiller_model).toBe('gpt-4o');
+        }
+    });
+
+    it('rejects slack source without channels', () => {
+        const config = {
+            name: 'slack-bad',
+            type: 'slack',
+            chunk: { target_tokens: 600 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects slack source with empty channels array', () => {
+        const config = {
+            name: 'slack-empty',
+            type: 'slack',
+            channels: [],
+            chunk: { target_tokens: 600 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects slack source with confidence_threshold out of range', () => {
+        const config = {
+            name: 'slack-bad-threshold',
+            type: 'slack',
+            channels: ['C01234ABCDE'],
+            confidence_threshold: 1.5,
+            chunk: { target_tokens: 600 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects file source without path', () => {
+        const config = {
+            name: 'bad-file',
+            type: 'markdown',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 600 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects file source without file_patterns', () => {
+        const config = {
+            name: 'bad-file2',
+            type: 'markdown',
+            path: 'docs/',
+            chunk: { target_tokens: 600 },
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('slack source does not require path or file_patterns', () => {
+        const config = {
+            name: 'slack-minimal',
+            type: 'slack',
+            channels: ['C01234ABCDE'],
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+    });
+
+    it('type narrowing works: file source has path', () => {
+        const config = {
+            name: 'test-docs',
+            type: 'markdown' as const,
+            path: 'docs/',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 600, overlap_tokens: 50 },
+        };
+        const result = SourceConfigSchema.parse(config);
+        if (result.type !== 'slack') {
+            // TypeScript should know this is FileSourceConfig
+            expect(result.path).toBe('docs/');
+            expect(result.file_patterns).toEqual(['**/*.md']);
+        }
+    });
+});

--- a/src/__tests__/slack-config.test.ts
+++ b/src/__tests__/slack-config.test.ts
@@ -155,7 +155,7 @@ describe('SourceConfig discriminated union', () => {
             chunk: { target_tokens: 600, overlap_tokens: 50 },
         };
         const result = SourceConfigSchema.parse(config);
-        if (result.type !== 'slack') {
+        if (result.type !== 'slack' && result.type !== 'discord') {
             // TypeScript should know this is FileSourceConfig
             expect(result.path).toBe('docs/');
             expect(result.file_patterns).toEqual(['**/*.md']);

--- a/src/__tests__/slack-provider.test.ts
+++ b/src/__tests__/slack-provider.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { SlackDataProvider } from '../indexing/providers/slack.js';
+import type { SlackSourceConfig } from '../types.js';
+
+// Mock dependencies
+vi.mock('../indexing/providers/slack-api.js', () => {
+    const MockSlackApiClient = vi.fn(function (this: Record<string, unknown>) {
+        this.fetchChannelHistory = vi.fn();
+        this.fetchThreadReplies = vi.fn();
+        this.fetchUserInfo = vi.fn();
+        this.getChannelPermalink = vi.fn();
+    });
+    return { SlackApiClient: MockSlackApiClient };
+});
+
+vi.mock('../indexing/distiller.js', () => ({
+    distillThread: vi.fn(),
+}));
+
+vi.mock('../config.js', () => ({
+    getConfig: vi.fn().mockReturnValue({
+        openaiApiKey: 'test-key',
+        slackBotToken: 'xoxb-test',
+        slackSigningSecret: 'test-secret',
+        databaseUrl: 'postgresql://test',
+        githubToken: '',
+        githubWebhookSecret: '',
+        port: 3001,
+        nodeEnv: 'test',
+        logLevel: 'info',
+        cloneDir: '/tmp/test',
+    }),
+}));
+
+import { SlackApiClient } from '../indexing/providers/slack-api.js';
+import { distillThread } from '../indexing/distiller.js';
+
+const slackConfig: SlackSourceConfig = {
+    name: 'slack-test',
+    type: 'slack',
+    channels: ['C001'],
+    confidence_threshold: 0.7,
+    trigger_emoji: 'pathfinder',
+    min_thread_replies: 2,
+    chunk: { target_tokens: 600, overlap_tokens: 0 },
+};
+
+describe('SlackDataProvider', () => {
+    let provider: SlackDataProvider;
+    let mockApiClient: Record<string, ReturnType<typeof vi.fn>>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        provider = new SlackDataProvider(slackConfig, {
+            cloneDir: '/tmp/test',
+            slackBotToken: 'xoxb-test',
+        });
+        // Get the mock instance created by the constructor
+        mockApiClient = (SlackApiClient as ReturnType<typeof vi.fn>).mock.results[0].value;
+    });
+
+    describe('fullAcquire', () => {
+        it('fetches threads and distills Q&A pairs', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([
+                { ts: '1000.0001', thread_ts: '1000.0001', reply_count: 3, user: 'U001', text: 'Question?' },
+            ]);
+            mockApiClient.fetchThreadReplies.mockResolvedValue([
+                { ts: '1000.0001', user: 'U001', text: 'Question?' },
+                { ts: '1000.0002', user: 'U002', text: 'Answer here.' },
+                { ts: '1000.0003', user: 'U001', text: 'Thanks!' },
+            ]);
+            mockApiClient.fetchUserInfo
+                .mockResolvedValueOnce({ id: 'U001', displayName: 'Alice' })
+                .mockResolvedValueOnce({ id: 'U002', displayName: 'Bob' })
+                .mockResolvedValueOnce({ id: 'U001', displayName: 'Alice' });
+            mockApiClient.getChannelPermalink.mockResolvedValue('https://slack.com/archives/C001/p1000');
+            (distillThread as ReturnType<typeof vi.fn>).mockResolvedValue({
+                pairs: [{ question: 'What is X?', answer: 'X is Y.', confidence: 0.9 }],
+            });
+
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toHaveLength(1);
+            expect(result.items[0].id).toBe('C001:1000.0001:0');
+            expect(result.items[0].content).toContain('Q: What is X?');
+            expect(result.items[0].content).toContain('A: X is Y.');
+            expect(result.items[0].title).toBe('What is X?');
+            expect(result.items[0].sourceUrl).toBe('https://slack.com/archives/C001/p1000');
+            expect(result.items[0].metadata?.confidence).toBe(0.9);
+            expect(result.stateToken).toBe('1000.0001');
+            expect(result.removedIds).toEqual([]);
+        });
+
+        it('filters threads below min_thread_replies', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([
+                { ts: '1000.0001', thread_ts: '1000.0001', reply_count: 1, user: 'U001', text: 'Only one reply' },
+            ]);
+
+            const result = await provider.fullAcquire();
+            expect(result.items).toEqual([]);
+            expect(mockApiClient.fetchThreadReplies).not.toHaveBeenCalled();
+        });
+
+        it('filters Q&A pairs below confidence threshold', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([
+                { ts: '1000.0001', thread_ts: '1000.0001', reply_count: 3, user: 'U001' },
+            ]);
+            mockApiClient.fetchThreadReplies.mockResolvedValue([
+                { ts: '1000.0001', user: 'U001', text: 'Q' },
+                { ts: '1000.0002', user: 'U002', text: 'A' },
+            ]);
+            mockApiClient.fetchUserInfo.mockResolvedValue({ id: 'U001', displayName: 'User' });
+            (distillThread as ReturnType<typeof vi.fn>).mockResolvedValue({
+                pairs: [
+                    { question: 'High conf', answer: 'Answer', confidence: 0.9 },
+                    { question: 'Low conf', answer: 'Answer', confidence: 0.3 },
+                ],
+            });
+            mockApiClient.getChannelPermalink.mockResolvedValue('https://slack.com/link');
+
+            const result = await provider.fullAcquire();
+            expect(result.items).toHaveLength(1);
+            expect(result.items[0].title).toBe('High conf');
+        });
+
+        it('handles empty channel gracefully', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([]);
+            const result = await provider.fullAcquire();
+            expect(result.items).toEqual([]);
+            expect(result.stateToken).toBe('0');
+        });
+
+        it('continues processing other channels on error', async () => {
+            const multiChannelConfig: SlackSourceConfig = {
+                ...slackConfig,
+                channels: ['C001', 'C002'],
+            };
+            const multiProvider = new SlackDataProvider(multiChannelConfig, {
+                cloneDir: '/tmp/test',
+                slackBotToken: 'xoxb-test',
+            });
+            const multiMock = (SlackApiClient as ReturnType<typeof vi.fn>).mock.results[
+                (SlackApiClient as ReturnType<typeof vi.fn>).mock.results.length - 1
+            ].value;
+
+            multiMock.fetchChannelHistory
+                .mockRejectedValueOnce(new Error('channel_not_found'))
+                .mockResolvedValueOnce([
+                    { ts: '2000.0001', thread_ts: '2000.0001', reply_count: 3, user: 'U001' },
+                ]);
+            multiMock.fetchThreadReplies.mockResolvedValue([
+                { ts: '2000.0001', user: 'U001', text: 'Q' },
+                { ts: '2000.0002', user: 'U002', text: 'A' },
+            ]);
+            multiMock.fetchUserInfo.mockResolvedValue({ id: 'U001', displayName: 'User' });
+            multiMock.getChannelPermalink.mockResolvedValue('https://slack.com/link');
+            (distillThread as ReturnType<typeof vi.fn>).mockResolvedValue({
+                pairs: [{ question: 'Q', answer: 'A', confidence: 0.9 }],
+            });
+
+            const result = await multiProvider.fullAcquire();
+            expect(result.items).toHaveLength(1);
+        });
+    });
+
+    describe('incrementalAcquire', () => {
+        it('passes oldest parameter for incremental fetch', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([]);
+
+            await provider.incrementalAcquire('1500.0000');
+            expect(mockApiClient.fetchChannelHistory).toHaveBeenCalledWith('C001', '1500.0000');
+        });
+
+        it('returns stateToken >= lastStateToken', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([]);
+
+            const result = await provider.incrementalAcquire('1500.0000');
+            expect(result.stateToken).toBe('1500.0000');
+        });
+    });
+
+    describe('getCurrentStateToken', () => {
+        it('returns max timestamp from channels', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([
+                { ts: '2000.0001' },
+            ]);
+
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBe('2000.0001');
+        });
+
+        it('returns null when no messages found', async () => {
+            mockApiClient.fetchChannelHistory.mockResolvedValue([]);
+
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBeNull();
+        });
+    });
+
+    describe('constructor', () => {
+        it('throws for non-slack config', () => {
+            expect(() => new SlackDataProvider(
+                { name: 'test', type: 'markdown', path: 'docs/', file_patterns: ['**/*.md'], chunk: {} } as unknown as SlackSourceConfig,
+                { cloneDir: '/tmp/test' },
+            )).toThrow('SlackDataProvider requires a slack source config');
+        });
+    });
+});

--- a/src/__tests__/slack-provider.test.ts
+++ b/src/__tests__/slack-provider.test.ts
@@ -43,6 +43,7 @@ const slackConfig: SlackSourceConfig = {
     trigger_emoji: 'pathfinder',
     min_thread_replies: 2,
     chunk: { target_tokens: 600, overlap_tokens: 0 },
+    category: 'faq',
 };
 
 describe('SlackDataProvider', () => {
@@ -101,7 +102,7 @@ describe('SlackDataProvider', () => {
             expect(mockApiClient.fetchThreadReplies).not.toHaveBeenCalled();
         });
 
-        it('filters Q&A pairs below confidence threshold', async () => {
+        it('stores all Q&A pairs regardless of confidence (filtering at query time)', async () => {
             mockApiClient.fetchChannelHistory.mockResolvedValue([
                 { ts: '1000.0001', thread_ts: '1000.0001', reply_count: 3, user: 'U001' },
             ]);
@@ -119,8 +120,11 @@ describe('SlackDataProvider', () => {
             mockApiClient.getChannelPermalink.mockResolvedValue('https://slack.com/link');
 
             const result = await provider.fullAcquire();
-            expect(result.items).toHaveLength(1);
+            expect(result.items).toHaveLength(2);
             expect(result.items[0].title).toBe('High conf');
+            expect(result.items[0].metadata?.confidence).toBe(0.9);
+            expect(result.items[1].title).toBe('Low conf');
+            expect(result.items[1].metadata?.confidence).toBe(0.3);
         });
 
         it('handles empty channel gracefully', async () => {

--- a/src/__tests__/slack-webhook.test.ts
+++ b/src/__tests__/slack-webhook.test.ts
@@ -1,0 +1,213 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+import { verifySlackSignature, createSlackWebhookHandler, type SlackReindexOrchestrator } from '../webhooks/slack.js';
+
+// Mock config
+vi.mock('../config.js', () => ({
+    getConfig: vi.fn().mockReturnValue({
+        slackSigningSecret: 'test-signing-secret',
+        slackBotToken: 'xoxb-test',
+        openaiApiKey: 'test-key',
+        databaseUrl: 'postgresql://test',
+        githubToken: '',
+        githubWebhookSecret: '',
+        port: 3001,
+        nodeEnv: 'test',
+        logLevel: 'info',
+        cloneDir: '/tmp/test',
+    }),
+    getServerConfig: vi.fn().mockReturnValue({
+        server: { name: 'test', version: '1.0' },
+        sources: [
+            {
+                name: 'slack-support',
+                type: 'slack',
+                channels: ['C001', 'C002'],
+                confidence_threshold: 0.7,
+                trigger_emoji: 'pathfinder',
+                min_thread_replies: 2,
+                chunk: {},
+            },
+        ],
+        tools: [],
+    }),
+}));
+
+// Helper to create a valid Slack signature
+function signPayload(body: string, secret: string, timestamp: string): string {
+    const sigBasestring = `v0:${timestamp}:${body}`;
+    return 'v0=' + crypto.createHmac('sha256', secret).update(sigBasestring).digest('hex');
+}
+
+// Helper to create mock request/response
+function mockReqRes(body: object, headers: Record<string, string> = {}) {
+    const bodyStr = JSON.stringify(body);
+    const timestamp = String(Math.floor(Date.now() / 1000));
+    const signature = signPayload(bodyStr, 'test-signing-secret', timestamp);
+
+    const req = {
+        body: Buffer.from(bodyStr),
+        headers: {
+            'x-slack-request-timestamp': timestamp,
+            'x-slack-signature': signature,
+            ...headers,
+        },
+    } as any;
+
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+        headersSent: false,
+    } as any;
+
+    return { req, res };
+}
+
+describe('verifySlackSignature', () => {
+    const secret = 'test-secret';
+
+    it('verifies valid signature', () => {
+        const body = Buffer.from('{"test": true}');
+        const timestamp = String(Math.floor(Date.now() / 1000));
+        const sigBasestring = `v0:${timestamp}:${body.toString('utf-8')}`;
+        const signature = 'v0=' + crypto.createHmac('sha256', secret).update(sigBasestring).digest('hex');
+
+        expect(verifySlackSignature(body, timestamp, signature, secret)).toBe(true);
+    });
+
+    it('rejects invalid signature', () => {
+        const body = Buffer.from('{"test": true}');
+        const timestamp = String(Math.floor(Date.now() / 1000));
+        expect(verifySlackSignature(body, timestamp, 'v0=invalid', secret)).toBe(false);
+    });
+
+    it('rejects missing timestamp', () => {
+        const body = Buffer.from('{"test": true}');
+        expect(verifySlackSignature(body, undefined, 'v0=sig', secret)).toBe(false);
+    });
+
+    it('rejects missing signature', () => {
+        const body = Buffer.from('{"test": true}');
+        const timestamp = String(Math.floor(Date.now() / 1000));
+        expect(verifySlackSignature(body, timestamp, undefined, secret)).toBe(false);
+    });
+
+    it('rejects expired timestamp (>5 minutes old)', () => {
+        const body = Buffer.from('{"test": true}');
+        const oldTimestamp = String(Math.floor(Date.now() / 1000) - 400);
+        const sigBasestring = `v0:${oldTimestamp}:${body.toString('utf-8')}`;
+        const signature = 'v0=' + crypto.createHmac('sha256', secret).update(sigBasestring).digest('hex');
+
+        expect(verifySlackSignature(body, oldTimestamp, signature, secret)).toBe(false);
+    });
+});
+
+describe('createSlackWebhookHandler', () => {
+    let orchestrator: SlackReindexOrchestrator;
+    let handler: ReturnType<typeof createSlackWebhookHandler>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        orchestrator = {
+            queueSourceReindex: vi.fn(),
+        };
+        handler = createSlackWebhookHandler(orchestrator);
+    });
+
+    it('responds to URL verification challenge', async () => {
+        const { req, res } = mockReqRes({
+            type: 'url_verification',
+            challenge: 'abc123',
+        });
+        // URL verification doesn't need signature
+        req.body = Buffer.from(JSON.stringify({ type: 'url_verification', challenge: 'abc123' }));
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith({ challenge: 'abc123' });
+    });
+
+    it('triggers reindex on matching reaction_added event', async () => {
+        const { req, res } = mockReqRes({
+            type: 'event_callback',
+            event: {
+                type: 'reaction_added',
+                reaction: 'pathfinder',
+                item: { type: 'message', channel: 'C001', ts: '1234.5678' },
+            },
+        });
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(orchestrator.queueSourceReindex).toHaveBeenCalledWith('slack-support');
+    });
+
+    it('ignores reactions with non-matching emoji', async () => {
+        const { req, res } = mockReqRes({
+            type: 'event_callback',
+            event: {
+                type: 'reaction_added',
+                reaction: 'thumbsup',
+                item: { type: 'message', channel: 'C001', ts: '1234.5678' },
+            },
+        });
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(orchestrator.queueSourceReindex).not.toHaveBeenCalled();
+    });
+
+    it('ignores reactions from non-configured channels', async () => {
+        const { req, res } = mockReqRes({
+            type: 'event_callback',
+            event: {
+                type: 'reaction_added',
+                reaction: 'pathfinder',
+                item: { type: 'message', channel: 'C999', ts: '1234.5678' },
+            },
+        });
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(orchestrator.queueSourceReindex).not.toHaveBeenCalled();
+    });
+
+    it('rejects request with invalid signature', async () => {
+        const bodyStr = JSON.stringify({
+            type: 'event_callback',
+            event: { type: 'reaction_added', reaction: 'pathfinder', item: { channel: 'C001', ts: '1' } },
+        });
+
+        const req = {
+            body: Buffer.from(bodyStr),
+            headers: {
+                'x-slack-request-timestamp': String(Math.floor(Date.now() / 1000)),
+                'x-slack-signature': 'v0=invalidsig',
+            },
+        } as any;
+
+        const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(401);
+    });
+
+    it('rejects non-Buffer request body', async () => {
+        const req = { body: '{"test": true}', headers: {} } as any;
+        const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(500);
+    });
+
+    it('acknowledges unknown event types', async () => {
+        const { req, res } = mockReqRes({
+            type: 'event_callback',
+            event: { type: 'message' },
+        });
+
+        await handler(req, res);
+        expect(res.status).toHaveBeenCalledWith(200);
+        expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ ignored: true }));
+    });
+});

--- a/src/__tests__/validate.test.ts
+++ b/src/__tests__/validate.test.ts
@@ -1,0 +1,224 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { ValidationResult } from '../validate.js';
+
+// Mock fs
+vi.mock('node:fs', async () => {
+    const actual = await vi.importActual('node:fs');
+    return {
+        ...actual,
+        existsSync: vi.fn().mockReturnValue(true),
+        readFileSync: vi.fn(),
+    };
+});
+
+// Mock child_process
+vi.mock('node:child_process', () => ({
+    execSync: vi.fn(),
+}));
+
+// Mock config
+vi.mock('../config.js', () => {
+    const sources = [
+        {
+            name: 'docs',
+            type: 'markdown',
+            path: './docs',
+            file_patterns: ['**/*.md'],
+            chunk: {},
+        },
+        {
+            name: 'discord-support',
+            type: 'discord',
+            guild_id: '123456',
+            channels: [
+                { id: '111', type: 'text' },
+                { id: '222', type: 'forum' },
+            ],
+            confidence_threshold: 0.7,
+            min_thread_replies: 2,
+            chunk: {},
+            category: 'faq',
+        },
+    ];
+    const tools = [
+        { name: 'search-docs', type: 'search', source: 'docs', description: 'Search', default_limit: 10, max_limit: 50, result_format: 'docs' },
+        { name: 'get-faq', type: 'knowledge', sources: ['discord-support'], description: 'FAQ', min_confidence: 0.7, default_limit: 20, max_limit: 100 },
+    ];
+    return {
+        getConfig: vi.fn().mockReturnValue({
+            openaiApiKey: 'test-key',
+            slackBotToken: '',
+            slackSigningSecret: '',
+            discordBotToken: 'test-discord-token',
+            discordPublicKey: 'test-public-key',
+            databaseUrl: 'postgresql://test',
+            githubToken: '',
+            githubWebhookSecret: '',
+            port: 3001,
+            nodeEnv: 'test',
+            logLevel: 'info',
+            cloneDir: '/tmp/test',
+        }),
+        getServerConfig: vi.fn().mockReturnValue({
+            server: { name: 'test', version: '1.0' },
+            sources,
+            tools,
+            embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+            indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+        }),
+    };
+});
+
+// Mock Discord API client
+vi.mock('../indexing/providers/discord-api.js', () => {
+    const MockDiscordApiClient = vi.fn(function (this: Record<string, unknown>) {
+        this.rest = {
+            get: vi.fn(),
+        };
+    });
+    return { DiscordApiClient: MockDiscordApiClient };
+});
+
+// Mock Slack API client
+vi.mock('../indexing/providers/slack-api.js', () => {
+    const MockSlackApiClient = vi.fn(function (this: Record<string, unknown>) {
+        this.webClient = {
+            auth: { test: vi.fn() },
+            conversations: { info: vi.fn() },
+        };
+    });
+    return { SlackApiClient: MockSlackApiClient };
+});
+
+import { validateConfig } from '../validate.js';
+import { existsSync } from 'node:fs';
+import { getConfig, getServerConfig } from '../config.js';
+
+const defaultSources = [
+    {
+        name: 'docs',
+        type: 'markdown',
+        path: './docs',
+        file_patterns: ['**/*.md'],
+        chunk: {},
+    },
+    {
+        name: 'discord-support',
+        type: 'discord',
+        guild_id: '123456',
+        channels: [
+            { id: '111', type: 'text' },
+            { id: '222', type: 'forum' },
+        ],
+        confidence_threshold: 0.7,
+        min_thread_replies: 2,
+        chunk: {},
+        category: 'faq',
+    },
+];
+
+const defaultTools = [
+    { name: 'search-docs', type: 'search', source: 'docs', description: 'Search', default_limit: 10, max_limit: 50, result_format: 'docs' },
+    { name: 'get-faq', type: 'knowledge', sources: ['discord-support'], description: 'FAQ', min_confidence: 0.7, default_limit: 20, max_limit: 100 },
+];
+
+const defaultServerConfig = {
+    server: { name: 'test', version: '1.0' },
+    sources: defaultSources,
+    tools: defaultTools,
+    embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+    indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+};
+
+const defaultConfig = {
+    openaiApiKey: 'test-key',
+    slackBotToken: '',
+    slackSigningSecret: '',
+    discordBotToken: 'test-discord-token',
+    discordPublicKey: 'test-public-key',
+    databaseUrl: 'postgresql://test',
+    githubToken: '',
+    githubWebhookSecret: '',
+    port: 3001,
+    nodeEnv: 'test',
+    logLevel: 'info',
+    cloneDir: '/tmp/test',
+};
+
+describe('validateConfig', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+        (getConfig as ReturnType<typeof vi.fn>).mockReturnValue(defaultConfig);
+        (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue(defaultServerConfig);
+    });
+
+    it('returns valid result when config and sources are accessible', async () => {
+        const result = await validateConfig();
+
+        expect(result.configValid).toBe(true);
+        expect(result.sources).toHaveLength(2);
+        expect(result.errors).toHaveLength(0);
+    });
+
+    it('reports missing env vars', async () => {
+        const { getConfig } = await import('../config.js');
+        (getConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            openaiApiKey: '',
+            discordBotToken: '',
+            discordPublicKey: '',
+            slackBotToken: '',
+            databaseUrl: '',
+        });
+
+        const result = await validateConfig();
+
+        const discordEnv = result.envVars.find(e => e.name === 'DISCORD_BOT_TOKEN');
+        expect(discordEnv?.present).toBe(false);
+        expect(result.errors.some(e => e.includes('DISCORD_BOT_TOKEN'))).toBe(true);
+    });
+
+    it('validates tool-source cross references', async () => {
+        const result = await validateConfig();
+
+        expect(result.tools).toHaveLength(2);
+        expect(result.tools.every(t => t.valid)).toBe(true);
+    });
+
+    it('detects invalid tool-source references', async () => {
+        const { getServerConfig } = await import('../config.js');
+        (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            server: { name: 'test', version: '1.0' },
+            sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+            tools: [{ name: 'bad-tool', type: 'search', source: 'nonexistent', description: 'X', default_limit: 10, max_limit: 50, result_format: 'docs' }],
+            embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+            indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+        });
+
+        const result = await validateConfig();
+        const badTool = result.tools.find(t => t.name === 'bad-tool');
+        expect(badTool?.valid).toBe(false);
+        expect(result.errors.some(e => e.includes('nonexistent'))).toBe(true);
+    });
+
+    it('handles config load failure gracefully', async () => {
+        const { getServerConfig } = await import('../config.js');
+        (getServerConfig as ReturnType<typeof vi.fn>).mockImplementation(() => {
+            throw new Error('Invalid YAML at line 5');
+        });
+
+        const result = await validateConfig();
+        expect(result.configValid).toBe(false);
+        expect(result.errors).toHaveLength(1);
+        expect(result.errors[0]).toContain('Invalid YAML');
+    });
+
+    it('detects local path not existing', async () => {
+        (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+        const result = await validateConfig();
+
+        const docsSource = result.sources.find(s => s.name === 'docs');
+        expect(docsSource?.valid).toBe(false);
+    });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -62,4 +62,15 @@ program
         });
     });
 
+program
+    .command('validate')
+    .description('Validate config and probe source connectivity')
+    .option('-c, --config <path>', 'Path to pathfinder.yaml')
+    .action(async (opts) => {
+        const { validateConfig, formatValidationResult } = await import('./validate.js');
+        const result = await validateConfig(opts.config);
+        console.log(formatValidationResult(result));
+        process.exit(result.errors.length > 0 ? 1 : 0);
+    });
+
 program.parse();

--- a/src/config.ts
+++ b/src/config.ts
@@ -29,6 +29,13 @@ export function hasSearchTools(): boolean {
 }
 
 /**
+ * Check whether any knowledge tools are configured (requires embeddings + indexing).
+ */
+export function hasKnowledgeTools(): boolean {
+    return getServerConfig().tools.some(t => t.type === 'knowledge');
+}
+
+/**
  * Check whether any collect tools are configured (requires database).
  */
 export function hasCollectTools(): boolean {
@@ -49,8 +56,10 @@ export function hasBashSemanticSearch(): boolean {
  * Get the set of source names that need indexing (only those referenced by search tools).
  */
 export function getIndexableSourceNames(): Set<string> {
-    const searchTools = getServerConfig().tools.filter(t => t.type === 'search');
-    return new Set(searchTools.map(t => t.source));
+    const cfg = getServerConfig();
+    const searchSources = cfg.tools.filter(t => t.type === 'search').map(t => t.source);
+    const knowledgeSources = cfg.tools.filter(t => t.type === 'knowledge').flatMap(t => t.sources);
+    return new Set([...searchSources, ...knowledgeSources]);
 }
 
 let cachedConfig: Config | null = null;
@@ -58,7 +67,7 @@ let cachedConfig: Config | null = null;
 function parseConfig(): Config {
     const missing: string[] = [];
 
-    const needsRag = hasSearchTools();
+    const needsRag = hasSearchTools() || hasKnowledgeTools();
     const needsDb = needsRag || hasCollectTools() || hasBashSemanticSearch();
 
     const databaseUrl = process.env.DATABASE_URL;
@@ -204,6 +213,18 @@ function loadServerConfig(): ServerConfig {
         }
     }
 
+    // Cross-validate: every knowledge tool's sources must reference existing source names
+    const knowledgeTools = result.data.tools.filter(t => t.type === 'knowledge');
+    for (const tool of knowledgeTools) {
+        for (const src of tool.sources) {
+            if (!sourceNames.has(src)) {
+                throw new Error(
+                    `Knowledge tool "${tool.name}" references source "${src}" which is not defined in sources.`
+                );
+            }
+        }
+    }
+
     // Cross-validate: webhook repo_sources and path_triggers must reference valid source names
     if (result.data.webhook) {
         const wh = result.data.webhook;
@@ -221,6 +242,18 @@ function loadServerConfig(): ServerConfig {
                 throw new Error(
                     `Webhook path_triggers key "${triggerKey}" does not match any defined source name.`
                 );
+            }
+        }
+    }
+
+    // Warn if knowledge tools reference non-FAQ sources
+    for (const tool of result.data.tools) {
+        if (tool.type === 'knowledge') {
+            for (const srcName of tool.sources) {
+                const src = result.data.sources.find(s => s.name === srcName);
+                if (src && (!('category' in src) || src.category !== 'faq')) {
+                    console.warn(`[config] Knowledge tool "${tool.name}" references source "${srcName}" which does not have category: "faq" — queries may return empty results`);
+                }
             }
         }
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -17,6 +17,8 @@ export interface Config {
     nodeEnv: string;
     logLevel: string;
     cloneDir: string;
+    slackBotToken: string;
+    slackSigningSecret: string;
 }
 
 /**
@@ -67,6 +69,13 @@ function parseConfig(): Config {
 
     const githubWebhookSecret = process.env.GITHUB_WEBHOOK_SECRET ?? '';
 
+    // Slack credentials — required when any slack source is configured
+    const hasSlackSource = getServerConfig().sources.some(s => s.type === 'slack');
+    const slackBotToken = process.env.SLACK_BOT_TOKEN ?? '';
+    const slackSigningSecret = process.env.SLACK_SIGNING_SECRET ?? '';
+    if (hasSlackSource && !slackBotToken) missing.push('SLACK_BOT_TOKEN');
+    if (hasSlackSource && !openaiApiKey) missing.push('OPENAI_API_KEY (required for Slack distillation)');
+
     if (missing.length > 0) {
         throw new Error(
             `Missing required environment variables: ${missing.join(', ')}. ` +
@@ -88,6 +97,8 @@ function parseConfig(): Config {
         nodeEnv: process.env.NODE_ENV || 'development',
         logLevel: process.env.LOG_LEVEL || 'info',
         cloneDir: process.env.CLONE_DIR || '/tmp/mcp-repos',
+        slackBotToken,
+        slackSigningSecret,
     };
 }
 
@@ -214,8 +225,9 @@ function loadServerConfig(): ServerConfig {
         }
     }
 
-    // Validate local source paths exist
+    // Validate local source paths exist (file-based sources only)
     for (const source of result.data.sources) {
+        if (source.type === 'slack') continue;
         if (!source.repo) {
             const resolved = resolve(source.path);
             if (!existsSync(resolved)) {

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { ServerConfigSchema, type ServerConfig } from './types.js';
+import { ServerConfigSchema, type ServerConfig, isDiscordSourceConfig } from './types.js';
 
 // ── Environment variable config (secrets and runtime settings) ────────────────
 
@@ -19,6 +19,8 @@ export interface Config {
     cloneDir: string;
     slackBotToken: string;
     slackSigningSecret: string;
+    discordBotToken: string;
+    discordPublicKey: string;
 }
 
 /**
@@ -85,6 +87,15 @@ function parseConfig(): Config {
     if (hasSlackSource && !slackBotToken) missing.push('SLACK_BOT_TOKEN');
     if (hasSlackSource && !openaiApiKey) missing.push('OPENAI_API_KEY (required for Slack distillation)');
 
+    // Discord credentials — required when any discord source is configured
+    const hasDiscordSource = getServerConfig().sources.some(s => s.type === 'discord');
+    const hasDiscordTextChannels = getServerConfig().sources.some(s => isDiscordSourceConfig(s) && s.channels.some(c => c.type === 'text'));
+    const discordBotToken = process.env.DISCORD_BOT_TOKEN ?? '';
+    const discordPublicKey = process.env.DISCORD_PUBLIC_KEY ?? '';
+    if (hasDiscordSource && !discordBotToken) missing.push('DISCORD_BOT_TOKEN');
+    if (hasDiscordSource && !discordPublicKey) missing.push('DISCORD_PUBLIC_KEY');
+    if (hasDiscordTextChannels && !openaiApiKey) missing.push('OPENAI_API_KEY (required for Discord text channel distillation)');
+
     if (missing.length > 0) {
         throw new Error(
             `Missing required environment variables: ${missing.join(', ')}. ` +
@@ -108,6 +119,8 @@ function parseConfig(): Config {
         cloneDir: process.env.CLONE_DIR || '/tmp/mcp-repos',
         slackBotToken,
         slackSigningSecret,
+        discordBotToken,
+        discordPublicKey,
     };
 }
 
@@ -260,7 +273,7 @@ function loadServerConfig(): ServerConfig {
 
     // Validate local source paths exist (file-based sources only)
     for (const source of result.data.sources) {
-        if (source.type === 'slack') continue;
+        if (source.type === 'slack' || source.type === 'discord') continue;
         if (!source.repo) {
             const resolved = resolve(source.path);
             if (!existsSync(resolved)) {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -1,6 +1,6 @@
 import pgvector from "pgvector";
 import { getPool } from "./client.js";
-import type { Chunk, ChunkResult, IndexState, IndexStatus } from "../types.js";
+import type { Chunk, ChunkResult, FaqChunkResult, IndexState, IndexStatus } from "../types.js";
 
 // ---------------------------------------------------------------------------
 // Search
@@ -298,6 +298,70 @@ export async function getAllChunksForLlms(): Promise<{ source_name: string; file
         'SELECT source_name, file_path, title, content, chunk_index FROM chunks ORDER BY source_name, file_path, chunk_index'
     );
     return result.rows;
+}
+
+/**
+ * Fetch FAQ chunks filtered by source name and minimum confidence.
+ * Confidence is stored in chunk metadata JSONB; this query extracts and filters it.
+ * Results are ordered by source_name, then indexed_at DESC (most recent first).
+ */
+export async function getFaqChunks(
+    sourceNames: string[],
+    minConfidence: number,
+    limit?: number,
+): Promise<FaqChunkResult[]> {
+    const pool = getPool();
+
+    if (sourceNames.length === 0) return [];
+
+    // Build parameterized source_name IN clause
+    const placeholders = sourceNames.map((_, i) => `$${i + 1}`).join(', ');
+    const confidenceParam = sourceNames.length + 1;
+
+    let sql = `
+        SELECT
+            id,
+            source_name,
+            source_url,
+            title,
+            content,
+            repo_url,
+            file_path,
+            start_line,
+            end_line,
+            language,
+            0.0 AS similarity,
+            metadata,
+            (metadata->>'confidence')::float AS confidence
+        FROM chunks
+        WHERE source_name IN (${placeholders})
+          AND (metadata->>'confidence')::float >= $${confidenceParam}
+        ORDER BY source_name, indexed_at DESC
+    `;
+
+    const params: unknown[] = [...sourceNames, minConfidence];
+
+    if (limit != null) {
+        sql += ` LIMIT $${confidenceParam + 1}`;
+        params.push(limit);
+    }
+
+    const { rows } = await pool.query(sql, params);
+    return rows.map((r: Record<string, unknown>) => ({
+        id: r.id as number,
+        source_name: r.source_name as string,
+        source_url: (r.source_url as string) ?? null,
+        title: (r.title as string) ?? null,
+        content: r.content as string,
+        repo_url: (r.repo_url as string) ?? null,
+        file_path: r.file_path as string,
+        start_line: (r.start_line as number) ?? null,
+        end_line: (r.end_line as number) ?? null,
+        language: (r.language as string) ?? null,
+        similarity: parseFloat(r.similarity as string),
+        metadata: (r.metadata as Record<string, unknown>) ?? {},
+        confidence: parseFloat(r.confidence as string),
+    }));
 }
 
 /**

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -332,9 +332,10 @@ export async function getFaqChunks(
             language,
             0.0 AS similarity,
             metadata,
-            (metadata->>'confidence')::float AS confidence
+            COALESCE((metadata->>'confidence')::float, 0.0) AS confidence
         FROM chunks
         WHERE source_name IN (${placeholders})
+          AND metadata ? 'confidence'
           AND (metadata->>'confidence')::float >= $${confidenceParam}
         ORDER BY source_name, indexed_at DESC
     `;
@@ -360,7 +361,7 @@ export async function getFaqChunks(
         language: (r.language as string) ?? null,
         similarity: parseFloat(r.similarity as string),
         metadata: (r.metadata as Record<string, unknown>) ?? {},
-        confidence: parseFloat(r.confidence as string),
+        confidence: parseFloat(r.confidence as string) || 0.0,
     }));
 }
 

--- a/src/faq-txt.ts
+++ b/src/faq-txt.ts
@@ -1,0 +1,51 @@
+import type { FaqChunkResult } from './types.js';
+
+interface FaqSource {
+    name: string;
+    confidenceThreshold: number;
+}
+
+/**
+ * Generate the /faq.txt content from FAQ chunks.
+ * Groups Q&A pairs by source, with source headings.
+ */
+export function generateFaqTxt(
+    chunks: FaqChunkResult[],
+    serverName: string,
+    faqSources: FaqSource[],
+): string {
+    const lines: string[] = [
+        `# ${serverName} — Frequently Asked Questions`,
+        '',
+    ];
+
+    // Group chunks by source_name
+    const bySource = new Map<string, FaqChunkResult[]>();
+    for (const chunk of chunks) {
+        if (!bySource.has(chunk.source_name)) bySource.set(chunk.source_name, []);
+        bySource.get(chunk.source_name)!.push(chunk);
+    }
+
+    // Emit each source section in the order of faqSources config
+    let hasContent = false;
+    for (const source of faqSources) {
+        const sourceChunks = bySource.get(source.name);
+        if (!sourceChunks || sourceChunks.length === 0) continue;
+
+        hasContent = true;
+        lines.push(`## ${source.name}`, '');
+
+        for (const chunk of sourceChunks) {
+            // Content is stored as "Q: ...\n\nA: ..."
+            lines.push(chunk.content);
+            lines.push('');
+        }
+    }
+
+    if (!hasContent) {
+        lines.push('No FAQ content available yet.');
+        lines.push('');
+    }
+
+    return lines.join('\n');
+}

--- a/src/indexing/chunking/index.ts
+++ b/src/indexing/chunking/index.ts
@@ -27,6 +27,7 @@ registerChunker('code', chunkCode);
 registerChunker('raw-text', chunkRawText);
 registerChunker('html', chunkHtml);
 
-import { chunkSlack } from './slack.js';
+import { chunkQa } from './qa.js';
 
-registerChunker('slack', chunkSlack);
+registerChunker('slack', chunkQa);
+registerChunker('discord', chunkQa);

--- a/src/indexing/chunking/index.ts
+++ b/src/indexing/chunking/index.ts
@@ -26,3 +26,7 @@ registerChunker('markdown', chunkMarkdown);
 registerChunker('code', chunkCode);
 registerChunker('raw-text', chunkRawText);
 registerChunker('html', chunkHtml);
+
+import { chunkSlack } from './slack.js';
+
+registerChunker('slack', chunkSlack);

--- a/src/indexing/chunking/qa.ts
+++ b/src/indexing/chunking/qa.ts
@@ -1,14 +1,14 @@
-// Slack chunker — formats distilled Q&A pairs for embedding.
-// Minimal: each Q&A pair is already a self-contained chunk from the distiller.
+// Q&A chunker — formats distilled Q&A pairs for embedding.
+// Source-agnostic: used by any source that produces Q&A-formatted content.
 
 import type { ChunkOutput, SourceConfig } from '../../types.js';
 
 /**
- * Chunk Slack Q&A content. Each content item from the SlackDataProvider
- * is a single Q&A pair, already sized appropriately by the LLM distiller.
+ * Chunk Q&A content. Each content item from a FAQ-category provider
+ * is a single Q&A pair, already sized appropriately.
  * The chunker formats it and returns a single ChunkOutput.
  */
-export function chunkSlack(content: string, filePath: string, config: SourceConfig): ChunkOutput[] {
+export function chunkQa(content: string, filePath: string, config: SourceConfig): ChunkOutput[] {
     if (!content || !content.trim()) {
         return [];
     }

--- a/src/indexing/chunking/slack.ts
+++ b/src/indexing/chunking/slack.ts
@@ -1,0 +1,26 @@
+// Slack chunker — formats distilled Q&A pairs for embedding.
+// Minimal: each Q&A pair is already a self-contained chunk from the distiller.
+
+import type { ChunkOutput, SourceConfig } from '../../types.js';
+
+/**
+ * Chunk Slack Q&A content. Each content item from the SlackDataProvider
+ * is a single Q&A pair, already sized appropriately by the LLM distiller.
+ * The chunker formats it and returns a single ChunkOutput.
+ */
+export function chunkSlack(content: string, filePath: string, config: SourceConfig): ChunkOutput[] {
+    if (!content || !content.trim()) {
+        return [];
+    }
+
+    // The content is already formatted as "Q: ...\n\nA: ..." by the provider.
+    // Extract the question for use as title.
+    const questionMatch = content.match(/^Q:\s*(.+?)(?:\n|$)/);
+    const title = questionMatch ? questionMatch[1].trim() : undefined;
+
+    return [{
+        content: content.trim(),
+        title,
+        chunkIndex: 0,
+    }];
+}

--- a/src/indexing/distiller.ts
+++ b/src/indexing/distiller.ts
@@ -1,0 +1,147 @@
+// LLM thread distiller — extracts Q&A pairs from conversation threads.
+// Source-agnostic: takes structured messages, returns structured Q&A pairs.
+
+import OpenAI from 'openai';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ThreadMessage {
+    author: string;
+    content: string;
+    timestamp: string;
+    reactions?: Array<{ name: string; count: number }>;
+}
+
+export interface DistilledPair {
+    question: string;
+    answer: string;
+    confidence: number; // 0.0 - 1.0
+}
+
+export interface DistillerResult {
+    pairs: DistilledPair[];
+}
+
+export interface DistillerOptions {
+    model?: string;
+    maxMessages?: number;
+    apiKey?: string;
+}
+
+// ── Constants ────────────────────────────────────────────────────────────────
+
+const DEFAULT_MODEL = 'gpt-4o-mini';
+const DEFAULT_MAX_MESSAGES = 100;
+
+const SYSTEM_PROMPT = `You are a Q&A extraction engine. Given a conversation thread, identify distinct question-answer pairs.
+
+For each pair:
+1. Extract the core question (rephrase if needed for clarity)
+2. Extract the best answer (synthesize from multiple replies if needed)
+3. Score confidence from 0.0 to 1.0 based on:
+   - Answer completeness (does it fully address the question?)
+   - Questioner satisfaction signals ("thanks", "that worked", etc.)
+   - Community validation (reactions like thumbsup, check marks)
+   - Answer specificity (concrete steps vs vague suggestions)
+
+Return JSON with this exact structure:
+{
+  "pairs": [
+    {
+      "question": "How do I configure X?",
+      "answer": "You can configure X by...",
+      "confidence": 0.85
+    }
+  ]
+}
+
+Rules:
+- A thread may contain multiple Q&A pairs (follow-up questions)
+- Skip greetings, pleasantries, and off-topic tangents
+- If no clear Q&A exists, return {"pairs": []}
+- Keep answers concise but complete (aim for 1-3 paragraphs)
+- Preserve code blocks, URLs, and technical details from answers
+- Confidence below 0.3 means the answer is likely incomplete or wrong`;
+
+// ── Distiller ────────────────────────────────────────────────────────────────
+
+/**
+ * Distill a conversation thread into Q&A pairs using an LLM.
+ */
+export async function distillThread(
+    messages: ThreadMessage[],
+    options?: DistillerOptions,
+): Promise<DistillerResult> {
+    const model = options?.model ?? DEFAULT_MODEL;
+    const maxMessages = options?.maxMessages ?? DEFAULT_MAX_MESSAGES;
+
+    if (messages.length === 0) {
+        return { pairs: [] };
+    }
+
+    // Truncate to max messages
+    const truncated = messages.slice(0, maxMessages);
+
+    // Format as conversation transcript
+    const transcript = truncated.map(msg => {
+        const reactions = msg.reactions && msg.reactions.length > 0
+            ? ` [reactions: ${msg.reactions.map(r => `:${r.name}: x${r.count}`).join(', ')}]`
+            : '';
+        return `[${msg.timestamp}] ${msg.author}: ${msg.content}${reactions}`;
+    }).join('\n\n');
+
+    const client = new OpenAI({ apiKey: options?.apiKey });
+
+    try {
+        const response = await client.chat.completions.create({
+            model,
+            messages: [
+                { role: 'system', content: SYSTEM_PROMPT },
+                { role: 'user', content: transcript },
+            ],
+            response_format: { type: 'json_object' },
+            temperature: 0.1,
+        });
+
+        const content = response.choices[0]?.message?.content;
+        if (!content) {
+            console.warn('[distiller] Empty response from LLM');
+            return { pairs: [] };
+        }
+
+        const parsed = JSON.parse(content);
+
+        // Validate structure
+        if (!Array.isArray(parsed.pairs)) {
+            console.warn('[distiller] Invalid response structure — missing pairs array');
+            return { pairs: [] };
+        }
+
+        // Validate and filter each pair
+        const validPairs: DistilledPair[] = [];
+        for (const pair of parsed.pairs) {
+            if (
+                typeof pair.question === 'string' && pair.question.trim() &&
+                typeof pair.answer === 'string' && pair.answer.trim() &&
+                typeof pair.confidence === 'number' &&
+                pair.confidence >= 0 && pair.confidence <= 1
+            ) {
+                validPairs.push({
+                    question: pair.question.trim(),
+                    answer: pair.answer.trim(),
+                    confidence: pair.confidence,
+                });
+            } else {
+                console.warn('[distiller] Skipping malformed pair:', JSON.stringify(pair).slice(0, 200));
+            }
+        }
+
+        return { pairs: validPairs };
+    } catch (error) {
+        if (error instanceof SyntaxError) {
+            console.error('[distiller] Failed to parse LLM JSON response:', error.message);
+            return { pairs: [] };
+        }
+        throw error; // Re-throw API errors for caller to handle
+    }
+}

--- a/src/indexing/distiller.ts
+++ b/src/indexing/distiller.ts
@@ -26,6 +26,7 @@ export interface DistillerOptions {
     model?: string;
     maxMessages?: number;
     apiKey?: string;
+    client?: OpenAI;
 }
 
 // ── Constants ────────────────────────────────────────────────────────────────
@@ -90,7 +91,7 @@ export async function distillThread(
         return `[${msg.timestamp}] ${msg.author}: ${msg.content}${reactions}`;
     }).join('\n\n');
 
-    const client = new OpenAI({ apiKey: options?.apiKey });
+    const client = options?.client ?? new OpenAI({ apiKey: options?.apiKey });
 
     try {
         const response = await client.chat.completions.create({

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -9,14 +9,15 @@ import {
     getIndexState,
     upsertIndexState,
 } from '../db/queries.js';
-import type { IndexState, IndexStatus, SourceConfig } from '../types.js';
+import { isFileSourceConfig } from '../types.js';
+import type { IndexState, IndexStatus, SourceConfig, FileSourceConfig } from '../types.js';
 import type { ProviderOptions } from './providers/types.js';
 
 /**
  * Find all source configs that reference a given repo URL.
  */
 function getSourcesByRepo(repoUrl: string): SourceConfig[] {
-    return getServerConfig().sources.filter(s => s.repo === repoUrl);
+    return getServerConfig().sources.filter(s => isFileSourceConfig(s) && s.repo === repoUrl);
 }
 
 function getStaleThresholdMs(): number {
@@ -89,13 +90,13 @@ export class IndexingOrchestrator {
             }
             // Queue incremental reindexes for each affected git-backed repo
             const reposToReindex = new Set(
-                sourcesNeedingFullReindex.filter(s => s.repo).map(s => s.repo!),
+                sourcesNeedingFullReindex.filter(s => isFileSourceConfig(s) && s.repo).map(s => (s as FileSourceConfig).repo!),
             );
             for (const repoUrl of reposToReindex) {
                 this.queueIncrementalReindex(repoUrl);
             }
             // Local sources (no repo) get queued as a full reindex of just those sources
-            const localSources = sourcesNeedingFullReindex.filter(s => !s.repo);
+            const localSources = sourcesNeedingFullReindex.filter(s => isFileSourceConfig(s) && !s.repo);
             if (localSources.length > 0) {
                 this.queue.push({ type: 'full-reindex-local', sources: localSources });
                 this.drain().catch(err => console.error('[orchestrator] drain() failed:', err));
@@ -105,7 +106,7 @@ export class IndexingOrchestrator {
         if (sourcesOk.length === 0) return;
 
         // Local sources in sourcesOk have no remote to check — always reindex on startup
-        const localSourcesOk = sourcesOk.filter(s => !s.repo);
+        const localSourcesOk = sourcesOk.filter(s => isFileSourceConfig(s) && !s.repo);
         if (localSourcesOk.length > 0) {
             console.log(`[orchestrator] Queuing reindex for ${localSourcesOk.length} local source(s)`);
             this.queue.push({ type: 'full-reindex-local', sources: localSourcesOk });
@@ -115,7 +116,7 @@ export class IndexingOrchestrator {
         console.log('[orchestrator] Checking remotes for changes on indexed sources...');
 
         // Check each git-backed source for changes
-        const gitSourcesOk = sourcesOk.filter(s => s.repo);
+        const gitSourcesOk = sourcesOk.filter(s => isFileSourceConfig(s) && s.repo);
         for (const source of gitSourcesOk) {
             try {
                 const currentToken = await this.getSourceStateToken(source);
@@ -126,7 +127,7 @@ export class IndexingOrchestrator {
                         ? 'source unavailable (clone missing?)'
                         : `remote ${currentToken.slice(0, 8)} differs from indexed`;
                     console.log(`[orchestrator] ${reason} for ${source.name} — queuing reindex`);
-                    if (source.repo) {
+                    if (isFileSourceConfig(source) && source.repo) {
                         this.queueIncrementalReindex(source.repo);
                     }
                 } else {
@@ -152,6 +153,7 @@ export class IndexingOrchestrator {
         const providerOptions: ProviderOptions = {
             cloneDir: config.cloneDir,
             githubToken: config.githubToken,
+            slackBotToken: config.slackBotToken,
         };
         const provider = getProvider(source.type)(source, providerOptions);
         return provider.getCurrentStateToken();
@@ -367,7 +369,7 @@ export class IndexingOrchestrator {
     ): Promise<void> {
         const lockKey = `${sourceConfig.type}:${sourceConfig.name}`;
         await this.withSourceLock(lockKey, async () => {
-            const providerOptions: ProviderOptions = { cloneDir, githubToken };
+            const providerOptions: ProviderOptions = { cloneDir, githubToken, slackBotToken: getConfig().slackBotToken };
             const provider = getProvider(sourceConfig.type)(sourceConfig, providerOptions);
             const pipeline = new IndexingPipeline(embeddingClient, sourceConfig);
 

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -162,6 +162,7 @@ export class IndexingOrchestrator {
             cloneDir: config.cloneDir,
             githubToken: config.githubToken,
             slackBotToken: config.slackBotToken,
+            discordBotToken: config.discordBotToken,
         };
         const provider = getProvider(source.type)(source, providerOptions);
         return provider.getCurrentStateToken();
@@ -401,7 +402,7 @@ export class IndexingOrchestrator {
     ): Promise<void> {
         const lockKey = `${sourceConfig.type}:${sourceConfig.name}`;
         await this.withSourceLock(lockKey, async () => {
-            const providerOptions: ProviderOptions = { cloneDir, githubToken, slackBotToken: getConfig().slackBotToken };
+            const providerOptions: ProviderOptions = { cloneDir, githubToken, slackBotToken: getConfig().slackBotToken, discordBotToken: getConfig().discordBotToken };
             const provider = getProvider(sourceConfig.type)(sourceConfig, providerOptions);
             const pipeline = new IndexingPipeline(embeddingClient, sourceConfig);
 

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -10,7 +10,7 @@ import {
     upsertIndexState,
 } from '../db/queries.js';
 import { isFileSourceConfig } from '../types.js';
-import type { IndexState, IndexStatus, SourceConfig, FileSourceConfig } from '../types.js';
+import type { IndexState, IndexStatus, SourceConfig } from '../types.js';
 import type { ProviderOptions } from './providers/types.js';
 
 /**
@@ -90,9 +90,10 @@ export class IndexingOrchestrator {
                 return;
             }
             // Queue incremental reindexes for each affected git-backed repo
-            const reposToReindex = new Set(
-                sourcesNeedingFullReindex.filter(s => isFileSourceConfig(s) && s.repo).map(s => (s as FileSourceConfig).repo!),
-            );
+            const reposToReindex = new Set<string>();
+            for (const s of sourcesNeedingFullReindex) {
+                if (isFileSourceConfig(s) && s.repo) reposToReindex.add(s.repo);
+            }
             for (const repoUrl of reposToReindex) {
                 this.queueIncrementalReindex(repoUrl);
             }
@@ -101,6 +102,12 @@ export class IndexingOrchestrator {
             if (localSources.length > 0) {
                 this.queue.push({ type: 'full-reindex-local', sources: localSources });
                 this.drain().catch(err => console.error('[orchestrator] drain() failed:', err));
+            }
+
+            // Non-file sources (e.g., Slack) that need reindexing
+            const nonFileSources = sourcesNeedingFullReindex.filter(s => !isFileSourceConfig(s));
+            for (const source of nonFileSources) {
+                this.queueSourceReindex(source.name);
             }
         }
 

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -26,9 +26,10 @@ function getStaleThresholdMs(): number {
 }
 
 interface Job {
-    type: 'full-reindex' | 'incremental-reindex' | 'full-reindex-local';
+    type: 'full-reindex' | 'incremental-reindex' | 'full-reindex-local' | 'source-reindex';
     repoUrl?: string; // for incremental
     sources?: SourceConfig[]; // for full-reindex-local
+    sourceName?: string; // for source-reindex
 }
 
 export class IndexingOrchestrator {
@@ -184,6 +185,18 @@ export class IndexingOrchestrator {
     }
 
     /**
+     * Queue a reindex for a single named source. Returns immediately.
+     * Used by webhook handlers to trigger reindexing of specific sources.
+     */
+    queueSourceReindex(sourceName: string): void {
+        this.queue.push({ type: 'source-reindex', sourceName });
+        console.log(`[orchestrator] Source re-index queued for ${sourceName}`);
+        this.drain().catch((err) => {
+            console.error('[orchestrator] drain() failed:', err);
+        });
+    }
+
+    /**
      * Returns true if any indexing job is currently running.
      */
     isIndexing(): boolean {
@@ -303,6 +316,18 @@ export class IndexingOrchestrator {
                 job.repoUrl,
             );
             affectedSourceNames = getSourcesByRepo(job.repoUrl).map(s => s.name);
+        } else if (job.type === 'source-reindex') {
+            if (!job.sourceName) {
+                console.warn('[orchestrator] source-reindex job has no sourceName, skipping');
+                return;
+            }
+            const sourceConfig = serverCfg2.sources.find(s => s.name === job.sourceName);
+            if (!sourceConfig) {
+                console.warn(`[orchestrator] source-reindex: source "${job.sourceName}" not found in config`);
+                return;
+            }
+            await this.indexSourceWithState(sourceConfig, embeddingClient, config.cloneDir);
+            affectedSourceNames = [job.sourceName];
         }
 
         if (affectedSourceNames.length > 0 && this.onReindexComplete) {

--- a/src/indexing/pipeline.ts
+++ b/src/indexing/pipeline.ts
@@ -4,6 +4,7 @@ import { getChunker } from './chunking/index.js';
 import { deriveUrl } from './url-derivation.js';
 import { EmbeddingClient } from './embeddings.js';
 import { upsertChunks, deleteChunksByFile } from '../db/queries.js';
+import { isFileSourceConfig } from '../types.js';
 import type { Chunk, SourceConfig } from '../types.js';
 import type { ContentItem } from './providers/types.js';
 
@@ -50,7 +51,7 @@ export class IndexingPipeline {
 
         const texts = chunkOutputs.map(c => c.content);
         const embeddings = await this.embeddingClient.embedBatch(texts);
-        const sourceUrl = item.sourceUrl ?? deriveUrl(item.id, this.sourceConfig);
+        const sourceUrl = item.sourceUrl ?? (isFileSourceConfig(this.sourceConfig) ? deriveUrl(item.id, this.sourceConfig) : null);
 
         const chunks: Chunk[] = chunkOutputs.map((chunk, i) => ({
             source_name: this.sourceConfig.name,
@@ -58,7 +59,7 @@ export class IndexingPipeline {
             title: chunk.title ?? item.title ?? null,
             content: chunk.content,
             embedding: embeddings[i],
-            repo_url: this.sourceConfig.repo ?? null,
+            repo_url: isFileSourceConfig(this.sourceConfig) ? (this.sourceConfig.repo ?? null) : null,
             file_path: item.id,
             start_line: chunk.startLine ?? null,
             end_line: chunk.endLine ?? null,

--- a/src/indexing/providers/discord-api.ts
+++ b/src/indexing/providers/discord-api.ts
@@ -1,0 +1,253 @@
+// Discord REST API client wrapper — handles pagination, rate limiting, user caching.
+// Uses @discordjs/rest (REST-only, no gateway/WebSocket).
+
+import { REST } from '@discordjs/rest';
+import { Routes } from 'discord-api-types/v10';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface DiscordMessage {
+    id: string;
+    author: { id: string; username: string; global_name?: string };
+    content: string;
+    timestamp: string;
+    thread?: { id: string; message_count: number };
+    reactions?: Array<{ emoji: { name: string }; count: number }>;
+}
+
+export interface DiscordThread {
+    id: string;
+    name: string;
+    parent_id: string;
+    message_count: number;
+    owner_id: string;
+    created_timestamp: string;
+    last_message_id: string;
+    archived: boolean;
+}
+
+export interface DiscordUser {
+    id: string;
+    displayName: string;
+}
+
+export interface DiscordApiClientOptions {
+    token: string;
+    /** Max retries on rate-limited requests (default: 5) */
+    maxRetries?: number;
+}
+
+// ── Rate limit helpers ───────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ── Client ───────────────────────────────────────────────────────────────────
+
+const MAX_PAGES = 100;
+const DEFAULT_PAGE_LIMIT = 100;
+
+export class DiscordApiClient {
+    private rest: REST;
+    private maxRetries: number;
+    private userCache = new Map<string, DiscordUser>();
+    private logPrefix = '[discord-api]';
+
+    constructor(options: DiscordApiClientOptions) {
+        this.rest = new REST({ version: '10', rejectOnRateLimit: ['/'] }).setToken(options.token);
+        this.maxRetries = options.maxRetries ?? 5;
+    }
+
+    /**
+     * Fetch messages from a text channel, paginated using `after` parameter.
+     * If `after` is provided, only messages after that snowflake ID are returned.
+     */
+    async fetchChannelMessages(
+        channelId: string,
+        after?: string,
+        limit?: number,
+    ): Promise<DiscordMessage[]> {
+        const messages: DiscordMessage[] = [];
+        let lastId = after;
+        const pageLimit = limit ?? DEFAULT_PAGE_LIMIT;
+        let pages = 0;
+
+        do {
+            pages++;
+            const query = new URLSearchParams({ limit: String(pageLimit) });
+            if (lastId) query.set('after', lastId);
+
+            const result = await this.callWithRetry(() =>
+                this.rest.get(Routes.channelMessages(channelId), { query }) as Promise<DiscordMessage[]>,
+            );
+
+            if (!result || result.length === 0) break;
+
+            messages.push(...result);
+            lastId = result[result.length - 1].id;
+
+            // If we got fewer than the page limit, there are no more pages
+            if (result.length < pageLimit) break;
+
+            if (pages >= MAX_PAGES) {
+                console.warn(`${this.logPrefix} fetchChannelMessages hit max pages (${MAX_PAGES}) for channel ${channelId}`);
+                break;
+            }
+        } while (true);
+
+        return messages;
+    }
+
+    /**
+     * Fetch all threads in a forum channel (active + archived).
+     * Active threads: GET /guilds/{guildId}/threads/active, filtered by parent_id.
+     * Archived threads: paginated via before parameter.
+     */
+    async fetchForumThreads(channelId: string, guildId: string): Promise<DiscordThread[]> {
+        const threadMap = new Map<string, DiscordThread>();
+
+        // 1. Active threads (guild-level, filter by parent_id)
+        try {
+            const activeResult = await this.callWithRetry(() =>
+                this.rest.get(Routes.guildActiveThreads(guildId)) as Promise<{ threads: DiscordThread[] }>,
+            );
+            for (const thread of activeResult.threads ?? []) {
+                if (thread.parent_id === channelId) {
+                    threadMap.set(thread.id, thread);
+                }
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            console.warn(`${this.logPrefix} Failed to fetch active threads for guild ${guildId}: ${msg}`);
+        }
+
+        // 2. Public archived threads
+        await this.fetchArchivedThreads(channelId, 'public', threadMap);
+
+        // 3. Private archived threads
+        await this.fetchArchivedThreads(channelId, 'private', threadMap);
+
+        return [...threadMap.values()];
+    }
+
+    /**
+     * Fetch messages within a thread.
+     */
+    async fetchThreadMessages(threadId: string, limit?: number): Promise<DiscordMessage[]> {
+        return this.fetchChannelMessages(threadId, undefined, limit);
+    }
+
+    /**
+     * Fetch user info with caching.
+     */
+    async fetchUser(userId: string): Promise<DiscordUser> {
+        const cached = this.userCache.get(userId);
+        if (cached) return cached;
+
+        const result = await this.callWithRetry(() =>
+            this.rest.get(Routes.user(userId)) as Promise<{ id: string; username: string; global_name?: string }>,
+        );
+
+        const user: DiscordUser = {
+            id: result.id,
+            displayName: result.global_name ?? result.username,
+        };
+
+        this.userCache.set(userId, user);
+        return user;
+    }
+
+    /**
+     * Get a message URL (deterministic, no API call).
+     */
+    getMessageUrl(guildId: string, channelId: string, messageId: string): string {
+        return `https://discord.com/channels/${guildId}/${channelId}/${messageId}`;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Fetch archived threads (public or private) with pagination.
+     */
+    private async fetchArchivedThreads(
+        channelId: string,
+        type: 'public' | 'private',
+        threadMap: Map<string, DiscordThread>,
+    ): Promise<void> {
+        let before: string | undefined;
+        let pages = 0;
+
+        do {
+            pages++;
+            const query = new URLSearchParams();
+            if (before) query.set('before', before);
+
+            try {
+                const result = await this.callWithRetry(() =>
+                    this.rest.get(
+                        `/channels/${channelId}/threads/archived/${type}`,
+                        { query },
+                    ) as Promise<{ threads: DiscordThread[]; has_more: boolean }>,
+                );
+
+                for (const thread of result.threads ?? []) {
+                    if (!threadMap.has(thread.id)) {
+                        threadMap.set(thread.id, thread);
+                    }
+                }
+
+                if (!result.has_more || !result.threads?.length) break;
+
+                // Use the last thread's ID as the before cursor
+                before = result.threads[result.threads.length - 1].id;
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to fetch ${type} archived threads for channel ${channelId}: ${msg}`);
+                break;
+            }
+
+            if (pages >= MAX_PAGES) {
+                console.warn(`${this.logPrefix} fetchArchivedThreads hit max pages (${MAX_PAGES})`);
+                break;
+            }
+        } while (true);
+    }
+
+    /**
+     * Call a Discord API method with retry on rate limit (429) responses.
+     * Respects retry_after with exponential backoff fallback.
+     */
+    private async callWithRetry<T>(
+        fn: () => Promise<T>,
+        attempt: number = 1,
+    ): Promise<T> {
+        try {
+            return await fn();
+        } catch (error: unknown) {
+            const status = (error as any)?.status ?? (error as any)?.statusCode;
+            const isRateLimited = status === 429;
+
+            if (!isRateLimited || attempt > this.maxRetries) {
+                throw error;
+            }
+
+            const retryAfter = (error as any)?.retryAfter
+                ?? (error as any)?.retry_after;
+            // retryAfter from @discordjs/rest is in ms; fallback to exponential backoff in ms
+            const delayMs = retryAfter != null
+                ? Math.max(retryAfter, 1000)
+                : Math.max(Math.pow(2, attempt) * 1000, 1000);
+
+            console.warn(
+                `${this.logPrefix} Rate limited (attempt ${attempt}/${this.maxRetries}), ` +
+                `retrying in ${delayMs}ms`,
+            );
+
+            await sleep(delayMs);
+            return this.callWithRetry(fn, attempt + 1);
+        }
+    }
+}

--- a/src/indexing/providers/discord.ts
+++ b/src/indexing/providers/discord.ts
@@ -1,0 +1,340 @@
+// DiscordDataProvider — Discord thread acquisition via REST API + LLM distillation (text)
+// and direct Q&A extraction (forum). Implements DataProvider.
+
+import OpenAI from 'openai';
+import { DiscordApiClient, type DiscordMessage, type DiscordThread } from './discord-api.js';
+import { distillThread, type ThreadMessage } from '../distiller.js';
+import { getConfig } from '../../config.js';
+import type { SourceConfig, DiscordSourceConfig, DiscordChannelConfig } from '../../types.js';
+import type { DataProvider, AcquisitionResult, ContentItem, ProviderOptions } from './types.js';
+
+const MAX_ANSWER_CHARS = 8000;
+
+export class DiscordDataProvider implements DataProvider {
+    private config: DiscordSourceConfig;
+    private apiClient: DiscordApiClient;
+    private openaiClient: OpenAI | null = null;
+    private logPrefix: string;
+
+    constructor(config: SourceConfig, options: ProviderOptions) {
+        if (config.type !== 'discord') {
+            throw new Error('DiscordDataProvider requires a discord source config');
+        }
+        this.config = config;
+        const token = options.discordBotToken;
+        if (!token) {
+            throw new Error('DiscordDataProvider requires a discordBotToken in provider options');
+        }
+        this.apiClient = new DiscordApiClient({ token });
+
+        // Only create OpenAI client if text channels are configured
+        const hasTextChannels = this.config.channels.some(c => c.type === 'text');
+        if (hasTextChannels) {
+            this.openaiClient = new OpenAI({ apiKey: getConfig().openaiApiKey });
+        }
+
+        this.logPrefix = `[discord-provider:${config.name}]`;
+    }
+
+    async fullAcquire(): Promise<AcquisitionResult> {
+        console.log(`${this.logPrefix} Starting full acquire for ${this.config.channels.length} channel(s)`);
+        const allItems: ContentItem[] = [];
+        let maxSnowflake = '0';
+        let failedChannels = 0;
+
+        for (const channel of this.config.channels) {
+            try {
+                const { items, latestId } = channel.type === 'text'
+                    ? await this.processTextChannel(channel.id)
+                    : await this.processForumChannel(channel.id);
+
+                allItems.push(...items);
+                if (BigInt(latestId) > BigInt(maxSnowflake)) maxSnowflake = latestId;
+            } catch (err) {
+                failedChannels++;
+                const msg = err instanceof Error ? err.message : String(err);
+                console.error(`${this.logPrefix} Failed to process channel ${channel.id}: ${msg}`);
+            }
+        }
+
+        if (failedChannels === this.config.channels.length) {
+            throw new Error(`All ${failedChannels} channel(s) failed during acquire`);
+        }
+
+        console.log(`${this.logPrefix} Full acquire complete: ${allItems.length} Q&A pairs from ${this.config.channels.length} channel(s)`);
+
+        return {
+            items: allItems,
+            removedIds: [],
+            stateToken: maxSnowflake,
+        };
+    }
+
+    async incrementalAcquire(lastStateToken: string): Promise<AcquisitionResult> {
+        console.log(`${this.logPrefix} Starting incremental acquire since ${lastStateToken}`);
+        const allItems: ContentItem[] = [];
+        let maxSnowflake = lastStateToken;
+        let failedChannels = 0;
+
+        for (const channel of this.config.channels) {
+            try {
+                const { items, latestId } = channel.type === 'text'
+                    ? await this.processTextChannel(channel.id, lastStateToken)
+                    : await this.processForumChannel(channel.id, lastStateToken);
+
+                allItems.push(...items);
+                if (BigInt(latestId) > BigInt(maxSnowflake)) maxSnowflake = latestId;
+            } catch (err) {
+                failedChannels++;
+                const msg = err instanceof Error ? err.message : String(err);
+                console.error(`${this.logPrefix} Failed to process channel ${channel.id}: ${msg}`);
+            }
+        }
+
+        if (failedChannels === this.config.channels.length) {
+            throw new Error(`All ${failedChannels} channel(s) failed during acquire`);
+        }
+
+        console.log(`${this.logPrefix} Incremental acquire complete: ${allItems.length} Q&A pairs`);
+
+        return {
+            items: allItems,
+            removedIds: [],
+            stateToken: maxSnowflake,
+        };
+    }
+
+    async getCurrentStateToken(): Promise<string | null> {
+        let maxSnowflake = '0';
+
+        for (const channel of this.config.channels) {
+            try {
+                if (channel.type === 'text') {
+                    const messages = await this.apiClient.fetchChannelMessages(channel.id, undefined, 1);
+                    if (messages.length > 0) {
+                        const latest = messages[0].id;
+                        if (BigInt(latest) > BigInt(maxSnowflake)) maxSnowflake = latest;
+                    }
+                } else {
+                    const threads = await this.apiClient.fetchForumThreads(channel.id, this.config.guild_id);
+                    for (const thread of threads) {
+                        if (BigInt(thread.last_message_id) > BigInt(maxSnowflake)) {
+                            maxSnowflake = thread.last_message_id;
+                        }
+                    }
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to check channel ${channel.id}: ${msg}`);
+            }
+        }
+
+        return maxSnowflake === '0' ? null : maxSnowflake;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Process a text channel: fetch messages with threads, distill via LLM.
+     */
+    private async processTextChannel(
+        channelId: string,
+        after?: string,
+    ): Promise<{ items: ContentItem[]; latestId: string }> {
+        const messages = await this.apiClient.fetchChannelMessages(channelId, after);
+        const items: ContentItem[] = [];
+        let latestId = after ?? '0';
+
+        // Filter to messages with threads having >= min_thread_replies
+        const threads = messages.filter(
+            m => m.thread && m.thread.message_count >= this.config.min_thread_replies,
+        );
+
+        console.log(`${this.logPrefix} Channel ${channelId}: ${messages.length} messages, ${threads.length} qualifying threads`);
+
+        for (const message of threads) {
+            try {
+                const threadItems = await this.processTextThread(channelId, message);
+                items.push(...threadItems);
+
+                if (BigInt(message.id) > BigInt(latestId)) latestId = message.id;
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.error(`${this.logPrefix} Failed to distill thread ${message.id}: ${msg}`);
+            }
+        }
+
+        return { items, latestId };
+    }
+
+    /**
+     * Process a single text channel thread: fetch replies, resolve users, distill.
+     */
+    private async processTextThread(
+        channelId: string,
+        parentMessage: DiscordMessage,
+    ): Promise<ContentItem[]> {
+        const threadId = parentMessage.thread!.id;
+        const replies = await this.apiClient.fetchThreadMessages(threadId);
+
+        // Resolve user display names
+        const threadMessages: ThreadMessage[] = [];
+        for (const reply of replies) {
+            let author = reply.author.global_name ?? reply.author.username;
+            try {
+                const user = await this.apiClient.fetchUser(reply.author.id);
+                author = user.displayName;
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to resolve user ${reply.author.id}: ${msg}`);
+            }
+
+            threadMessages.push({
+                author,
+                content: reply.content,
+                timestamp: reply.timestamp,
+                reactions: reply.reactions?.map(r => ({ name: r.emoji.name, count: r.count })),
+            });
+        }
+
+        // Distill the thread
+        const distillerResult = await distillThread(threadMessages, {
+            model: this.config.distiller_model,
+            client: this.openaiClient!,
+        });
+
+        const items: ContentItem[] = [];
+        const sourceUrl = this.apiClient.getMessageUrl(
+            this.config.guild_id,
+            channelId,
+            parentMessage.id,
+        );
+        const participants = [...new Set(threadMessages.map(m => m.author))];
+
+        for (let i = 0; i < distillerResult.pairs.length; i++) {
+            const pair = distillerResult.pairs[i];
+
+            items.push({
+                id: `${channelId}:${parentMessage.id}:${i}`,
+                content: `Q: ${pair.question}\n\nA: ${pair.answer}`,
+                title: pair.question,
+                sourceUrl,
+                metadata: {
+                    channel: channelId,
+                    participants,
+                    confidence: pair.confidence,
+                },
+            });
+        }
+
+        return items;
+    }
+
+    /**
+     * Process a forum channel: fetch threads, extract Q&A directly.
+     */
+    private async processForumChannel(
+        channelId: string,
+        afterToken?: string,
+    ): Promise<{ items: ContentItem[]; latestId: string }> {
+        const allThreads = await this.apiClient.fetchForumThreads(channelId, this.config.guild_id);
+        let latestId = afterToken ?? '0';
+        const items: ContentItem[] = [];
+
+        // Filter by min_thread_replies
+        let threads = allThreads.filter(t => t.message_count >= this.config.min_thread_replies);
+
+        // For incremental, filter threads with new activity
+        if (afterToken) {
+            threads = threads.filter(t => BigInt(t.last_message_id) > BigInt(afterToken));
+        }
+
+        console.log(`${this.logPrefix} Forum ${channelId}: ${allThreads.length} total threads, ${threads.length} qualifying`);
+
+        for (const thread of threads) {
+            try {
+                const messages = await this.apiClient.fetchThreadMessages(thread.id);
+                const answer = synthesizeForumAnswer(messages, thread.name);
+
+                if (!answer) {
+                    console.log(`${this.logPrefix} Skipping forum thread ${thread.id} — empty synthesized answer`);
+                    continue;
+                }
+
+                const truncatedAnswer = truncateAnswer(answer);
+                const sourceUrl = this.apiClient.getMessageUrl(
+                    this.config.guild_id,
+                    thread.id,
+                    messages[0]?.id ?? thread.id,
+                );
+
+                items.push({
+                    id: `${channelId}:${thread.id}`,
+                    content: `Q: ${thread.name}\n\nA: ${truncatedAnswer}`,
+                    title: thread.name,
+                    sourceUrl,
+                    metadata: {
+                        channel: channelId,
+                        confidence: 1.0,
+                        forumThread: true,
+                    },
+                });
+
+                if (BigInt(thread.last_message_id) > BigInt(latestId)) {
+                    latestId = thread.last_message_id;
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.error(`${this.logPrefix} Failed to process forum thread ${thread.id}: ${msg}`);
+            }
+        }
+
+        return { items, latestId };
+    }
+}
+
+/**
+ * Synthesize an answer from forum thread reply messages.
+ */
+function synthesizeForumAnswer(messages: DiscordMessage[], threadName: string): string {
+    if (messages.length === 0) return '';
+
+    const firstContent = messages[0]?.content.trim() ?? '';
+    const titleLower = threadName.trim().toLowerCase();
+
+    let processedMessages = messages;
+
+    // If the first message starts with or matches the title, strip the title portion
+    // but keep any additional content the OP may have added
+    if (firstContent.toLowerCase().startsWith(titleLower)) {
+        const remainder = firstContent.slice(threadName.trim().length).trim();
+        if (!remainder) {
+            // First message was just the title restated — skip it
+            processedMessages = messages.slice(1);
+        }
+        // If there's a remainder, keep the full message (OP added context beyond the title)
+    } else if (titleLower.startsWith(firstContent.toLowerCase()) && firstContent.length > 0) {
+        // First message is a truncated version of the title — skip it
+        processedMessages = messages.slice(1);
+    }
+
+    // Filter out messages with empty/whitespace-only content
+    const withContent = processedMessages.filter(m => m.content.trim().length > 0);
+    if (withContent.length === 0) return '';
+
+    return withContent
+        .map(m => `${m.author.global_name ?? m.author.username}: ${m.content}`)
+        .join('\n\n');
+}
+
+/**
+ * Truncate an answer if it exceeds MAX_ANSWER_CHARS.
+ */
+function truncateAnswer(answer: string): string {
+    if (answer.length <= MAX_ANSWER_CHARS) return answer;
+    const truncated = answer.slice(0, MAX_ANSWER_CHARS);
+    const lastBreak = truncated.lastIndexOf('\n\n');
+    return (lastBreak > 0 ? truncated.slice(0, lastBreak) : truncated) + '\n\n[truncated]';
+}

--- a/src/indexing/providers/file.ts
+++ b/src/indexing/providers/file.ts
@@ -6,7 +6,8 @@ import path from 'node:path';
 import { createHash } from 'node:crypto';
 import { simpleGit, type SimpleGit } from 'simple-git';
 import { matchesPatterns, hasLowSemanticValue } from '../utils.js';
-import type { SourceConfig } from '../../types.js';
+import { isFileSourceConfig } from '../../types.js';
+import type { SourceConfig, FileSourceConfig } from '../../types.js';
 import type { DataProvider, AcquisitionResult, ContentItem, ProviderOptions } from './types.js';
 
 const DEFAULT_SKIP_DIRS = new Set(['node_modules', 'dist', 'build', '.git']);
@@ -28,13 +29,16 @@ function authenticatedUrl(repoUrl: string, githubToken?: string): string {
 }
 
 export class FileDataProvider implements DataProvider {
-    private config: SourceConfig;
+    private config: FileSourceConfig;
     private options: ProviderOptions;
     private logPrefix: string;
     private skipDirs: Set<string>;
     private maxFileSize: number;
 
     constructor(config: SourceConfig, options: ProviderOptions) {
+        if (!isFileSourceConfig(config)) {
+            throw new Error('FileDataProvider cannot handle slack source type');
+        }
         this.config = config;
         this.options = options;
         this.logPrefix = `[file-provider:${config.name}]`;

--- a/src/indexing/providers/index.ts
+++ b/src/indexing/providers/index.ts
@@ -24,3 +24,7 @@ import { FileDataProvider } from './file.js';
 for (const type of ['markdown', 'code', 'raw-text', 'html']) {
     registerProvider(type, (config, options) => new FileDataProvider(config, options));
 }
+
+import { SlackDataProvider } from './slack.js';
+
+registerProvider('slack', (config, options) => new SlackDataProvider(config, options));

--- a/src/indexing/providers/index.ts
+++ b/src/indexing/providers/index.ts
@@ -28,3 +28,7 @@ for (const type of ['markdown', 'code', 'raw-text', 'html']) {
 import { SlackDataProvider } from './slack.js';
 
 registerProvider('slack', (config, options) => new SlackDataProvider(config, options));
+
+import { DiscordDataProvider } from './discord.js';
+
+registerProvider('discord', (config, options) => new DiscordDataProvider(config, options));

--- a/src/indexing/providers/slack-api.ts
+++ b/src/indexing/providers/slack-api.ts
@@ -1,0 +1,216 @@
+// Slack Web API client wrapper — handles pagination, rate limiting, user caching.
+
+import { WebClient, type WebAPICallResult } from '@slack/web-api';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface SlackMessage {
+    ts: string;
+    user?: string;
+    text?: string;
+    thread_ts?: string;
+    reply_count?: number;
+    reactions?: Array<{ name: string; count: number }>;
+    team?: string;
+}
+
+export interface SlackUser {
+    id: string;
+    displayName: string;
+    teamId?: string;
+}
+
+export interface SlackApiClientOptions {
+    token: string;
+    /** Max retries on rate-limited requests (default: 5) */
+    maxRetries?: number;
+}
+
+// ── Rate limit helpers ───────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ── Client ───────────────────────────────────────────────────────────────────
+
+export class SlackApiClient {
+    private client: WebClient;
+    private maxRetries: number;
+    private userCache = new Map<string, SlackUser>();
+    private teamNameCache = new Map<string, string>();
+    private logPrefix = '[slack-api]';
+
+    constructor(options: SlackApiClientOptions) {
+        this.client = new WebClient(options.token, {
+            // Disable built-in retry so we handle it ourselves
+            retryConfig: { retries: 0 },
+        });
+        this.maxRetries = options.maxRetries ?? 5;
+    }
+
+    /**
+     * Fetch channel message history, paginated. Returns all top-level messages.
+     * If `oldest` is provided, only messages after that timestamp are returned.
+     */
+    async fetchChannelHistory(channelId: string, oldest?: string): Promise<SlackMessage[]> {
+        const messages: SlackMessage[] = [];
+        let cursor: string | undefined;
+
+        do {
+            const result = await this.callWithRetry(() =>
+                this.client.conversations.history({
+                    channel: channelId,
+                    oldest,
+                    cursor,
+                    limit: 200,
+                }),
+            );
+
+            const rawMessages = (result as any).messages as SlackMessage[] | undefined;
+            if (rawMessages) {
+                messages.push(...rawMessages);
+            }
+
+            cursor = (result as any).response_metadata?.next_cursor;
+        } while (cursor);
+
+        return messages;
+    }
+
+    /**
+     * Fetch all replies in a thread, paginated.
+     */
+    async fetchThreadReplies(channelId: string, threadTs: string): Promise<SlackMessage[]> {
+        const messages: SlackMessage[] = [];
+        let cursor: string | undefined;
+
+        do {
+            const result = await this.callWithRetry(() =>
+                this.client.conversations.replies({
+                    channel: channelId,
+                    ts: threadTs,
+                    cursor,
+                    limit: 200,
+                }),
+            );
+
+            const rawMessages = (result as any).messages as SlackMessage[] | undefined;
+            if (rawMessages) {
+                messages.push(...rawMessages);
+            }
+
+            cursor = (result as any).response_metadata?.next_cursor;
+        } while (cursor);
+
+        return messages;
+    }
+
+    /**
+     * Fetch user info with caching. Returns display name with workspace suffix
+     * for external users in Slack Connect channels.
+     */
+    async fetchUserInfo(userId: string): Promise<SlackUser> {
+        const cached = this.userCache.get(userId);
+        if (cached) return cached;
+
+        const result = await this.callWithRetry(() =>
+            this.client.users.info({ user: userId }),
+        );
+
+        const user = (result as any).user;
+        const profile = user?.profile;
+        const displayName = profile?.display_name || profile?.real_name || userId;
+        const teamId = user?.team_id;
+
+        let fullName = displayName;
+        if (teamId) {
+            const teamName = await this.resolveTeamName(teamId);
+            if (teamName) {
+                fullName = `${displayName} (${teamName})`;
+            }
+        }
+
+        const slackUser: SlackUser = {
+            id: userId,
+            displayName: fullName,
+            teamId,
+        };
+
+        this.userCache.set(userId, slackUser);
+        return slackUser;
+    }
+
+    /**
+     * Get a permalink URL for a specific message.
+     */
+    async getChannelPermalink(channelId: string, messageTs: string): Promise<string> {
+        const result = await this.callWithRetry(() =>
+            this.client.chat.getPermalink({
+                channel: channelId,
+                message_ts: messageTs,
+            }),
+        );
+
+        return (result as any).permalink as string;
+    }
+
+    /**
+     * Resolve a team ID to a team name (for Slack Connect workspace suffix).
+     * Caches results. Returns null if lookup fails (e.g., no permission).
+     */
+    private async resolveTeamName(teamId: string): Promise<string | null> {
+        const cached = this.teamNameCache.get(teamId);
+        if (cached !== undefined) return cached || null;
+
+        try {
+            const result = await this.callWithRetry(() =>
+                this.client.team.info({ team: teamId }),
+            );
+            const name = (result as any).team?.name ?? null;
+            this.teamNameCache.set(teamId, name ?? '');
+            return name;
+        } catch {
+            this.teamNameCache.set(teamId, '');
+            return null;
+        }
+    }
+
+    /**
+     * Call a Slack API method with retry on rate limit (429) responses.
+     * Respects Retry-After header with exponential backoff fallback.
+     */
+    private async callWithRetry<T extends WebAPICallResult>(
+        fn: () => Promise<T>,
+        attempt: number = 1,
+    ): Promise<T> {
+        try {
+            return await fn();
+        } catch (error: unknown) {
+            const isRateLimited = (error as any)?.code === 'slack_webapi_rate_limited_error'
+                || (error as any)?.data?.error === 'ratelimited';
+
+            if (!isRateLimited || attempt > this.maxRetries) {
+                throw error;
+            }
+
+            const retryAfter = (error as any)?.data?.retryAfter
+                ?? (error as any)?.retryAfter
+                ?? Math.pow(2, attempt);
+            const delayMs = retryAfter * 1000;
+
+            console.warn(
+                `${this.logPrefix} Rate limited (attempt ${attempt}/${this.maxRetries}), ` +
+                `retrying in ${retryAfter}s`,
+            );
+
+            await sleep(delayMs);
+            return this.callWithRetry(fn, attempt + 1);
+        }
+    }
+
+    /** Expose the underlying WebClient for testing/advanced usage. */
+    get webClient(): WebClient {
+        return this.client;
+    }
+}

--- a/src/indexing/providers/slack-api.ts
+++ b/src/indexing/providers/slack-api.ts
@@ -34,6 +34,8 @@ function sleep(ms: number): Promise<void> {
 
 // ── Client ───────────────────────────────────────────────────────────────────
 
+const MAX_PAGES = 100;
+
 export class SlackApiClient {
     private client: WebClient;
     private maxRetries: number;
@@ -53,17 +55,20 @@ export class SlackApiClient {
      * Fetch channel message history, paginated. Returns all top-level messages.
      * If `oldest` is provided, only messages after that timestamp are returned.
      */
-    async fetchChannelHistory(channelId: string, oldest?: string): Promise<SlackMessage[]> {
+    async fetchChannelHistory(channelId: string, oldest?: string, limit?: number): Promise<SlackMessage[]> {
         const messages: SlackMessage[] = [];
         let cursor: string | undefined;
+        const pageLimit = limit ?? 200;
+        let pages = 0;
 
         do {
+            pages++;
             const result = await this.callWithRetry(() =>
                 this.client.conversations.history({
                     channel: channelId,
                     oldest,
                     cursor,
-                    limit: 200,
+                    limit: pageLimit,
                 }),
             );
 
@@ -72,7 +77,15 @@ export class SlackApiClient {
                 messages.push(...rawMessages);
             }
 
+            // When an explicit limit is provided, don't paginate — return just the first page
+            if (limit !== undefined) break;
+
             cursor = (result as any).response_metadata?.next_cursor;
+
+            if (pages >= MAX_PAGES) {
+                console.warn(`${this.logPrefix} fetchChannelHistory hit max pages (${MAX_PAGES}) for channel ${channelId}`);
+                break;
+            }
         } while (cursor);
 
         return messages;
@@ -84,8 +97,10 @@ export class SlackApiClient {
     async fetchThreadReplies(channelId: string, threadTs: string): Promise<SlackMessage[]> {
         const messages: SlackMessage[] = [];
         let cursor: string | undefined;
+        let pages = 0;
 
         do {
+            pages++;
             const result = await this.callWithRetry(() =>
                 this.client.conversations.replies({
                     channel: channelId,
@@ -101,6 +116,11 @@ export class SlackApiClient {
             }
 
             cursor = (result as any).response_metadata?.next_cursor;
+
+            if (pages >= MAX_PAGES) {
+                console.warn(`${this.logPrefix} fetchThreadReplies hit max pages (${MAX_PAGES}) for thread ${threadTs}`);
+                break;
+            }
         } while (cursor);
 
         return messages;
@@ -195,9 +215,9 @@ export class SlackApiClient {
             }
 
             const retryAfter = (error as any)?.data?.retryAfter
-                ?? (error as any)?.retryAfter
-                ?? Math.pow(2, attempt);
-            const delayMs = retryAfter * 1000;
+                || (error as any)?.retryAfter
+                || Math.pow(2, attempt);
+            const delayMs = Math.max(retryAfter * 1000, 1000);
 
             console.warn(
                 `${this.logPrefix} Rate limited (attempt ${attempt}/${this.maxRetries}), ` +

--- a/src/indexing/providers/slack.ts
+++ b/src/indexing/providers/slack.ts
@@ -1,0 +1,210 @@
+// SlackDataProvider — Slack thread acquisition via Web API + LLM distillation.
+// Implements DataProvider: fetches threads from configured channels, distills
+// them into Q&A pairs, and returns ContentItems for the indexing pipeline.
+
+import { SlackApiClient, type SlackMessage } from './slack-api.js';
+import { distillThread, type ThreadMessage } from '../distiller.js';
+import { getConfig } from '../../config.js';
+import type { SourceConfig, SlackSourceConfig } from '../../types.js';
+import type { DataProvider, AcquisitionResult, ContentItem, ProviderOptions } from './types.js';
+
+export class SlackDataProvider implements DataProvider {
+    private config: SlackSourceConfig;
+    private apiClient: SlackApiClient;
+    private logPrefix: string;
+
+    constructor(config: SourceConfig, options: ProviderOptions) {
+        if (config.type !== 'slack') {
+            throw new Error('SlackDataProvider requires a slack source config');
+        }
+        this.config = config;
+        this.apiClient = new SlackApiClient({
+            token: options.slackBotToken ?? '',
+        });
+        this.logPrefix = `[slack-provider:${config.name}]`;
+    }
+
+    async fullAcquire(): Promise<AcquisitionResult> {
+        console.log(`${this.logPrefix} Starting full acquire for ${this.config.channels.length} channel(s)`);
+        const allItems: ContentItem[] = [];
+        let maxTimestamp = '0';
+
+        for (const channelId of this.config.channels) {
+            try {
+                const { items, latestTs } = await this.processChannel(channelId);
+                allItems.push(...items);
+                if (latestTs > maxTimestamp) maxTimestamp = latestTs;
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.error(`${this.logPrefix} Failed to process channel ${channelId}: ${msg}`);
+            }
+        }
+
+        console.log(`${this.logPrefix} Full acquire complete: ${allItems.length} Q&A pairs from ${this.config.channels.length} channel(s)`);
+
+        return {
+            items: allItems,
+            removedIds: [],
+            stateToken: maxTimestamp,
+        };
+    }
+
+    async incrementalAcquire(lastStateToken: string): Promise<AcquisitionResult> {
+        console.log(`${this.logPrefix} Starting incremental acquire since ${lastStateToken}`);
+        const allItems: ContentItem[] = [];
+        let maxTimestamp = lastStateToken;
+
+        for (const channelId of this.config.channels) {
+            try {
+                const { items, latestTs } = await this.processChannel(channelId, lastStateToken);
+                allItems.push(...items);
+                if (latestTs > maxTimestamp) maxTimestamp = latestTs;
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.error(`${this.logPrefix} Failed to process channel ${channelId}: ${msg}`);
+            }
+        }
+
+        console.log(`${this.logPrefix} Incremental acquire complete: ${allItems.length} Q&A pairs`);
+
+        return {
+            items: allItems,
+            removedIds: [], // Slack API doesn't surface deletions; caught on next full acquire
+            stateToken: maxTimestamp,
+        };
+    }
+
+    async getCurrentStateToken(): Promise<string | null> {
+        let maxTimestamp = '0';
+
+        for (const channelId of this.config.channels) {
+            try {
+                const messages = await this.apiClient.fetchChannelHistory(channelId);
+                if (messages.length > 0) {
+                    // Messages are returned newest-first by Slack
+                    const latest = messages[0].ts;
+                    if (latest > maxTimestamp) maxTimestamp = latest;
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to check channel ${channelId}: ${msg}`);
+            }
+        }
+
+        return maxTimestamp === '0' ? null : maxTimestamp;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private helpers
+    // -----------------------------------------------------------------------
+
+    /**
+     * Process a single channel: fetch threads, distill, return items.
+     */
+    private async processChannel(
+        channelId: string,
+        oldest?: string,
+    ): Promise<{ items: ContentItem[]; latestTs: string }> {
+        const messages = await this.apiClient.fetchChannelHistory(channelId, oldest);
+        const items: ContentItem[] = [];
+        let latestTs = oldest ?? '0';
+
+        // Filter to threaded messages with sufficient replies
+        const threads = messages.filter(
+            m => m.thread_ts === m.ts && (m.reply_count ?? 0) >= this.config.min_thread_replies,
+        );
+
+        console.log(`${this.logPrefix} Channel ${channelId}: ${messages.length} messages, ${threads.length} qualifying threads`);
+
+        // Process threads sequentially to avoid OpenAI rate limits
+        for (const thread of threads) {
+            try {
+                const threadItems = await this.processThread(channelId, thread);
+                items.push(...threadItems);
+
+                if (thread.ts > latestTs) latestTs = thread.ts;
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.error(`${this.logPrefix} Failed to distill thread ${thread.ts}: ${msg}`);
+            }
+        }
+
+        return { items, latestTs };
+    }
+
+    /**
+     * Process a single thread: fetch replies, resolve users, distill, create items.
+     */
+    private async processThread(
+        channelId: string,
+        parentMessage: SlackMessage,
+    ): Promise<ContentItem[]> {
+        const replies = await this.apiClient.fetchThreadReplies(channelId, parentMessage.ts);
+
+        // Resolve user display names
+        const threadMessages: ThreadMessage[] = [];
+        for (const reply of replies) {
+            let author = reply.user ?? 'unknown';
+            try {
+                if (reply.user) {
+                    const user = await this.apiClient.fetchUserInfo(reply.user);
+                    author = user.displayName;
+                }
+            } catch {
+                // Fall back to user ID
+            }
+
+            threadMessages.push({
+                author,
+                content: reply.text ?? '',
+                timestamp: reply.ts,
+                reactions: reply.reactions,
+            });
+        }
+
+        // Distill the thread
+        const cfg = getConfig();
+        const distillerResult = await distillThread(threadMessages, {
+            model: this.config.distiller_model,
+            apiKey: cfg.openaiApiKey,
+        });
+
+        // Filter by confidence threshold and create ContentItems
+        const items: ContentItem[] = [];
+        let permalink: string | undefined;
+
+        for (let i = 0; i < distillerResult.pairs.length; i++) {
+            const pair = distillerResult.pairs[i];
+
+            if (pair.confidence < this.config.confidence_threshold) {
+                continue;
+            }
+
+            // Lazy-fetch permalink (only if we have qualifying pairs)
+            if (!permalink) {
+                try {
+                    permalink = await this.apiClient.getChannelPermalink(channelId, parentMessage.ts);
+                } catch {
+                    permalink = undefined;
+                }
+            }
+
+            const participants = [...new Set(threadMessages.map(m => m.author))];
+
+            items.push({
+                id: `${channelId}:${parentMessage.ts}:${i}`,
+                content: `Q: ${pair.question}\n\nA: ${pair.answer}`,
+                title: pair.question,
+                sourceUrl: permalink,
+                metadata: {
+                    channel: channelId,
+                    participants,
+                    confidence: pair.confidence,
+                    emojiTriggered: false,
+                },
+            });
+        }
+
+        return items;
+    }
+}

--- a/src/indexing/providers/slack.ts
+++ b/src/indexing/providers/slack.ts
@@ -186,29 +186,24 @@ export class SlackDataProvider implements DataProvider {
             client: this.openaiClient,
         });
 
-        // Filter by confidence threshold and create ContentItems
+        // Create ContentItems for ALL pairs — confidence filtering happens at query time
         const items: ContentItem[] = [];
         let permalink: string | undefined;
 
+        if (distillerResult.pairs.length > 0) {
+            try {
+                permalink = await this.apiClient.getChannelPermalink(channelId, parentMessage.ts);
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to get permalink for ${channelId}/${parentMessage.ts}: ${msg}`);
+                permalink = undefined;
+            }
+        }
+
+        const participants = [...new Set(threadMessages.map(m => m.author))];
+
         for (let i = 0; i < distillerResult.pairs.length; i++) {
             const pair = distillerResult.pairs[i];
-
-            if (pair.confidence < this.config.confidence_threshold) {
-                continue;
-            }
-
-            // Lazy-fetch permalink (only if we have qualifying pairs)
-            if (!permalink) {
-                try {
-                    permalink = await this.apiClient.getChannelPermalink(channelId, parentMessage.ts);
-                } catch (err) {
-                    const msg = err instanceof Error ? err.message : String(err);
-                    console.warn(`${this.logPrefix} Failed to get permalink for ${channelId}/${parentMessage.ts}: ${msg}`);
-                    permalink = undefined;
-                }
-            }
-
-            const participants = [...new Set(threadMessages.map(m => m.author))];
 
             items.push({
                 id: `${channelId}:${parentMessage.ts}:${i}`,

--- a/src/indexing/providers/slack.ts
+++ b/src/indexing/providers/slack.ts
@@ -2,6 +2,7 @@
 // Implements DataProvider: fetches threads from configured channels, distills
 // them into Q&A pairs, and returns ContentItems for the indexing pipeline.
 
+import OpenAI from 'openai';
 import { SlackApiClient, type SlackMessage } from './slack-api.js';
 import { distillThread, type ThreadMessage } from '../distiller.js';
 import { getConfig } from '../../config.js';
@@ -11,6 +12,7 @@ import type { DataProvider, AcquisitionResult, ContentItem, ProviderOptions } fr
 export class SlackDataProvider implements DataProvider {
     private config: SlackSourceConfig;
     private apiClient: SlackApiClient;
+    private openaiClient: OpenAI;
     private logPrefix: string;
 
     constructor(config: SourceConfig, options: ProviderOptions) {
@@ -18,9 +20,12 @@ export class SlackDataProvider implements DataProvider {
             throw new Error('SlackDataProvider requires a slack source config');
         }
         this.config = config;
-        this.apiClient = new SlackApiClient({
-            token: options.slackBotToken ?? '',
-        });
+        const token = options.slackBotToken;
+        if (!token) {
+            throw new Error('SlackDataProvider requires a slackBotToken in provider options');
+        }
+        this.apiClient = new SlackApiClient({ token });
+        this.openaiClient = new OpenAI({ apiKey: getConfig().openaiApiKey });
         this.logPrefix = `[slack-provider:${config.name}]`;
     }
 
@@ -28,6 +33,7 @@ export class SlackDataProvider implements DataProvider {
         console.log(`${this.logPrefix} Starting full acquire for ${this.config.channels.length} channel(s)`);
         const allItems: ContentItem[] = [];
         let maxTimestamp = '0';
+        let failedChannels = 0;
 
         for (const channelId of this.config.channels) {
             try {
@@ -35,9 +41,14 @@ export class SlackDataProvider implements DataProvider {
                 allItems.push(...items);
                 if (latestTs > maxTimestamp) maxTimestamp = latestTs;
             } catch (err) {
+                failedChannels++;
                 const msg = err instanceof Error ? err.message : String(err);
                 console.error(`${this.logPrefix} Failed to process channel ${channelId}: ${msg}`);
             }
+        }
+
+        if (failedChannels === this.config.channels.length) {
+            throw new Error(`All ${failedChannels} channel(s) failed during acquire`);
         }
 
         console.log(`${this.logPrefix} Full acquire complete: ${allItems.length} Q&A pairs from ${this.config.channels.length} channel(s)`);
@@ -53,6 +64,7 @@ export class SlackDataProvider implements DataProvider {
         console.log(`${this.logPrefix} Starting incremental acquire since ${lastStateToken}`);
         const allItems: ContentItem[] = [];
         let maxTimestamp = lastStateToken;
+        let failedChannels = 0;
 
         for (const channelId of this.config.channels) {
             try {
@@ -60,9 +72,14 @@ export class SlackDataProvider implements DataProvider {
                 allItems.push(...items);
                 if (latestTs > maxTimestamp) maxTimestamp = latestTs;
             } catch (err) {
+                failedChannels++;
                 const msg = err instanceof Error ? err.message : String(err);
                 console.error(`${this.logPrefix} Failed to process channel ${channelId}: ${msg}`);
             }
+        }
+
+        if (failedChannels === this.config.channels.length) {
+            throw new Error(`All ${failedChannels} channel(s) failed during acquire`);
         }
 
         console.log(`${this.logPrefix} Incremental acquire complete: ${allItems.length} Q&A pairs`);
@@ -79,7 +96,7 @@ export class SlackDataProvider implements DataProvider {
 
         for (const channelId of this.config.channels) {
             try {
-                const messages = await this.apiClient.fetchChannelHistory(channelId);
+                const messages = await this.apiClient.fetchChannelHistory(channelId, undefined, 1);
                 if (messages.length > 0) {
                     // Messages are returned newest-first by Slack
                     const latest = messages[0].ts;
@@ -150,8 +167,9 @@ export class SlackDataProvider implements DataProvider {
                     const user = await this.apiClient.fetchUserInfo(reply.user);
                     author = user.displayName;
                 }
-            } catch {
-                // Fall back to user ID
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to resolve user ${reply.user}: ${msg}`);
             }
 
             threadMessages.push({
@@ -163,10 +181,9 @@ export class SlackDataProvider implements DataProvider {
         }
 
         // Distill the thread
-        const cfg = getConfig();
         const distillerResult = await distillThread(threadMessages, {
             model: this.config.distiller_model,
-            apiKey: cfg.openaiApiKey,
+            client: this.openaiClient,
         });
 
         // Filter by confidence threshold and create ContentItems
@@ -184,7 +201,9 @@ export class SlackDataProvider implements DataProvider {
             if (!permalink) {
                 try {
                     permalink = await this.apiClient.getChannelPermalink(channelId, parentMessage.ts);
-                } catch {
+                } catch (err) {
+                    const msg = err instanceof Error ? err.message : String(err);
+                    console.warn(`${this.logPrefix} Failed to get permalink for ${channelId}/${parentMessage.ts}: ${msg}`);
                     permalink = undefined;
                 }
             }

--- a/src/indexing/providers/types.ts
+++ b/src/indexing/providers/types.ts
@@ -56,6 +56,7 @@ export interface DataProvider {
 export interface ProviderOptions {
     cloneDir: string;
     githubToken?: string;
+    slackBotToken?: string;
 }
 
 /** Factory function that creates a DataProvider for a given source config. */

--- a/src/indexing/providers/types.ts
+++ b/src/indexing/providers/types.ts
@@ -57,6 +57,7 @@ export interface ProviderOptions {
     cloneDir: string;
     githubToken?: string;
     slackBotToken?: string;
+    discordBotToken?: string;
 }
 
 /** Factory function that creates a DataProvider for a given source config. */

--- a/src/indexing/url-derivation.ts
+++ b/src/indexing/url-derivation.ts
@@ -1,12 +1,12 @@
 // Configurable URL derivation from file paths based on source config.
 
-import type { SourceConfig } from '../types.js';
+import type { FileSourceConfig } from '../types.js';
 
 /**
  * Derive a public URL from a relative file path using the source's URL derivation rules.
  * Returns null if the source has no base_url or url_derivation configured.
  */
-export function deriveUrl(filePath: string, sourceConfig: SourceConfig): string | null {
+export function deriveUrl(filePath: string, sourceConfig: FileSourceConfig): string | null {
     if (!sourceConfig.base_url || !sourceConfig.url_derivation) return null;
 
     const d = sourceConfig.url_derivation;

--- a/src/indexing/utils.ts
+++ b/src/indexing/utils.ts
@@ -1,6 +1,6 @@
 // Shared indexing utilities — used by providers, bash-fs, and test scripts.
 
-import type { SourceConfig } from '../types.js';
+import type { FileSourceConfig } from '../types.js';
 
 /**
  * Check if file content has low semantic value (SVG paths, base64, minified code).
@@ -52,7 +52,7 @@ export function globToRegex(pattern: string): RegExp {
  * Check if a relative file path matches the source's file_patterns (include)
  * and does not match exclude_patterns.
  */
-export function matchesPatterns(relPath: string, sourceConfig: SourceConfig): boolean {
+export function matchesPatterns(relPath: string, sourceConfig: FileSourceConfig): boolean {
     const normalized = relPath.replace(/\\/g, '/');
 
     // Check excludes first (takes precedence)

--- a/src/mcp/server.ts
+++ b/src/mcp/server.ts
@@ -4,6 +4,7 @@ import { EmbeddingClient } from '../indexing/embeddings.js';
 import { getConfig, getServerConfig } from '../config.js';
 import { registerSearchTool } from './tools/search.js';
 import { registerCollectTool } from './tools/collect.js';
+import { registerKnowledgeTool } from './tools/knowledge.js';
 import { registerBashTool } from './tools/bash.js';
 import { SessionStateManager } from './tools/bash-session.js';
 import type { BashTelemetry } from './tools/bash-telemetry.js';
@@ -78,6 +79,9 @@ export function createMcpServer(
                 });
                 break;
             }
+            case 'knowledge':
+                registerKnowledgeTool(server, getEmbeddingClient(), tool);
+                break;
             default: {
                 const _exhaustive: never = tool;
                 throw new Error(`Unknown tool type: ${(_exhaustive as { type: string }).type}`);

--- a/src/mcp/tools/bash-fs.ts
+++ b/src/mcp/tools/bash-fs.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { Bash } from 'just-bash';
 import { matchesPatterns } from '../../indexing/utils.js';
+import { isFileSourceConfig } from '../../types.js';
 import type { SourceConfig } from '../../types.js';
 import { generateIndexMd, generateSearchTipsMd } from './bash-virtual-files.js';
 
@@ -53,6 +54,7 @@ export async function buildBashFilesMap(
     const multiSource = sources.length > 1;
 
     for (const source of sources) {
+        if (!isFileSourceConfig(source)) continue; // Slack sources don't have filesystem paths
         let rootDir: string;
         if (source.repo && options?.cloneDir) {
             // Git-based source: the orchestrator clones into cloneDir/<repoName>/

--- a/src/mcp/tools/knowledge.ts
+++ b/src/mcp/tools/knowledge.ts
@@ -82,7 +82,7 @@ export function registerKnowledgeTool(
 
                     // Now get FAQ chunks (with confidence) for the same sources to cross-reference
                     // Use a very low confidence threshold (0) to get all, then filter
-                    const faqChunks = await getFaqChunks(toolConfig.sources, 0);
+                    const faqChunks = await getFaqChunks(toolConfig.sources, 0, effectiveLimit * 5);
                     const faqById = new Map(faqChunks.map(c => [c.id, c]));
 
                     // Merge: keep search results that have FAQ metadata and meet confidence threshold
@@ -102,10 +102,10 @@ export function registerKnowledgeTool(
                     };
                 }
             } catch (error) {
+                console.error(`[${toolConfig.name}] Knowledge query failed:`, error);
                 const detail = error instanceof Error ? error.message : String(error);
-                console.error(`[${toolConfig.name}] Error: ${detail}`);
                 return {
-                    content: [{ type: "text" as const, text: "Error: Knowledge query failed. Please try again later." }],
+                    content: [{ type: "text" as const, text: `Error querying FAQ: ${detail}` }],
                     isError: true,
                 };
             }

--- a/src/mcp/tools/knowledge.ts
+++ b/src/mcp/tools/knowledge.ts
@@ -1,0 +1,114 @@
+import { z } from 'zod';
+import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import type { EmbeddingClient } from '../../indexing/embeddings.js';
+import type { KnowledgeToolConfig, FaqChunkResult, ChunkResult } from '../../types.js';
+import { getFaqChunks, searchChunks } from '../../db/queries.js';
+
+/**
+ * Format FAQ results in the standard QUESTION/ANSWER/SOURCE/CONFIDENCE format.
+ */
+export function formatFaqResults(results: FaqChunkResult[]): string {
+    if (results.length === 0) return "No FAQ results found.";
+
+    return results.map((r, i) => [
+        `Q&A ${i + 1}`,
+        `QUESTION: ${r.title || '(untitled)'}`,
+        `ANSWER: ${extractAnswer(r.content)}`,
+        `SOURCE: ${r.source_url || r.file_path}`,
+        `CONFIDENCE: ${r.confidence.toFixed(2)}`,
+    ].join('\n')).join('\n\n');
+}
+
+/**
+ * Extract the answer portion from Q&A content format "Q: ...\n\nA: ..."
+ */
+function extractAnswer(content: string): string {
+    const match = content.match(/\nA:\s*([\s\S]*)/);
+    if (match) return match[1].trim();
+    // Fallback: return full content
+    return content;
+}
+
+/**
+ * Register a knowledge tool on the MCP server.
+ * Supports two modes: browse (no query) and search (with query).
+ */
+export function registerKnowledgeTool(
+    server: McpServer,
+    embeddingClient: EmbeddingClient,
+    toolConfig: KnowledgeToolConfig,
+): void {
+    const inputSchema = {
+        query: z.string().optional().describe("Search query. Omit for full FAQ listing."),
+        limit: z.number().min(1).max(toolConfig.max_limit).optional()
+            .describe(`Maximum results to return (default: ${toolConfig.default_limit})`),
+        min_confidence: z.number().min(0).max(1).optional()
+            .describe(`Override minimum confidence threshold (default: ${toolConfig.min_confidence})`),
+    };
+
+    server.tool(
+        toolConfig.name,
+        toolConfig.description,
+        inputSchema,
+        async ({ query, limit, min_confidence }) => {
+            const effectiveLimit = limit ?? toolConfig.default_limit;
+            const effectiveConfidence = min_confidence ?? toolConfig.min_confidence;
+
+            try {
+                if (!query || query.trim() === '') {
+                    // Browse mode: return all FAQ entries above confidence
+                    const chunks = await getFaqChunks(
+                        toolConfig.sources,
+                        effectiveConfidence,
+                        effectiveLimit,
+                    );
+                    return {
+                        content: [{ type: "text" as const, text: formatFaqResults(chunks) }],
+                    };
+                } else {
+                    // Search mode: embed query, search each source, merge, filter by confidence
+                    const embedding = await embeddingClient.embed(query);
+
+                    // Search each source independently and merge
+                    const allResults: ChunkResult[] = [];
+                    for (const sourceName of toolConfig.sources) {
+                        const results = await searchChunks(embedding, effectiveLimit, sourceName);
+                        allResults.push(...results);
+                    }
+
+                    // Sort by similarity descending, take top N
+                    allResults.sort((a, b) => b.similarity - a.similarity);
+                    const topResults = allResults.slice(0, effectiveLimit);
+
+                    // Now get FAQ chunks (with confidence) for the same sources to cross-reference
+                    // Use a very low confidence threshold (0) to get all, then filter
+                    const faqChunks = await getFaqChunks(toolConfig.sources, 0);
+                    const faqById = new Map(faqChunks.map(c => [c.id, c]));
+
+                    // Merge: keep search results that have FAQ metadata and meet confidence threshold
+                    const mergedResults: FaqChunkResult[] = [];
+                    for (const result of topResults) {
+                        const faqChunk = faqById.get(result.id);
+                        if (faqChunk && faqChunk.confidence >= effectiveConfidence) {
+                            mergedResults.push({
+                                ...faqChunk,
+                                similarity: result.similarity,
+                            });
+                        }
+                    }
+
+                    return {
+                        content: [{ type: "text" as const, text: formatFaqResults(mergedResults) }],
+                    };
+                }
+            } catch (error) {
+                const detail = error instanceof Error ? error.message : String(error);
+                console.error(`[${toolConfig.name}] Error: ${detail}`);
+                return {
+                    content: [{ type: "text" as const, text: "Error: Knowledge query failed. Please try again later." }],
+                    isError: true,
+                };
+            }
+        },
+    );
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -12,6 +12,7 @@ import { getConfig, getServerConfig, hasSearchTools, hasCollectTools, hasBashSem
 import { IndexingOrchestrator } from "./indexing/orchestrator.js";
 
 import { createWebhookHandler } from "./webhooks/github.js";
+import { createSlackWebhookHandler } from "./webhooks/slack.js";
 import { SessionStateManager } from "./mcp/tools/bash-session.js";
 import { BashTelemetry } from "./mcp/tools/bash-telemetry.js";
 import { insertCollectedData } from "./db/queries.js";
@@ -48,6 +49,7 @@ app.use((_req, res, next) => {
 // ---------------------------------------------------------------------------
 
 let webhookHandler: ((req: Request, res: Response) => Promise<void>) | null = null;
+let slackWebhookHandler: ((req: Request, res: Response) => Promise<void>) | null = null;
 let orchestratorRef: IndexingOrchestrator | null = null;
 const startedAt = new Date();
 const bashInstances = new Map<string, Bash>();
@@ -98,6 +100,23 @@ app.post("/webhooks/github", express.raw({ type: "application/json" }), async (r
         }
     } catch (err) {
         console.error("[webhook] Handler error:", err);
+        if (!res.headersSent) {
+            res.status(500).json({ error: "Internal webhook handler error" });
+        }
+    }
+});
+
+// Slack webhook endpoint — also before express.json() for raw body signature verification
+app.post("/webhooks/slack", express.raw({ type: "application/json" }), async (req: Request, res: Response) => {
+    const handler = slackWebhookHandler;
+    if (!handler) {
+        res.status(503).json({ error: "Server still initializing" });
+        return;
+    }
+    try {
+        await handler(req, res);
+    } catch (err) {
+        console.error("[slack-webhook] Handler error:", err);
         if (!res.headersSent) {
             res.status(500).json({ error: "Internal webhook handler error" });
         }
@@ -458,6 +477,13 @@ export async function startServer(options?: ServerOptions): Promise<void> {
         const orchestrator = new IndexingOrchestrator();
         orchestratorRef = orchestrator;
         webhookHandler = createWebhookHandler(orchestrator);
+
+        // Wire up Slack webhook if any slack sources are configured
+        const hasSlackSources = serverCfg.sources.some(s => s.type === 'slack');
+        if (hasSlackSources) {
+            slackWebhookHandler = createSlackWebhookHandler(orchestrator);
+            console.log('[startup] Slack webhook handler enabled');
+        }
 
         orchestrator.onReindexComplete = (sourceNames) => {
             // Invalidate llms.txt caches so next request regenerates

--- a/src/server.ts
+++ b/src/server.ts
@@ -9,11 +9,12 @@ import { buildBashFilesMap, rebuildBashInstance } from "./mcp/tools/bash-fs.js";
 import { initializeSchema, closePool } from "./db/client.js";
 import { getIndexStats, getAllChunksForLlms, getFaqChunks } from "./db/queries.js";
 import { getConfig, getServerConfig, hasSearchTools, hasKnowledgeTools, hasCollectTools, hasBashSemanticSearch } from "./config.js";
-import type { SlackSourceConfig } from "./types.js";
+import { isSlackSourceConfig, isDiscordSourceConfig } from "./types.js";
 import { IndexingOrchestrator } from "./indexing/orchestrator.js";
 
 import { createWebhookHandler } from "./webhooks/github.js";
 import { createSlackWebhookHandler } from "./webhooks/slack.js";
+import { createDiscordWebhookHandler } from "./webhooks/discord.js";
 import { SessionStateManager } from "./mcp/tools/bash-session.js";
 import { BashTelemetry } from "./mcp/tools/bash-telemetry.js";
 import { insertCollectedData } from "./db/queries.js";
@@ -52,6 +53,7 @@ app.use((_req, res, next) => {
 
 let webhookHandler: ((req: Request, res: Response) => Promise<void>) | null = null;
 let slackWebhookHandler: ((req: Request, res: Response) => Promise<void>) | null = null;
+let discordWebhookHandler: ((req: Request, res: Response) => Promise<void>) | null = null;
 let orchestratorRef: IndexingOrchestrator | null = null;
 const startedAt = new Date();
 const bashInstances = new Map<string, Bash>();
@@ -119,6 +121,23 @@ app.post("/webhooks/slack", express.raw({ type: "application/json" }), async (re
         await handler(req, res);
     } catch (err) {
         console.error("[slack-webhook] Handler error:", err);
+        if (!res.headersSent) {
+            res.status(500).json({ error: "Internal webhook handler error" });
+        }
+    }
+});
+
+// Discord webhook endpoint — also before express.json() for raw body signature verification
+app.post("/webhooks/discord", express.raw({ type: "application/json" }), async (req: Request, res: Response) => {
+    const handler = discordWebhookHandler;
+    if (!handler) {
+        res.status(503).json({ error: "Server still initializing" });
+        return;
+    }
+    try {
+        await handler(req, res);
+    } catch (err) {
+        console.error("[discord-webhook] Handler error:", err);
         if (!res.headersSent) {
             res.status(500).json({ error: "Internal webhook handler error" });
         }
@@ -406,7 +425,9 @@ app.get('/faq.txt', async (_req: Request, res: Response) => {
                 .filter(s => ('category' in s) && s.category === 'faq')
                 .map(s => ({
                     name: s.name,
-                    confidenceThreshold: s.type === 'slack' ? (s as SlackSourceConfig).confidence_threshold : 0.7,
+                    confidenceThreshold: isSlackSourceConfig(s) ? s.confidence_threshold
+                        : isDiscordSourceConfig(s) ? s.confidence_threshold
+                        : 0.7,
                 }));
 
             if (faqSources.length === 0) {
@@ -522,6 +543,13 @@ export async function startServer(options?: ServerOptions): Promise<void> {
         if (hasSlackSources) {
             slackWebhookHandler = createSlackWebhookHandler(orchestrator);
             console.log('[startup] Slack webhook handler enabled');
+        }
+
+        // Wire up Discord webhook if any discord sources are configured
+        const hasDiscordSources = serverCfg.sources.some(s => s.type === 'discord');
+        if (hasDiscordSources) {
+            discordWebhookHandler = createDiscordWebhookHandler(orchestrator);
+            console.log('[startup] Discord webhook handler enabled');
         }
 
         orchestrator.onReindexComplete = (sourceNames) => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -415,8 +415,13 @@ app.get('/faq.txt', async (_req: Request, res: Response) => {
                 // Fetch FAQ chunks per source with its confidence threshold
                 const allChunks = [];
                 for (const src of faqSources) {
-                    const chunks = await getFaqChunks([src.name], src.confidenceThreshold);
-                    allChunks.push(...chunks);
+                    try {
+                        const chunks = await getFaqChunks([src.name], src.confidenceThreshold);
+                        allChunks.push(...chunks);
+                    } catch (err) {
+                        const msg = err instanceof Error ? err.message : String(err);
+                        console.error(`[faq.txt] Failed to fetch chunks for source "${src.name}": ${msg}`);
+                    }
                 }
                 cachedFaqTxt = generateFaqTxt(allChunks, serverCfg.server.name, faqSources);
             }

--- a/src/server.ts
+++ b/src/server.ts
@@ -7,8 +7,9 @@ import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { createMcpServer } from "./mcp/server.js";
 import { buildBashFilesMap, rebuildBashInstance } from "./mcp/tools/bash-fs.js";
 import { initializeSchema, closePool } from "./db/client.js";
-import { getIndexStats, getAllChunksForLlms } from "./db/queries.js";
-import { getConfig, getServerConfig, hasSearchTools, hasCollectTools, hasBashSemanticSearch } from "./config.js";
+import { getIndexStats, getAllChunksForLlms, getFaqChunks } from "./db/queries.js";
+import { getConfig, getServerConfig, hasSearchTools, hasKnowledgeTools, hasCollectTools, hasBashSemanticSearch } from "./config.js";
+import type { SlackSourceConfig } from "./types.js";
 import { IndexingOrchestrator } from "./indexing/orchestrator.js";
 
 import { createWebhookHandler } from "./webhooks/github.js";
@@ -19,6 +20,7 @@ import { insertCollectedData } from "./db/queries.js";
 import { IpSessionLimiter } from "./ip-limiter.js";
 import { WorkspaceManager } from "./workspace.js";
 import { generateLlmsTxt, generateLlmsFullTxt } from "./llms-txt.js";
+import { generateFaqTxt } from "./faq-txt.js";
 import { generateSkillMd } from "./skill-md.js";
 
 export interface ServerOptions {
@@ -36,7 +38,7 @@ app.use(
 
 // Advertise llms.txt via Link header on all responses
 app.use((_req, res, next) => {
-    res.setHeader('Link', '</llms.txt>; rel="llms-txt"');
+    res.setHeader('Link', '</llms.txt>; rel="llms-txt", </faq.txt>; rel="faq"');
     next();
 });
 
@@ -312,7 +314,7 @@ app.delete("/mcp", async (req: Request, res: Response) => {
 
 app.get("/health", async (_req: Request, res: Response) => {
     const uptime = Math.floor((Date.now() - startedAt.getTime()) / 1000);
-    const needsDb = hasSearchTools() || hasCollectTools() || hasBashSemanticSearch();
+    const needsDb = hasSearchTools() || hasKnowledgeTools() || hasCollectTools() || hasBashSemanticSearch();
 
     if (!needsDb) {
         res.json({
@@ -367,6 +369,7 @@ app.get("/health", async (_req: Request, res: Response) => {
 
 let cachedLlmsTxt: string | null = null;
 let cachedLlmsFullTxt: string | null = null;
+let cachedFaqTxt: string | null = null;
 
 app.get('/llms.txt', async (_req: Request, res: Response) => {
     try {
@@ -391,6 +394,37 @@ app.get('/llms-full.txt', async (_req: Request, res: Response) => {
     } catch (err) {
         console.error("[llms-full.txt] Generation failed:", err);
         res.status(503).type('text/plain').send('Service unavailable — index not ready.');
+    }
+});
+
+app.get('/faq.txt', async (_req: Request, res: Response) => {
+    try {
+        if (!cachedFaqTxt) {
+            const serverCfg = getServerConfig();
+            // Find FAQ sources: sources with category === 'faq'
+            const faqSources = serverCfg.sources
+                .filter(s => ('category' in s) && s.category === 'faq')
+                .map(s => ({
+                    name: s.name,
+                    confidenceThreshold: s.type === 'slack' ? (s as SlackSourceConfig).confidence_threshold : 0.7,
+                }));
+
+            if (faqSources.length === 0) {
+                cachedFaqTxt = generateFaqTxt([], serverCfg.server.name, []);
+            } else {
+                // Fetch FAQ chunks per source with its confidence threshold
+                const allChunks = [];
+                for (const src of faqSources) {
+                    const chunks = await getFaqChunks([src.name], src.confidenceThreshold);
+                    allChunks.push(...chunks);
+                }
+                cachedFaqTxt = generateFaqTxt(allChunks, serverCfg.server.name, faqSources);
+            }
+        }
+        res.type('text/plain').send(cachedFaqTxt);
+    } catch (err) {
+        console.error("[faq.txt] Generation failed:", err);
+        res.status(503).type('text/plain').send('# Service unavailable\nFAQ index not ready.');
     }
 });
 
@@ -435,7 +469,7 @@ export async function startServer(options?: ServerOptions): Promise<void> {
         console.log(`[startup] Workspace manager enabled (dir: ${workspaceDir})`);
     }
 
-    const needsDb = hasSearchTools() || hasCollectTools() || hasBashSemanticSearch();
+    const needsDb = hasSearchTools() || hasKnowledgeTools() || hasCollectTools() || hasBashSemanticSearch();
 
     if (needsDb) {
         console.log("[startup] Initializing database schema...");
@@ -473,7 +507,7 @@ export async function startServer(options?: ServerOptions): Promise<void> {
     }
 
     // Indexing and webhooks only needed when search tools are configured
-    if (hasSearchTools()) {
+    if (hasSearchTools() || hasKnowledgeTools()) {
         const orchestrator = new IndexingOrchestrator();
         orchestratorRef = orchestrator;
         webhookHandler = createWebhookHandler(orchestrator);
@@ -486,9 +520,10 @@ export async function startServer(options?: ServerOptions): Promise<void> {
         }
 
         orchestrator.onReindexComplete = (sourceNames) => {
-            // Invalidate llms.txt caches so next request regenerates
+            // Invalidate caches so next request regenerates
             cachedLlmsTxt = null;
             cachedLlmsFullTxt = null;
+            cachedFaqTxt = null;
             refreshBashInstances(sourceNames, "reindex").catch((err) => {
                 console.error("[reindex] Bash refresh failed:", err);
             });

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,7 @@ const BaseSourceFields = {
     name: z.string().min(1),
     chunk: ChunkConfigSchema,
     version: z.string().optional(),
+    category: z.enum(['faq']).optional(),
 };
 
 // File-based source schema (markdown, code, raw-text, html) — unchanged fields from today
@@ -48,9 +49,27 @@ export const FileSourceConfigSchema = z.object({
 export const SlackSourceConfigSchema = z.object({
     ...BaseSourceFields,
     type: z.literal('slack'),
+    category: z.enum(['faq']).default('faq'),  // override base optional with default
     channels: z.array(z.string()).min(1),
     confidence_threshold: z.number().min(0).max(1).default(0.7),
     trigger_emoji: z.string().default('pathfinder'),
+    min_thread_replies: z.number().int().positive().default(2),
+    distiller_model: z.string().optional(),
+});
+
+// Discord source schema — channel-based with forum thread support
+export const DiscordChannelConfigSchema = z.object({
+    id: z.string().min(1),
+    type: z.enum(['text', 'forum']),
+});
+
+export const DiscordSourceConfigSchema = z.object({
+    ...BaseSourceFields,
+    type: z.literal('discord'),
+    category: z.enum(['faq']).default('faq'),
+    guild_id: z.string().min(1),
+    channels: z.array(DiscordChannelConfigSchema).min(1),
+    confidence_threshold: z.number().min(0).max(1).default(0.7),
     min_thread_replies: z.number().int().positive().default(2),
     distiller_model: z.string().optional(),
 });
@@ -59,6 +78,7 @@ export const SlackSourceConfigSchema = z.object({
 export const SourceConfigSchema = z.discriminatedUnion('type', [
     FileSourceConfigSchema,
     SlackSourceConfigSchema,
+    DiscordSourceConfigSchema,
 ]);
 
 // ── Tool configuration schemas ────────────────────────────────────────────────
@@ -120,12 +140,23 @@ export const CollectToolConfigSchema = z.object({
     ),
 });
 
+export const KnowledgeToolConfigSchema = z.object({
+    name: z.string().min(1),
+    type: z.literal('knowledge'),
+    description: z.string().min(1),
+    sources: z.array(z.string().min(1)).min(1),
+    min_confidence: z.number().min(0).max(1).default(0.7),
+    default_limit: z.number().int().positive().default(20),
+    max_limit: z.number().int().positive().default(100),
+});
+
 // Cross-field constraints (e.g. default_limit <= max_limit for search tools)
 // are enforced in ServerConfigSchema.superRefine, not here.
 export const AnyToolConfigSchema = z.discriminatedUnion('type', [
     SearchToolConfigObjectSchema,
     CollectToolConfigSchema,
     BashToolConfigSchema,
+    KnowledgeToolConfigSchema,
 ]);
 
 // ── Embedding configuration schemas ───────────────────────────────────────────
@@ -166,7 +197,7 @@ export const ServerConfigSchema = z.object({
     indexing: IndexingConfigSchema.optional(),
     webhook: WebhookConfigSchema.optional(),
 }).superRefine((cfg, ctx) => {
-    const hasRag = cfg.tools.some(t => t.type === 'search');
+    const hasRag = cfg.tools.some(t => t.type === 'search' || t.type === 'knowledge');
     if (hasRag && !cfg.embedding) {
         ctx.addIssue({
             code: z.ZodIssueCode.custom,
@@ -209,6 +240,25 @@ export const ServerConfigSchema = z.object({
                 });
             }
         }
+        // Cross-validate: knowledge tool sources must reference existing source names
+        if (tool.type === 'knowledge') {
+            for (const src of tool.sources) {
+                if (!sourceNames.has(src)) {
+                    ctx.addIssue({
+                        code: z.ZodIssueCode.custom,
+                        message: `Knowledge tool "${tool.name}" references source "${src}" which is not defined in sources.`,
+                        path: ['tools'],
+                    });
+                }
+            }
+            if (tool.default_limit > tool.max_limit) {
+                ctx.addIssue({
+                    code: z.ZodIssueCode.custom,
+                    message: `Tool "${tool.name}": default_limit must not exceed max_limit`,
+                    path: ['tools'],
+                });
+            }
+        }
     }
 });
 
@@ -219,9 +269,12 @@ export type ChunkConfig = z.infer<typeof ChunkConfigSchema>;
 export type SourceConfig = z.infer<typeof SourceConfigSchema>;
 export type FileSourceConfig = z.infer<typeof FileSourceConfigSchema>;
 export type SlackSourceConfig = z.infer<typeof SlackSourceConfigSchema>;
+export type DiscordChannelConfig = z.infer<typeof DiscordChannelConfigSchema>;
+export type DiscordSourceConfig = z.infer<typeof DiscordSourceConfigSchema>;
 export type SearchToolConfig = z.infer<typeof SearchToolConfigSchema>;
 export type BashToolConfig = z.infer<typeof BashToolConfigSchema>;
 export type CollectToolConfig = z.infer<typeof CollectToolConfigSchema>;
+export type KnowledgeToolConfig = z.infer<typeof KnowledgeToolConfigSchema>;
 export type EmbeddingConfig = z.infer<typeof EmbeddingConfigSchema>;
 export type IndexingConfig = z.infer<typeof IndexingConfigSchema>;
 export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
@@ -238,6 +291,10 @@ export function isFileSourceConfig(config: SourceConfig): config is FileSourceCo
 
 export function isSlackSourceConfig(config: SourceConfig): config is SlackSourceConfig {
     return config.type === 'slack';
+}
+
+export function isDiscordSourceConfig(config: SourceConfig): config is DiscordSourceConfig {
+    return config.type === 'discord';
 }
 
 // ── Data types: unified chunk ─────────────────────────────────────────────────
@@ -271,6 +328,11 @@ export interface ChunkResult {
     end_line: number | null;
     language: string | null;
     similarity: number;
+}
+
+export interface FaqChunkResult extends ChunkResult {
+    metadata: Record<string, unknown>;
+    confidence: number;  // extracted from metadata->>'confidence'
 }
 
 // Chunker output: what chunkers produce before embedding

--- a/src/types.ts
+++ b/src/types.ts
@@ -231,8 +231,9 @@ export type BashOptions = z.infer<typeof BashOptionsSchema>;
 
 // ── Source config type guards ────────────────────────────────────────────────
 
+const FILE_SOURCE_TYPES = new Set(['markdown', 'code', 'raw-text', 'html']);
 export function isFileSourceConfig(config: SourceConfig): config is FileSourceConfig {
-    return config.type !== 'slack';
+    return FILE_SOURCE_TYPES.has(config.type);
 }
 
 export function isSlackSourceConfig(config: SourceConfig): config is SlackSourceConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,16 @@ export const ChunkConfigSchema = z.object({
     overlap_lines: z.number().int().nonnegative().optional(),
 });
 
-export const SourceConfigSchema = z.object({
+// Base fields shared by all source types
+const BaseSourceFields = {
     name: z.string().min(1),
+    chunk: ChunkConfigSchema,
+    version: z.string().optional(),
+};
+
+// File-based source schema (markdown, code, raw-text, html) — unchanged fields from today
+export const FileSourceConfigSchema = z.object({
+    ...BaseSourceFields,
     type: z.enum(['markdown', 'code', 'raw-text', 'html']),
     repo: z.string().url().optional(),
     branch: z.string().optional(),
@@ -34,9 +42,24 @@ export const SourceConfigSchema = z.object({
     exclude_patterns: z.array(z.string()).optional(),
     skip_dirs: z.array(z.string()).optional(),
     max_file_size: z.number().int().positive().optional(),
-    chunk: ChunkConfigSchema,
-    version: z.string().optional(),
 });
+
+// Slack source schema — different required fields
+export const SlackSourceConfigSchema = z.object({
+    ...BaseSourceFields,
+    type: z.literal('slack'),
+    channels: z.array(z.string()).min(1),
+    confidence_threshold: z.number().min(0).max(1).default(0.7),
+    trigger_emoji: z.string().default('pathfinder'),
+    min_thread_replies: z.number().int().positive().default(2),
+    distiller_model: z.string().optional(),
+});
+
+// Union: TypeScript infers the right shape based on `type`
+export const SourceConfigSchema = z.discriminatedUnion('type', [
+    FileSourceConfigSchema,
+    SlackSourceConfigSchema,
+]);
 
 // ── Tool configuration schemas ────────────────────────────────────────────────
 
@@ -194,6 +217,8 @@ export const ServerConfigSchema = z.object({
 export type UrlDerivationConfig = z.infer<typeof UrlDerivationConfigSchema>;
 export type ChunkConfig = z.infer<typeof ChunkConfigSchema>;
 export type SourceConfig = z.infer<typeof SourceConfigSchema>;
+export type FileSourceConfig = z.infer<typeof FileSourceConfigSchema>;
+export type SlackSourceConfig = z.infer<typeof SlackSourceConfigSchema>;
 export type SearchToolConfig = z.infer<typeof SearchToolConfigSchema>;
 export type BashToolConfig = z.infer<typeof BashToolConfigSchema>;
 export type CollectToolConfig = z.infer<typeof CollectToolConfigSchema>;
@@ -203,6 +228,16 @@ export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
 export type BashCacheConfig = z.infer<typeof BashCacheConfigSchema>;
 export type BashOptions = z.infer<typeof BashOptionsSchema>;
+
+// ── Source config type guards ────────────────────────────────────────────────
+
+export function isFileSourceConfig(config: SourceConfig): config is FileSourceConfig {
+    return config.type !== 'slack';
+}
+
+export function isSlackSourceConfig(config: SourceConfig): config is SlackSourceConfig {
+    return config.type === 'slack';
+}
 
 // ── Data types: unified chunk ─────────────────────────────────────────────────
 

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -1,0 +1,226 @@
+// Config + connectivity validation for the pathfinder validate CLI command.
+
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { getConfig, getServerConfig } from './config.js';
+import { isFileSourceConfig, isSlackSourceConfig, isDiscordSourceConfig } from './types.js';
+import type { SourceConfig } from './types.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface ValidationResult {
+    configValid: boolean;
+    envVars: Array<{ name: string; present: boolean; required: boolean }>;
+    sources: Array<{
+        name: string;
+        type: string;
+        valid: boolean;
+        details: string;
+        channels?: Array<{ id: string; name?: string; valid: boolean; detail: string }>;
+    }>;
+    tools: Array<{ name: string; valid: boolean; detail: string }>;
+    errors: string[];
+}
+
+// ── Validation ──────────────────────────────────────────────────────────────
+
+export async function validateConfig(configPath?: string): Promise<ValidationResult> {
+    const result: ValidationResult = {
+        configValid: false,
+        envVars: [],
+        sources: [],
+        tools: [],
+        errors: [],
+    };
+
+    // Step 1: Config schema validation
+    let serverCfg;
+    try {
+        if (configPath) {
+            process.env.PATHFINDER_CONFIG = configPath;
+        }
+        serverCfg = getServerConfig();
+        result.configValid = true;
+    } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        result.errors.push(`Config validation failed: ${msg}`);
+        return result;
+    }
+
+    const cfg = getConfig();
+
+    // Step 2: Environment variable checks
+    const hasDiscordSource = serverCfg.sources.some(s => s.type === 'discord');
+    const hasSlackSource = serverCfg.sources.some(s => s.type === 'slack');
+    const hasDiscordTextChannels = serverCfg.sources.some(
+        s => isDiscordSourceConfig(s) && s.channels.some(c => c.type === 'text')
+    );
+    const needsRag = serverCfg.tools.some(t => t.type === 'search' || t.type === 'knowledge');
+
+    const envChecks = [
+        { name: 'DATABASE_URL', present: !!cfg.databaseUrl, required: needsRag },
+        { name: 'OPENAI_API_KEY', present: !!cfg.openaiApiKey, required: needsRag || hasSlackSource || hasDiscordTextChannels },
+        { name: 'SLACK_BOT_TOKEN', present: !!cfg.slackBotToken, required: hasSlackSource },
+        { name: 'DISCORD_BOT_TOKEN', present: !!cfg.discordBotToken, required: hasDiscordSource },
+        { name: 'DISCORD_PUBLIC_KEY', present: !!cfg.discordPublicKey, required: hasDiscordSource },
+    ];
+    result.envVars = envChecks;
+
+    for (const check of envChecks) {
+        if (check.required && !check.present) {
+            result.errors.push(`Missing required environment variable: ${check.name}`);
+        }
+    }
+
+    // Step 3: Source connectivity probes
+    for (const source of serverCfg.sources) {
+        try {
+            const sourceResult = await validateSource(source);
+            result.sources.push(sourceResult);
+            if (!sourceResult.valid) {
+                result.errors.push(`Source "${source.name}" validation failed: ${sourceResult.details}`);
+            }
+        } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            result.sources.push({
+                name: source.name,
+                type: source.type,
+                valid: false,
+                details: `Validation error: ${msg}`,
+            });
+            result.errors.push(`Source "${source.name}" validation error: ${msg}`);
+        }
+    }
+
+    // Step 4: Tool cross-validation
+    const sourceNames = new Set(serverCfg.sources.map(s => s.name));
+
+    for (const tool of serverCfg.tools) {
+        if (tool.type === 'search') {
+            const valid = sourceNames.has(tool.source);
+            result.tools.push({
+                name: tool.name,
+                valid,
+                detail: valid ? `→ ${tool.source}` : `Source "${tool.source}" not found`,
+            });
+            if (!valid) result.errors.push(`Tool "${tool.name}" references missing source "${tool.source}"`);
+        } else if (tool.type === 'knowledge') {
+            const allValid = tool.sources.every(s => sourceNames.has(s));
+            result.tools.push({
+                name: tool.name,
+                valid: allValid,
+                detail: `→ [${tool.sources.join(', ')}]`,
+            });
+            if (!allValid) {
+                const missing = tool.sources.filter(s => !sourceNames.has(s));
+                result.errors.push(`Tool "${tool.name}" references missing sources: ${missing.join(', ')}`);
+            }
+        } else if (tool.type === 'bash') {
+            const allValid = tool.sources.every(s => sourceNames.has(s));
+            result.tools.push({
+                name: tool.name,
+                valid: allValid,
+                detail: `→ [${tool.sources.join(', ')}]`,
+            });
+            if (!allValid) {
+                const missing = tool.sources.filter(s => !sourceNames.has(s));
+                result.errors.push(`Tool "${tool.name}" references missing sources: ${missing.join(', ')}`);
+            }
+        } else {
+            result.tools.push({ name: tool.name, valid: true, detail: `type: ${tool.type}` });
+        }
+    }
+
+    return result;
+}
+
+// ── Source validators ──────────────────────────────────────────────────────────
+
+async function validateSource(source: SourceConfig): Promise<ValidationResult['sources'][0]> {
+    if (isFileSourceConfig(source)) {
+        return validateFileSource(source);
+    }
+    if (isSlackSourceConfig(source)) {
+        return { name: source.name, type: 'slack', valid: true, details: 'Slack validation requires live API probe — skipped in offline mode' };
+    }
+    if (isDiscordSourceConfig(source)) {
+        return { name: source.name, type: 'discord', valid: true, details: 'Discord validation requires live API probe — skipped in offline mode' };
+    }
+    // Exhaustive fallback — should not be reachable with current discriminated union
+    const s = source as SourceConfig;
+    return { name: s.name, type: (s as { type: string }).type, valid: true, details: 'Unknown source type' };
+}
+
+function validateFileSource(source: SourceConfig & { path: string; repo?: string }): ValidationResult['sources'][0] {
+    if (source.repo) {
+        // Remote repo — would need git ls-remote, skip for basic validation
+        return { name: source.name, type: source.type, valid: true, details: `Remote repo: ${source.repo}` };
+    }
+
+    const resolved = resolve(source.path);
+    const exists = existsSync(resolved);
+    return {
+        name: source.name,
+        type: source.type,
+        valid: exists,
+        details: exists ? `Path: ${resolved} — exists` : `Path: ${resolved} — not found`,
+    };
+}
+
+// ── Output formatting ──────────────────────────────────────────────────────────
+
+export function formatValidationResult(result: ValidationResult): string {
+    const lines: string[] = [];
+
+    lines.push('Pathfinder Config Validation');
+    lines.push('============================');
+    lines.push('');
+
+    if (result.configValid) {
+        lines.push(`Config: valid`);
+    } else {
+        lines.push(`Config: INVALID`);
+    }
+    lines.push('');
+
+    lines.push('Environment Variables:');
+    for (const env of result.envVars) {
+        if (!env.required) continue;
+        const status = env.present ? 'OK' : 'MISSING';
+        lines.push(`  ${env.name} ${status}`);
+    }
+    lines.push('');
+
+    lines.push('Sources:');
+    for (const source of result.sources) {
+        const status = source.valid ? 'OK' : 'FAILED';
+        lines.push(`  ${source.name} (${source.type}) ${status}`);
+        lines.push(`    ${source.details}`);
+        if (source.channels) {
+            for (const ch of source.channels) {
+                const chStatus = ch.valid ? 'OK' : 'FAILED';
+                lines.push(`    ${ch.id} ${chStatus} ${ch.detail}`);
+            }
+        }
+    }
+    lines.push('');
+
+    lines.push('Tools:');
+    for (const tool of result.tools) {
+        const status = tool.valid ? 'OK' : 'FAILED';
+        lines.push(`  ${tool.name} ${status} ${tool.detail}`);
+    }
+    lines.push('');
+
+    const errorCount = result.errors.length;
+    if (errorCount === 0) {
+        lines.push(`Result: All validations passed.`);
+    } else {
+        lines.push(`Result: ${errorCount} error(s) found.`);
+        for (const err of result.errors) {
+            lines.push(`  - ${err}`);
+        }
+    }
+
+    return lines.join('\n');
+}

--- a/src/webhooks/discord.ts
+++ b/src/webhooks/discord.ts
@@ -1,0 +1,85 @@
+// Discord Interactions webhook handler — Ed25519 signature verification + PING handling.
+// Intentionally minimal: only handles the PING interaction required for Discord app setup.
+// Reaction events (MESSAGE_REACTION_ADD) require the Gateway WebSocket, which we don't use.
+
+import { verifyKey } from 'discord-interactions';
+import type { Request, Response } from 'express';
+import { getConfig } from '../config.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface DiscordInteraction {
+    type: number;  // 1 = PING, 2 = APPLICATION_COMMAND, etc.
+    [key: string]: unknown;
+}
+
+/**
+ * Minimal interface for the orchestrator dependency.
+ */
+export interface DiscordReindexOrchestrator {
+    queueSourceReindex(sourceName: string): void;
+}
+
+// ── Signature verification ───────────────────────────────────────────────────
+
+export async function verifyDiscordSignature(
+    rawBody: Buffer,
+    signature: string | undefined,
+    timestamp: string | undefined,
+    publicKey: string,
+): Promise<boolean> {
+    if (!signature || !timestamp) return false;
+
+    try {
+        return await verifyKey(rawBody, signature, timestamp, publicKey);
+    } catch {
+        return false;
+    }
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a Discord webhook handler wired to a specific orchestrator instance.
+ */
+export function createDiscordWebhookHandler(orchestrator: DiscordReindexOrchestrator) {
+    return async function handleDiscordWebhook(req: Request, res: Response): Promise<void> {
+        const cfg = getConfig();
+
+        // -- Raw body check ------------------------------------------------
+        const rawBody = Buffer.isBuffer(req.body) ? req.body : null;
+        if (!rawBody) {
+            console.error('[discord-webhook] req.body is not a Buffer — ensure the route uses express.raw()');
+            res.status(500).json({ error: 'Server misconfiguration: raw body not available' });
+            return;
+        }
+
+        // -- Signature verification ----------------------------------------
+        const signature = req.headers['x-signature-ed25519'] as string | undefined;
+        const timestamp = req.headers['x-signature-timestamp'] as string | undefined;
+
+        const publicKey = cfg.discordPublicKey;
+        if (!await verifyDiscordSignature(rawBody, signature, timestamp, publicKey)) {
+            res.status(401).json({ error: 'Invalid or missing Discord signature' });
+            return;
+        }
+
+        // -- Parse payload -------------------------------------------------
+        let interaction: DiscordInteraction;
+        try {
+            interaction = JSON.parse(rawBody.toString('utf-8')) as DiscordInteraction;
+        } catch {
+            res.status(400).json({ error: 'Malformed JSON payload' });
+            return;
+        }
+
+        // -- PING handling (type: 1) — required by Discord for URL verification
+        if (interaction.type === 1) {
+            res.status(200).json({ type: 1 });
+            return;
+        }
+
+        // -- All other interaction types: acknowledge
+        res.status(200).json({ ok: true, ignored: true, reason: `unhandled interaction type: ${interaction.type}` });
+    };
+}

--- a/src/webhooks/slack.ts
+++ b/src/webhooks/slack.ts
@@ -1,0 +1,169 @@
+// Slack Events API webhook handler for emoji-triggered reindexing.
+// Handles URL verification challenges and reaction_added events.
+
+import crypto from 'node:crypto';
+import type { Request, Response } from 'express';
+import { getConfig, getServerConfig } from '../config.js';
+import { isSlackSourceConfig } from '../types.js';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface SlackEvent {
+    type: string;
+    [key: string]: unknown;
+}
+
+interface SlackEventPayload {
+    type: string;             // 'url_verification' | 'event_callback'
+    token?: string;
+    challenge?: string;       // for url_verification
+    event?: SlackEvent;
+}
+
+interface ReactionAddedEvent extends SlackEvent {
+    type: 'reaction_added';
+    reaction: string;
+    item: {
+        type: string;
+        channel: string;
+        ts: string;
+    };
+}
+
+/**
+ * Minimal interface for the orchestrator dependency.
+ */
+export interface SlackReindexOrchestrator {
+    queueSourceReindex(sourceName: string): void;
+}
+
+// ── Signature verification ───────────────────────────────────────────────────
+
+export function verifySlackSignature(
+    rawBody: Buffer,
+    timestamp: string | undefined,
+    signature: string | undefined,
+    signingSecret: string,
+): boolean {
+    if (!timestamp || !signature) return false;
+
+    // Reject requests older than 5 minutes (replay protection)
+    const now = Math.floor(Date.now() / 1000);
+    if (Math.abs(now - parseInt(timestamp, 10)) > 300) return false;
+
+    const sigBasestring = `v0:${timestamp}:${rawBody.toString('utf-8')}`;
+    const expected = 'v0=' + crypto
+        .createHmac('sha256', signingSecret)
+        .update(sigBasestring)
+        .digest('hex');
+
+    if (signature.length !== expected.length) return false;
+
+    return crypto.timingSafeEqual(
+        Buffer.from(signature, 'utf-8'),
+        Buffer.from(expected, 'utf-8'),
+    );
+}
+
+// ── Factory ──────────────────────────────────────────────────────────────────
+
+/**
+ * Create a Slack webhook handler wired to a specific orchestrator instance.
+ */
+export function createSlackWebhookHandler(orchestrator: SlackReindexOrchestrator) {
+    return async function handleSlackWebhook(req: Request, res: Response): Promise<void> {
+        const cfg = getConfig();
+
+        // -- Raw body check ------------------------------------------------
+        const rawBody = Buffer.isBuffer(req.body) ? req.body : null;
+        if (!rawBody) {
+            console.error('[slack-webhook] req.body is not a Buffer — ensure the route uses express.raw()');
+            res.status(500).json({ error: 'Server misconfiguration: raw body not available' });
+            return;
+        }
+
+        // -- Parse payload -------------------------------------------------
+        let payload: SlackEventPayload;
+        try {
+            payload = JSON.parse(rawBody.toString('utf-8')) as SlackEventPayload;
+        } catch {
+            res.status(400).json({ error: 'Malformed JSON payload' });
+            return;
+        }
+
+        // -- URL verification challenge ------------------------------------
+        // Slack sends this during app setup; no signature verification needed
+        if (payload.type === 'url_verification') {
+            res.status(200).json({ challenge: payload.challenge });
+            return;
+        }
+
+        // -- Signature verification ----------------------------------------
+        if (!cfg.slackSigningSecret?.trim()) {
+            console.log('[slack-webhook] Rejecting request — signing secret not configured');
+            res.status(403).json({ error: 'Forbidden' });
+            return;
+        }
+
+        const timestamp = req.headers['x-slack-request-timestamp'] as string | undefined;
+        const signature = req.headers['x-slack-signature'] as string | undefined;
+
+        if (!verifySlackSignature(rawBody, timestamp, signature, cfg.slackSigningSecret)) {
+            res.status(401).json({ error: 'Invalid or missing Slack signature' });
+            return;
+        }
+
+        // -- Event routing -------------------------------------------------
+        if (payload.type !== 'event_callback' || !payload.event) {
+            res.status(200).json({ ok: true, ignored: true, reason: 'not an event_callback' });
+            return;
+        }
+
+        const event = payload.event;
+
+        if (event.type === 'reaction_added') {
+            const reactionEvent = event as ReactionAddedEvent;
+            handleReactionAdded(reactionEvent, orchestrator);
+            // Respond immediately (Slack requires <3s)
+            res.status(200).json({ ok: true });
+            return;
+        }
+
+        // Unknown event type — acknowledge but ignore
+        res.status(200).json({ ok: true, ignored: true, reason: `unhandled event type: ${event.type}` });
+    };
+}
+
+// ── Event handlers ───────────────────────────────────────────────────────────
+
+function handleReactionAdded(
+    event: ReactionAddedEvent,
+    orchestrator: SlackReindexOrchestrator,
+): void {
+    const serverCfg = getServerConfig();
+
+    // Find Slack sources where this reaction matches the trigger emoji
+    // and the channel is in the configured channel list
+    const matchingSources = serverCfg.sources.filter(s => {
+        if (!isSlackSourceConfig(s)) return false;
+        if (s.trigger_emoji !== event.reaction) return false;
+        if (!s.channels.includes(event.item.channel)) return false;
+        return true;
+    });
+
+    if (matchingSources.length === 0) {
+        console.log(
+            `[slack-webhook] Reaction :${event.reaction}: on ${event.item.channel} ` +
+            `— no matching Slack source configured, ignoring`,
+        );
+        return;
+    }
+
+    for (const source of matchingSources) {
+        console.log(
+            `[slack-webhook] Reaction :${event.reaction}: on ${event.item.channel} ` +
+            `— queuing reindex for source "${source.name}"`,
+        );
+        orchestrator.queueSourceReindex(source.name);
+    }
+}


### PR DESCRIPTION
## Summary

v1.5 Phase 2 — adds Slack and Discord as API-based data providers, plus FAQ endpoint, knowledge tool, and `pathfinder validate` CLI command.

### Slack Data Provider
- **SourceConfig discriminated union** — `FileSourceConfig | SlackSourceConfig | DiscordSourceConfig` with type guards
- **Slack API client** — paginated history/thread fetching, rate limit handling, user caching with Slack Connect workspace suffix
- **LLM Distiller** — extracts Q&A pairs from conversation threads via gpt-4o-mini with confidence scoring. Source-agnostic, reused by Discord text channels
- **SlackDataProvider** — fullAcquire/incrementalAcquire/getCurrentStateToken. Confidence filtering + emoji-trigger curation
- **Slack webhook** — Events API handler for reaction_added, HMAC signature verification

### Discord Data Provider
- **DiscordApiClient** — wraps @discordjs/rest with snowflake-based pagination, forum thread fetching (active + public/private archived, deduplicated), user caching, rate limit retry with correct ms units
- **DiscordDataProvider** — dual processing: text channels through LLM distiller, forum channels with direct Q&A extraction at confidence 1.0. Forum answer synthesis preserves OP content, truncates at 8000 chars. BigInt snowflake comparison for incremental acquire
- **Discord webhook** — Ed25519 verification via discord-interactions, PING-only (reaction events require Gateway WebSocket)
- **No emoji-triggered reindexing** — Discord reactions require WebSocket Gateway; relies on scheduled reindex

### FAQ Endpoint + Knowledge Tool
- `/faq.txt` endpoint — serves Q&A pairs filtered by confidence at query time (not ingestion time)
- `knowledge` MCP tool type — browse mode (full FAQ listing) + search mode (vector search scoped to FAQ sources)
- `category: 'faq'` on source configs drives FAQ inclusion

### Q&A Chunker Rename
- `chunkSlack` → `chunkQa`, registered for both `slack` and `discord` types

### `pathfinder validate` CLI Command
- Schema validation, env var checks, source connectivity probes, tool-source cross-validation
- Human-readable output with pass/fail per source, exit code 1 on errors

## Test plan

- [x] 854 tests pass (86 test files)
- [x] Build clean (`tsc`, zero errors)
- [x] Config backward compatibility verified
- [ ] Slack integration E2E: configure with workspace, verify threads distilled and searchable
- [ ] Discord integration E2E: configure with guild, verify text + forum channels indexed
- [ ] `pathfinder validate` confirms connectivity to configured sources
- [ ] Smoke test both production instances

## Config examples

```yaml
# Slack source
sources:
  - name: slack-support
    type: slack
    channels: [C01234ABCDE]
    confidence_threshold: 0.7
    trigger_emoji: "pathfinder"
    min_thread_replies: 2
    chunk: { target_tokens: 600 }

# Discord source (text + forum)
  - name: discord-community
    type: discord
    guild_id: "123456789012345678"
    channels:
      - id: "111111111111111111"
        type: text
      - id: "222222222222222222"
        type: forum
    confidence_threshold: 0.7
    min_thread_replies: 2
    chunk: { target_tokens: 600 }
```

**Env vars**: `SLACK_BOT_TOKEN`, `SLACK_SIGNING_SECRET`, `DISCORD_BOT_TOKEN`, `DISCORD_PUBLIC_KEY`, `OPENAI_API_KEY`