### PR TITLE
Add Notion data provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,17 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.4.0",
+    "version": "1.5.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@copilotkit/pathfinder",
-            "version": "1.4.0",
+            "version": "1.5.0",
             "license": "MIT",
             "dependencies": {
                 "@discordjs/rest": "^2.6.1",
                 "@modelcontextprotocol/sdk": "^1.25.2",
+                "@notionhq/client": "^5.17.0",
                 "@slack/web-api": "^7.15.0",
                 "cheerio": "^1.2.0",
                 "commander": "^14.0.3",
@@ -750,6 +751,15 @@
             "peerDependencies": {
                 "@emnapi/core": "^1.7.1",
                 "@emnapi/runtime": "^1.7.1"
+            }
+        },
+        "node_modules/@notionhq/client": {
+            "version": "5.17.0",
+            "resolved": "https://registry.npmjs.org/@notionhq/client/-/client-5.17.0.tgz",
+            "integrity": "sha512-hSNm3VUW5+Qs9vPOmegS6r1RT8O1jtTE/22wmSmiJc9kkb2YyddWr8SBQruvp06rALn2r2RAh9mLPirUUonsvw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@oxc-project/types": {

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "dependencies": {
         "@discordjs/rest": "^2.6.1",
         "@modelcontextprotocol/sdk": "^1.25.2",
+        "@notionhq/client": "^5.17.0",
         "@slack/web-api": "^7.15.0",
         "cheerio": "^1.2.0",
         "commander": "^14.0.3",

--- a/src/__tests__/code-chunker.test.ts
+++ b/src/__tests__/code-chunker.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect } from 'vitest';
+import { chunkCode } from '../indexing/chunking/code.js';
+import type { SourceConfig } from '../types.js';
+
+// Helper to build a minimal SourceConfig for code chunking
+function mkConfig(overrides: { target_lines?: number; overlap_lines?: number } = {}): SourceConfig {
+    return {
+        name: 'test',
+        type: 'code',
+        path: '/tmp',
+        file_patterns: ['*.ts'],
+        chunk: {
+            target_lines: overrides.target_lines,
+            overlap_lines: overrides.overlap_lines,
+        },
+    } as SourceConfig;
+}
+
+describe('chunkCode', () => {
+    // ── Empty / whitespace input ────────────────────────────────────────
+
+    it('returns empty array for empty string', () => {
+        expect(chunkCode('', 'test.ts', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array for whitespace-only string', () => {
+        expect(chunkCode('   \n\n  ', 'test.ts', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array for null/undefined content', () => {
+        expect(chunkCode(null as any, 'test.ts', mkConfig())).toEqual([]);
+        expect(chunkCode(undefined as any, 'test.ts', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array when content is only newlines', () => {
+        expect(chunkCode('\n\n\n', 'test.ts', mkConfig())).toEqual([]);
+    });
+
+    // ── Language detection ───────────────────────────────────────────────
+
+    it('detects TypeScript from .ts extension', () => {
+        const chunks = chunkCode('const x = 1;', 'src/index.ts', mkConfig());
+        expect(chunks[0].language).toBe('typescript');
+    });
+
+    it('detects TypeScript from .tsx extension', () => {
+        const chunks = chunkCode('const x = 1;', 'app.tsx', mkConfig());
+        expect(chunks[0].language).toBe('typescript');
+    });
+
+    it('detects JavaScript from .js extension', () => {
+        const chunks = chunkCode('const x = 1;', 'script.js', mkConfig());
+        expect(chunks[0].language).toBe('javascript');
+    });
+
+    it('detects JavaScript from .mjs extension', () => {
+        const chunks = chunkCode('export default {};', 'mod.mjs', mkConfig());
+        expect(chunks[0].language).toBe('javascript');
+    });
+
+    it('detects JavaScript from .cjs extension', () => {
+        const chunks = chunkCode('module.exports = {};', 'mod.cjs', mkConfig());
+        expect(chunks[0].language).toBe('javascript');
+    });
+
+    it('detects Python from .py extension', () => {
+        const chunks = chunkCode('def hello(): pass', 'main.py', mkConfig());
+        expect(chunks[0].language).toBe('python');
+    });
+
+    it('detects Ruby from .rb extension', () => {
+        const chunks = chunkCode('def hello; end', 'app.rb', mkConfig());
+        expect(chunks[0].language).toBe('ruby');
+    });
+
+    it('detects Go from .go extension', () => {
+        const chunks = chunkCode('package main', 'main.go', mkConfig());
+        expect(chunks[0].language).toBe('go');
+    });
+
+    it('detects Rust from .rs extension', () => {
+        const chunks = chunkCode('fn main() {}', 'main.rs', mkConfig());
+        expect(chunks[0].language).toBe('rust');
+    });
+
+    it('detects shell from .sh extension', () => {
+        const chunks = chunkCode('#!/bin/bash', 'run.sh', mkConfig());
+        expect(chunks[0].language).toBe('shell');
+    });
+
+    it('detects YAML from .yml extension', () => {
+        const chunks = chunkCode('key: value', 'config.yml', mkConfig());
+        expect(chunks[0].language).toBe('yaml');
+    });
+
+    it('detects CSS from .css extension', () => {
+        const chunks = chunkCode('body { color: red; }', 'styles.css', mkConfig());
+        expect(chunks[0].language).toBe('css');
+    });
+
+    it('detects C from .h extension', () => {
+        const chunks = chunkCode('#include <stdio.h>', 'header.h', mkConfig());
+        expect(chunks[0].language).toBe('c');
+    });
+
+    it('detects C++ from .hpp extension', () => {
+        const chunks = chunkCode('#pragma once', 'header.hpp', mkConfig());
+        expect(chunks[0].language).toBe('cpp');
+    });
+
+    it('falls back to extension string for unknown extensions', () => {
+        const chunks = chunkCode('content', 'file.xyz', mkConfig());
+        expect(chunks[0].language).toBe('xyz');
+    });
+
+    it('returns "text" for files with no extension', () => {
+        const chunks = chunkCode('content', 'Makefile', mkConfig());
+        // "Makefile" has no dot, so .pop() returns "Makefile" which is not in the map
+        expect(chunks[0].language).toBe('makefile');
+    });
+
+    // ── Basic chunking ──────────────────────────────────────────────────
+
+    it('returns a single chunk for small content', () => {
+        const content = 'const x = 1;\nconst y = 2;';
+        const chunks = chunkCode(content, 'test.ts', mkConfig());
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].chunkIndex).toBe(0);
+        expect(chunks[0].startLine).toBe(1);
+        expect(chunks[0].endLine).toBe(2);
+    });
+
+    it('includes file breadcrumb in chunk content', () => {
+        const content = 'const x = 1;';
+        const chunks = chunkCode(content, 'src/index.ts', mkConfig());
+        expect(chunks[0].content).toContain('// File: src/index.ts');
+    });
+
+    it('includes line numbers in chunk content', () => {
+        const content = 'line1\nline2\nline3';
+        const chunks = chunkCode(content, 'test.ts', mkConfig());
+        expect(chunks[0].content).toContain('1 | line1');
+        expect(chunks[0].content).toContain('2 | line2');
+        expect(chunks[0].content).toContain('3 | line3');
+    });
+
+    it('pads line numbers for alignment', () => {
+        const lines = Array.from({ length: 100 }, (_, i) => `line${i}`).join('\n');
+        const chunks = chunkCode(lines, 'test.ts', mkConfig({ target_lines: 200 }));
+        // Line 1 should be padded to match width of "100"
+        expect(chunks[0].content).toContain('  1 | line0');
+    });
+
+    it('strips trailing empty line from content ending with newline', () => {
+        const content = 'line1\nline2\n';
+        const chunks = chunkCode(content, 'test.ts', mkConfig());
+        expect(chunks[0].endLine).toBe(2);
+    });
+
+    // ── Line-based splitting ────────────────────────────────────────────
+
+    it('splits into multiple chunks when content exceeds target_lines', () => {
+        const lines = Array.from({ length: 200 }, (_, i) => `const x${i} = ${i};`).join('\n');
+        const chunks = chunkCode(lines, 'test.ts', mkConfig({ target_lines: 50 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    it('sets chunkIndex sequentially', () => {
+        const lines = Array.from({ length: 200 }, (_, i) => `line ${i}`).join('\n');
+        const chunks = chunkCode(lines, 'test.ts', mkConfig({ target_lines: 50 }));
+        for (let i = 0; i < chunks.length; i++) {
+            expect(chunks[i].chunkIndex).toBe(i);
+        }
+    });
+
+    it('sets startLine and endLine correctly', () => {
+        const content = 'a\nb\nc\nd\ne';
+        const chunks = chunkCode(content, 'test.ts', mkConfig({ target_lines: 200 }));
+        expect(chunks[0].startLine).toBe(1);
+        expect(chunks[0].endLine).toBe(5);
+    });
+
+    // ── Overlap between chunks ──────────────────────────────────────────
+
+    it('applies overlap lines between chunks', () => {
+        // Create content with clear blank line boundaries for splitting
+        const makeBlock = (n: number) => Array.from({ length: 15 }, (_, i) => `block${n}_line${i}`).join('\n');
+        const content = Array.from({ length: 10 }, (_, i) => makeBlock(i)).join('\n\n');
+        const chunks = chunkCode(content, 'test.ts', mkConfig({ target_lines: 40, overlap_lines: 5 }));
+        if (chunks.length >= 2) {
+            // With overlap, chunk 2's startLine should be less than chunk 1's endLine + 1
+            expect(chunks[1].startLine!).toBeLessThanOrEqual(chunks[0].endLine!);
+        }
+    });
+
+    it('does not apply overlap when overlap_lines is 0', () => {
+        const makeBlock = (n: number) => Array.from({ length: 15 }, (_, i) => `block${n}_line${i}`).join('\n');
+        const content = Array.from({ length: 10 }, (_, i) => makeBlock(i)).join('\n\n');
+        const chunks = chunkCode(content, 'test.ts', mkConfig({ target_lines: 40, overlap_lines: 0 }));
+        if (chunks.length >= 2) {
+            // Without overlap, chunk 2 starts after chunk 1 ends
+            expect(chunks[1].startLine!).toBeGreaterThan(chunks[0].endLine!);
+        }
+    });
+
+    // ── Block comment awareness ─────────────────────────────────────────
+
+    it('avoids splitting inside block comments', () => {
+        const lines: string[] = [];
+        // Add some normal code
+        for (let i = 0; i < 30; i++) lines.push(`const a${i} = ${i};`);
+        // Add a block comment spanning many lines
+        lines.push('/*');
+        for (let i = 0; i < 20; i++) lines.push(` * Comment line ${i}`);
+        lines.push(' */');
+        // More code
+        for (let i = 0; i < 30; i++) lines.push(`const b${i} = ${i};`);
+
+        const chunks = chunkCode(lines.join('\n'), 'test.ts', mkConfig({ target_lines: 40 }));
+        // The block comment should ideally not be split across chunks
+        // Find the chunk that starts the block comment
+        const commentChunks = chunks.filter(c => c.content.includes('/*') || c.content.includes('*/'));
+        // At minimum, /* and */ should be in the same chunk or adjacent chunks
+        expect(commentChunks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    it('avoids splitting inside template strings', () => {
+        const lines: string[] = [];
+        for (let i = 0; i < 30; i++) lines.push(`const a${i} = ${i};`);
+        lines.push('');
+        lines.push('const tmpl = `');
+        for (let i = 0; i < 10; i++) lines.push(`  template line ${i}`);
+        lines.push('`;');
+        lines.push('');
+        for (let i = 0; i < 30; i++) lines.push(`const b${i} = ${i};`);
+
+        const chunks = chunkCode(lines.join('\n'), 'test.ts', mkConfig({ target_lines: 40 }));
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // ── Blank-line boundary splitting ───────────────────────────────────
+
+    it('prefers splitting at blank line boundaries', () => {
+        // Two blocks separated by a blank line
+        const block1 = Array.from({ length: 40 }, (_, i) => `const a${i} = ${i};`).join('\n');
+        const block2 = Array.from({ length: 40 }, (_, i) => `const b${i} = ${i};`).join('\n');
+        const content = block1 + '\n\n' + block2;
+
+        const chunks = chunkCode(content, 'test.ts', mkConfig({ target_lines: 50, overlap_lines: 0 }));
+        if (chunks.length >= 2) {
+            // First chunk should end near the blank line boundary
+            expect(chunks[0].endLine!).toBeLessThanOrEqual(45);
+        }
+    });
+
+    // ── Mechanical fallback splitting ───────────────────────────────────
+
+    it('splits mechanically when no blank lines exist', () => {
+        // Dense code with no blank lines
+        const lines = Array.from({ length: 200 }, (_, i) => `x${i}();`).join('\n');
+        const chunks = chunkCode(lines, 'test.ts', mkConfig({ target_lines: 50 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    // ── Config defaults ─────────────────────────────────────────────────
+
+    it('uses default target_lines (80) when not specified', () => {
+        const lines = Array.from({ length: 100 }, (_, i) => `const x${i} = ${i};`).join('\n\n');
+        const config = mkConfig();
+        delete (config as any).chunk.target_lines;
+        const chunks = chunkCode(lines, 'test.ts', config);
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // ── Python triple quotes ────────────────────────────────────────────
+
+    it('handles Python triple-quote docstrings', () => {
+        const lines: string[] = [];
+        for (let i = 0; i < 30; i++) lines.push(`x${i} = ${i}`);
+        lines.push('');
+        lines.push('def foo():');
+        lines.push('    """');
+        for (let i = 0; i < 10; i++) lines.push(`    Docstring line ${i}`);
+        lines.push('    """');
+        lines.push('    pass');
+        lines.push('');
+        for (let i = 0; i < 30; i++) lines.push(`y${i} = ${i}`);
+
+        const chunks = chunkCode(lines.join('\n'), 'main.py', mkConfig({ target_lines: 40 }));
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks[0].language).toBe('python');
+    });
+
+    // ── String literal handling ──────────────────────────────────────────
+
+    it('does not treat block comment markers inside strings as real', () => {
+        const content = 'const a = "/* not a comment */";\nconst b = 1;';
+        const chunks = chunkCode(content, 'test.ts', mkConfig());
+        expect(chunks).toHaveLength(1);
+    });
+
+    it('handles single-line comments correctly', () => {
+        const content = '// This is a comment\nconst x = 1; // inline comment\nconst y = 2;';
+        const chunks = chunkCode(content, 'test.ts', mkConfig());
+        expect(chunks).toHaveLength(1);
+    });
+
+    // ── Double blank line preferred over single ─────────────────────────
+
+    it('prefers double-newline boundaries when available', () => {
+        const block1 = Array.from({ length: 35 }, (_, i) => `a${i}`).join('\n');
+        const block2 = Array.from({ length: 35 }, (_, i) => `b${i}`).join('\n');
+        const block3 = Array.from({ length: 35 }, (_, i) => `c${i}`).join('\n');
+        const content = block1 + '\n\n\n' + block2 + '\n\n\n' + block3;
+
+        const chunks = chunkCode(content, 'test.ts', mkConfig({ target_lines: 40, overlap_lines: 0 }));
+        expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    // ── Escaped characters in strings ───────────────────────────────────
+
+    it('handles escaped quotes in strings', () => {
+        const content = 'const a = "escaped \\" quote";\nconst b = \'escaped \\\' quote\';\nconst c = 1;';
+        const chunks = chunkCode(content, 'test.ts', mkConfig());
+        expect(chunks).toHaveLength(1);
+    });
+});

--- a/src/__tests__/config.test.ts
+++ b/src/__tests__/config.test.ts
@@ -1,0 +1,805 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { readFileSync, existsSync } from 'node:fs';
+
+// We need to control the module cache for config.ts, so we mock fs and
+// re-import config functions fresh in each test via resetModules.
+
+vi.mock('node:fs', async () => {
+    const actual = await vi.importActual('node:fs');
+    return {
+        ...actual,
+        existsSync: vi.fn(),
+        readFileSync: vi.fn(),
+    };
+});
+
+const mockedExistsSync = existsSync as ReturnType<typeof vi.fn>;
+const mockedReadFileSync = readFileSync as ReturnType<typeof vi.fn>;
+
+// Helper to build a minimal valid YAML config string
+function makeYaml(overrides: Record<string, unknown> = {}): string {
+    const base = {
+        server: { name: 'test', version: '1.0' },
+        sources: [
+            { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+        ],
+        tools: [
+            { name: 'search-docs', type: 'search', source: 'docs', description: 'Search docs', default_limit: 10, max_limit: 50, result_format: 'docs' },
+        ],
+        embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+        indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+        ...overrides,
+    };
+    // Use yaml library for proper serialization
+    const { stringify } = require('yaml');
+    return stringify(base);
+}
+
+// Fresh import helper — resets module cache so cached config is cleared
+async function freshImport() {
+    vi.resetModules();
+    // Re-mock fs after resetModules
+    vi.doMock('node:fs', async () => {
+        const actual = await vi.importActual('node:fs');
+        return {
+            ...actual,
+            existsSync: mockedExistsSync,
+            readFileSync: mockedReadFileSync,
+        };
+    });
+    const mod = await import('../config.js');
+    return mod;
+}
+
+describe('config.ts', () => {
+    const originalEnv = process.env;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        process.env = { ...originalEnv };
+    });
+
+    afterEach(() => {
+        process.env = originalEnv;
+    });
+
+    // ── resolveConfigPath ────────────────────────────────────────────────────
+
+    describe('resolveConfigPath (via getServerConfig)', () => {
+        it('uses PATHFINDER_CONFIG env var when set', async () => {
+            process.env.PATHFINDER_CONFIG = '/tmp/custom-config.yaml';
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getServerConfig } = await freshImport();
+            const cfg = getServerConfig();
+            expect(cfg.server.name).toBe('test');
+            expect(mockedReadFileSync).toHaveBeenCalledWith(
+                expect.stringContaining('custom-config.yaml'),
+                'utf-8'
+            );
+        });
+
+        it('throws when PATHFINDER_CONFIG points to non-existent file', async () => {
+            process.env.PATHFINDER_CONFIG = '/tmp/missing.yaml';
+            mockedExistsSync.mockReturnValue(false);
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('PATHFINDER_CONFIG points to');
+        });
+
+        it('falls back to MCP_DOCS_CONFIG with deprecation warning', async () => {
+            delete process.env.PATHFINDER_CONFIG;
+            process.env.MCP_DOCS_CONFIG = '/tmp/legacy.yaml';
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const { getServerConfig } = await freshImport();
+            getServerConfig();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('MCP_DOCS_CONFIG is deprecated'));
+            warnSpy.mockRestore();
+        });
+
+        it('throws when MCP_DOCS_CONFIG points to non-existent file', async () => {
+            delete process.env.PATHFINDER_CONFIG;
+            process.env.MCP_DOCS_CONFIG = '/tmp/missing-legacy.yaml';
+            mockedExistsSync.mockReturnValue(false);
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('MCP_DOCS_CONFIG points to');
+        });
+
+        it('falls back to pathfinder.yaml in cwd', async () => {
+            delete process.env.PATHFINDER_CONFIG;
+            delete process.env.MCP_DOCS_CONFIG;
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getServerConfig } = await freshImport();
+            const cfg = getServerConfig();
+            expect(cfg.server.name).toBe('test');
+        });
+
+        it('falls back to mcp-docs.yaml with deprecation warning', async () => {
+            delete process.env.PATHFINDER_CONFIG;
+            delete process.env.MCP_DOCS_CONFIG;
+            mockedExistsSync.mockImplementation((p: string) => {
+                if (p.endsWith('pathfinder.yaml')) return false;
+                return true;
+            });
+            mockedReadFileSync.mockReturnValue(makeYaml());
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const { getServerConfig } = await freshImport();
+            getServerConfig();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('mcp-docs.yaml is deprecated'));
+            warnSpy.mockRestore();
+        });
+
+        it('throws when no config file is found', async () => {
+            delete process.env.PATHFINDER_CONFIG;
+            delete process.env.MCP_DOCS_CONFIG;
+            mockedExistsSync.mockReturnValue(false);
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('No pathfinder.yaml found');
+        });
+    });
+
+    // ── loadServerConfig ─────────────────────────────────────────────────────
+
+    describe('loadServerConfig (via getServerConfig)', () => {
+        beforeEach(() => {
+            process.env.PATHFINDER_CONFIG = '/tmp/test.yaml';
+            mockedExistsSync.mockReturnValue(true);
+        });
+
+        it('parses valid YAML and returns server config', async () => {
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getServerConfig } = await freshImport();
+            const cfg = getServerConfig();
+            expect(cfg.server.name).toBe('test');
+            expect(cfg.sources).toHaveLength(1);
+            expect(cfg.tools).toHaveLength(1);
+        });
+
+        it('throws on invalid YAML schema (missing server)', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                sources: [{ name: 'x', type: 'markdown', path: '.', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 't', type: 'search', source: 'x', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' }],
+            }));
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('Invalid config');
+        });
+
+        it('defaults tool type to search when missing', async () => {
+            const { stringify } = require('yaml');
+            const config = {
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'search-docs', source: 'docs', description: 'Search', default_limit: 10, max_limit: 50, result_format: 'docs' }],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            };
+            mockedReadFileSync.mockReturnValue(stringify(config));
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const { getServerConfig } = await freshImport();
+            const cfg = getServerConfig();
+            expect(cfg.tools[0].type).toBe('search');
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('no type field'));
+            warnSpy.mockRestore();
+        });
+
+        it('rejects duplicate source names', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './a', file_patterns: ['**/*.md'], chunk: {} },
+                    { name: 'docs', type: 'markdown', path: './b', file_patterns: ['**/*.md'], chunk: {} },
+                ],
+                tools: [{ name: 't', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' }],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('Duplicate source names');
+        });
+
+        it('rejects duplicate tool names', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+                ],
+                tools: [
+                    { name: 'search', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                    { name: 'search', type: 'search', source: 'docs', description: 'd2', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('Duplicate tool names');
+        });
+
+        it('rejects search tool referencing non-existent source', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+                ],
+                tools: [
+                    { name: 'search', type: 'search', source: 'missing-source', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('references source "missing-source"');
+        });
+
+        it('rejects knowledge tool referencing non-existent source', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+                ],
+                tools: [
+                    { name: 'faq', type: 'knowledge', sources: ['ghost'], description: 'd', min_confidence: 0.5, default_limit: 10, max_limit: 50 },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('references source "ghost"');
+        });
+
+        it('validates webhook repo_sources reference existing sources', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+                ],
+                tools: [
+                    { name: 'search', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+                webhook: {
+                    repo_sources: { 'org/repo': ['missing-source'] },
+                    path_triggers: {},
+                },
+            }));
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('references source "missing-source"');
+        });
+
+        it('validates webhook path_triggers reference existing sources', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+                ],
+                tools: [
+                    { name: 'search', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+                webhook: {
+                    repo_sources: { 'org/repo': ['docs'] },
+                    path_triggers: { 'ghost-source': ['docs/**'] },
+                },
+            }));
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('path_triggers key "ghost-source"');
+        });
+
+        it('warns when knowledge tool references non-FAQ source', async () => {
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+                ],
+                tools: [
+                    { name: 'faq', type: 'knowledge', sources: ['docs'], description: 'd', min_confidence: 0.5, default_limit: 10, max_limit: 50 },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const { getServerConfig } = await freshImport();
+            getServerConfig();
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('does not have category: "faq"'));
+            warnSpy.mockRestore();
+        });
+
+        it('validates local file source paths exist', async () => {
+            mockedExistsSync.mockImplementation((p: string) => {
+                if (p.includes('test.yaml')) return true;
+                // Simulate the local path not existing
+                return false;
+            });
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getServerConfig } = await freshImport();
+            expect(() => getServerConfig()).toThrow('does not exist');
+        });
+
+        it('skips path validation for file sources with repo (remote)', async () => {
+            const { stringify } = require('yaml');
+            mockedExistsSync.mockImplementation((p: string) => {
+                if (p.includes('test.yaml')) return true;
+                // Local path does NOT exist, but we have a repo so it should not throw
+                return false;
+            });
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {}, repo: 'https://github.com/org/repo' },
+                ],
+                tools: [
+                    { name: 'search', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getServerConfig } = await freshImport();
+            // Should not throw — repo sources skip local path validation
+            const cfg = getServerConfig();
+            expect(cfg.sources[0].name).toBe('docs');
+        });
+
+        it('skips path validation for non-file sources (slack, discord, notion)', async () => {
+            const { stringify } = require('yaml');
+            mockedExistsSync.mockImplementation((p: string) => {
+                if (p.includes('test.yaml')) return true;
+                return false; // nothing else exists
+            });
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'slack-src', type: 'slack', channels: ['C123'], chunk: {} },
+                ],
+                tools: [
+                    { name: 'collect', type: 'collect', description: 'collect stuff', response: 'Collected', schema: { field1: { type: 'string' } } },
+                ],
+            }));
+
+            const { getServerConfig } = await freshImport();
+            const cfg = getServerConfig();
+            expect(cfg.sources[0].type).toBe('slack');
+        });
+    });
+
+    // ── Helper functions ─────────────────────────────────────────────────────
+
+    describe('helper functions', () => {
+        function setupConfig(tools: Array<Record<string, unknown>>, sources?: Array<Record<string, unknown>>) {
+            const { stringify } = require('yaml');
+            const srcs = sources ?? [
+                { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+            ];
+            const cfg: Record<string, unknown> = {
+                server: { name: 'test', version: '1.0' },
+                sources: srcs,
+                tools,
+            };
+            // Add embedding/indexing if search or knowledge tools present
+            if (tools.some(t => t.type === 'search' || t.type === 'knowledge')) {
+                cfg.embedding = { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 };
+                cfg.indexing = { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 };
+            }
+            return stringify(cfg);
+        }
+
+        beforeEach(() => {
+            process.env.PATHFINDER_CONFIG = '/tmp/test.yaml';
+        });
+
+        it('hasSearchTools returns true when search tools exist', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 's', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+            ]));
+
+            const { hasSearchTools } = await freshImport();
+            expect(hasSearchTools()).toBe(true);
+        });
+
+        it('hasSearchTools returns false when no search tools', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } },
+            ]));
+
+            const { hasSearchTools } = await freshImport();
+            expect(hasSearchTools()).toBe(false);
+        });
+
+        it('hasKnowledgeTools returns true when knowledge tools exist', async () => {
+            const sources = [
+                { name: 'faq', type: 'discord', guild_id: '123', channels: [{ id: '1', type: 'forum' }], category: 'faq', chunk: {} },
+            ];
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 'k', type: 'knowledge', sources: ['faq'], description: 'd', min_confidence: 0.5, default_limit: 10, max_limit: 50 },
+            ], sources));
+
+            const { hasKnowledgeTools } = await freshImport();
+            expect(hasKnowledgeTools()).toBe(true);
+        });
+
+        it('hasKnowledgeTools returns false when no knowledge tools', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } },
+            ]));
+
+            const { hasKnowledgeTools } = await freshImport();
+            expect(hasKnowledgeTools()).toBe(false);
+        });
+
+        it('hasCollectTools returns true when collect tools exist', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } },
+            ]));
+
+            const { hasCollectTools } = await freshImport();
+            expect(hasCollectTools()).toBe(true);
+        });
+
+        it('hasCollectTools returns false when no collect tools', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 's', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+            ]));
+
+            const { hasCollectTools } = await freshImport();
+            expect(hasCollectTools()).toBe(false);
+        });
+
+        it('hasBashSemanticSearch returns true for vector grep strategy', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'b', type: 'bash', sources: ['docs'], description: 'd', bash: { grep_strategy: 'vector' } }],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+            }));
+
+            const { hasBashSemanticSearch } = await freshImport();
+            expect(hasBashSemanticSearch()).toBe(true);
+        });
+
+        it('hasBashSemanticSearch returns true for hybrid grep strategy', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            const { stringify } = require('yaml');
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'b', type: 'bash', sources: ['docs'], description: 'd', bash: { grep_strategy: 'hybrid' } }],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+            }));
+
+            const { hasBashSemanticSearch } = await freshImport();
+            expect(hasBashSemanticSearch()).toBe(true);
+        });
+
+        it('hasBashSemanticSearch returns false for memory grep strategy', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 'b', type: 'bash', sources: ['docs'], description: 'd', bash: { grep_strategy: 'memory' } },
+            ]));
+
+            const { hasBashSemanticSearch } = await freshImport();
+            expect(hasBashSemanticSearch()).toBe(false);
+        });
+
+        it('getIndexableSourceNames returns sources from search and knowledge tools', async () => {
+            const sources = [
+                { name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} },
+                { name: 'faq', type: 'discord', guild_id: '123', channels: [{ id: '1', type: 'forum' }], category: 'faq', chunk: {} },
+            ];
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 's', type: 'search', source: 'docs', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                { name: 'k', type: 'knowledge', sources: ['faq'], description: 'd', min_confidence: 0.5, default_limit: 10, max_limit: 50 },
+            ], sources));
+
+            const { getIndexableSourceNames } = await freshImport();
+            const names = getIndexableSourceNames();
+            expect(names).toEqual(new Set(['docs', 'faq']));
+        });
+
+        it('getIndexableSourceNames returns empty set when no search/knowledge tools', async () => {
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(setupConfig([
+                { name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } },
+            ]));
+
+            const { getIndexableSourceNames } = await freshImport();
+            const names = getIndexableSourceNames();
+            expect(names.size).toBe(0);
+        });
+    });
+
+    // ── parseConfig (via getConfig) ──────────────────────────────────────────
+
+    describe('parseConfig (via getConfig)', () => {
+        beforeEach(() => {
+            process.env.PATHFINDER_CONFIG = '/tmp/test.yaml';
+        });
+
+        it('returns config with all env vars set for search tools', async () => {
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+            process.env.PORT = '4000';
+            process.env.NODE_ENV = 'production';
+            process.env.LOG_LEVEL = 'debug';
+            process.env.CLONE_DIR = '/tmp/clones';
+            process.env.GITHUB_TOKEN = 'ghp_test';
+            process.env.GITHUB_WEBHOOK_SECRET = 'secret';
+
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            const cfg = getConfig();
+            expect(cfg.databaseUrl).toBe('postgresql://test');
+            expect(cfg.openaiApiKey).toBe('sk-test');
+            expect(cfg.port).toBe(4000);
+            expect(cfg.nodeEnv).toBe('production');
+            expect(cfg.logLevel).toBe('debug');
+            expect(cfg.cloneDir).toBe('/tmp/clones');
+        });
+
+        it('uses default values for optional env vars', async () => {
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+            delete process.env.PORT;
+            delete process.env.NODE_ENV;
+            delete process.env.LOG_LEVEL;
+            delete process.env.CLONE_DIR;
+
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            const cfg = getConfig();
+            expect(cfg.port).toBe(3001);
+            expect(cfg.nodeEnv).toBe('development');
+            expect(cfg.logLevel).toBe('info');
+            expect(cfg.cloneDir).toBe('/tmp/mcp-repos');
+        });
+
+        it('throws when DATABASE_URL missing and search tools configured', async () => {
+            delete process.env.DATABASE_URL;
+            process.env.OPENAI_API_KEY = 'sk-test';
+
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('DATABASE_URL');
+        });
+
+        it('throws when OPENAI_API_KEY missing and search tools configured', async () => {
+            process.env.DATABASE_URL = 'postgresql://test';
+            delete process.env.OPENAI_API_KEY;
+
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('OPENAI_API_KEY');
+        });
+
+        it('does not require OPENAI_API_KEY for collect-only tools (but requires DATABASE_URL)', async () => {
+            process.env.DATABASE_URL = 'postgresql://test';
+            delete process.env.OPENAI_API_KEY;
+
+            const { stringify } = require('yaml');
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            }));
+
+            const { getConfig } = await freshImport();
+            const cfg = getConfig();
+            expect(cfg.openaiApiKey).toBe('');
+        });
+
+        it('requires DATABASE_URL when collect tools are configured', async () => {
+            delete process.env.DATABASE_URL;
+            delete process.env.OPENAI_API_KEY;
+
+            const { stringify } = require('yaml');
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            }));
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('DATABASE_URL');
+        });
+
+        it('throws when SLACK_BOT_TOKEN missing and slack source configured', async () => {
+            delete process.env.SLACK_BOT_TOKEN;
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+
+            const { stringify } = require('yaml');
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'slack', type: 'slack', channels: ['C123'], chunk: {} },
+                ],
+                tools: [
+                    { name: 's', type: 'search', source: 'slack', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('SLACK_BOT_TOKEN');
+        });
+
+        it('throws when DISCORD_BOT_TOKEN missing and discord source configured', async () => {
+            delete process.env.DISCORD_BOT_TOKEN;
+            delete process.env.DISCORD_PUBLIC_KEY;
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+
+            const { stringify } = require('yaml');
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'disc', type: 'discord', guild_id: '123', channels: [{ id: '1', type: 'forum' }], chunk: {} },
+                ],
+                tools: [
+                    { name: 's', type: 'search', source: 'disc', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('DISCORD_BOT_TOKEN');
+        });
+
+        it('throws when NOTION_TOKEN missing and notion source configured', async () => {
+            delete process.env.NOTION_TOKEN;
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+
+            const { stringify } = require('yaml');
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(stringify({
+                server: { name: 'test', version: '1.0' },
+                sources: [
+                    { name: 'notion', type: 'notion', chunk: {} },
+                ],
+                tools: [
+                    { name: 's', type: 'search', source: 'notion', description: 'd', default_limit: 5, max_limit: 10, result_format: 'docs' },
+                ],
+                embedding: { provider: 'openai', model: 'text-embedding-3-small', dimensions: 1536 },
+                indexing: { auto_reindex: true, reindex_hour_utc: 4, stale_threshold_hours: 24 },
+            }));
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('NOTION_TOKEN');
+        });
+
+        it('throws on invalid PORT value', async () => {
+            process.env.PORT = 'not-a-number';
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('Invalid PORT');
+        });
+
+        it('throws on PORT out of range (negative)', async () => {
+            process.env.PORT = '-1';
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('Invalid PORT');
+        });
+
+        it('throws on PORT out of range (>65535)', async () => {
+            process.env.PORT = '70000';
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            expect(() => getConfig()).toThrow('Invalid PORT');
+        });
+    });
+
+    // ── Config caching ───────────────────────────────────────────────────────
+
+    describe('caching', () => {
+        it('getServerConfig returns cached result on second call', async () => {
+            process.env.PATHFINDER_CONFIG = '/tmp/test.yaml';
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getServerConfig } = await freshImport();
+            const first = getServerConfig();
+            const second = getServerConfig();
+            expect(first).toBe(second); // same reference
+            // readFileSync called only once
+            expect(mockedReadFileSync).toHaveBeenCalledTimes(1);
+        });
+
+        it('getConfig returns cached result on second call', async () => {
+            process.env.PATHFINDER_CONFIG = '/tmp/test.yaml';
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { getConfig } = await freshImport();
+            const first = getConfig();
+            const second = getConfig();
+            expect(first).toBe(second);
+        });
+    });
+
+    // ── Config proxy ─────────────────────────────────────────────────────────
+
+    describe('config proxy', () => {
+        it('proxies property access to getConfig()', async () => {
+            process.env.PATHFINDER_CONFIG = '/tmp/test.yaml';
+            process.env.DATABASE_URL = 'postgresql://test';
+            process.env.OPENAI_API_KEY = 'sk-test';
+            process.env.PORT = '5555';
+            mockedExistsSync.mockReturnValue(true);
+            mockedReadFileSync.mockReturnValue(makeYaml());
+
+            const { config } = await freshImport();
+            expect(config.port).toBe(5555);
+            expect(config.openaiApiKey).toBe('sk-test');
+        });
+    });
+});

--- a/src/__tests__/embeddings.test.ts
+++ b/src/__tests__/embeddings.test.ts
@@ -1,0 +1,235 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// We need a reference to the mock create fn that persists across the mock factory
+let mockCreate: ReturnType<typeof vi.fn> = vi.fn();
+
+// Mock OpenAI before importing the module under test
+vi.mock('openai', () => {
+    class MockOpenAI {
+        embeddings = { create: (...args: unknown[]) => mockCreate(...args) };
+        constructor(_opts: Record<string, unknown>) {}
+    }
+    // Attach error classes so instanceof checks work in embeddings.ts
+    (MockOpenAI as any).RateLimitError = class RateLimitError extends Error {
+        constructor(msg = 'rate limit') { super(msg); this.name = 'RateLimitError'; }
+    };
+    (MockOpenAI as any).InternalServerError = class InternalServerError extends Error {
+        constructor(msg = 'internal') { super(msg); this.name = 'InternalServerError'; }
+    };
+    (MockOpenAI as any).APIConnectionError = class APIConnectionError extends Error {
+        constructor(msg = 'connection') { super(msg); this.name = 'APIConnectionError'; }
+    };
+    return { default: MockOpenAI };
+});
+
+// Stub timers so retry delays are instant
+vi.useFakeTimers({ shouldAdvanceTime: true });
+
+import OpenAI from 'openai';
+import { EmbeddingClient } from '../indexing/embeddings.js';
+
+/** Build a fake embeddings.create response */
+function fakeResponse(embeddings: number[][]) {
+    return {
+        data: embeddings.map((embedding, index) => ({ index, embedding })),
+    };
+}
+
+describe('EmbeddingClient', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCreate = vi.fn();
+    });
+
+    // ── Constructor defaults ────────────────────────────────────────────────
+
+    it('uses default model and dimensions', async () => {
+        mockCreate.mockResolvedValue(fakeResponse([[1, 2, 3]]));
+        const client = new EmbeddingClient('test-key');
+        await client.embed('hello');
+
+        expect(mockCreate).toHaveBeenCalledWith({
+            model: 'text-embedding-3-small',
+            input: ['hello'],
+            dimensions: 1536,
+        });
+    });
+
+    it('accepts custom model and dimensions', async () => {
+        mockCreate.mockResolvedValue(fakeResponse([[1, 2]]));
+        const client = new EmbeddingClient('test-key', 'text-embedding-3-large', 3072);
+        await client.embed('hello');
+
+        expect(mockCreate).toHaveBeenCalledWith({
+            model: 'text-embedding-3-large',
+            input: ['hello'],
+            dimensions: 3072,
+        });
+    });
+
+    // ── embed (single text) ─────────────────────────────────────────────────
+
+    it('returns a single embedding vector', async () => {
+        mockCreate.mockResolvedValue(fakeResponse([[0.1, 0.2, 0.3]]));
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embed('test text');
+        expect(result).toEqual([0.1, 0.2, 0.3]);
+    });
+
+    // ── embedBatch ──────────────────────────────────────────────────────────
+
+    it('returns empty array for empty input', async () => {
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embedBatch([]);
+        expect(result).toEqual([]);
+        expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it('embeds multiple texts in a single batch', async () => {
+        mockCreate.mockResolvedValue(
+            fakeResponse([
+                [1, 0, 0],
+                [0, 1, 0],
+                [0, 0, 1],
+            ]),
+        );
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embedBatch(['a', 'b', 'c']);
+        expect(result).toHaveLength(3);
+        expect(result[0]).toEqual([1, 0, 0]);
+        expect(result[2]).toEqual([0, 0, 1]);
+    });
+
+    it('sorts results by index even if API returns them out of order', async () => {
+        mockCreate.mockResolvedValue({
+            data: [
+                { index: 2, embedding: [0, 0, 1] },
+                { index: 0, embedding: [1, 0, 0] },
+                { index: 1, embedding: [0, 1, 0] },
+            ],
+        });
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embedBatch(['a', 'b', 'c']);
+        expect(result[0]).toEqual([1, 0, 0]);
+        expect(result[1]).toEqual([0, 1, 0]);
+        expect(result[2]).toEqual([0, 0, 1]);
+    });
+
+    // ── Text truncation ─────────────────────────────────────────────────────
+
+    it('truncates texts longer than 30,000 characters', async () => {
+        mockCreate.mockResolvedValue(fakeResponse([[1]]));
+        const client = new EmbeddingClient('test-key');
+        const longText = 'x'.repeat(50_000);
+        await client.embedBatch([longText]);
+
+        const calledInput = mockCreate.mock.calls[0][0].input;
+        expect(calledInput[0].length).toBe(30_000);
+    });
+
+    it('does not truncate texts under 30,000 characters', async () => {
+        mockCreate.mockResolvedValue(fakeResponse([[1]]));
+        const client = new EmbeddingClient('test-key');
+        const text = 'x'.repeat(29_999);
+        await client.embedBatch([text]);
+
+        const calledInput = mockCreate.mock.calls[0][0].input;
+        expect(calledInput[0].length).toBe(29_999);
+    });
+
+    // ── Batching (MAX_BATCH_SIZE = 2048) ────────────────────────────────────
+
+    it('splits large input into multiple batches of 2048', async () => {
+        // Create 2050 texts — should produce 2 batches (2048 + 2)
+        const texts = Array.from({ length: 2050 }, (_, i) => `text-${i}`);
+        mockCreate
+            .mockResolvedValueOnce(
+                fakeResponse(Array.from({ length: 2048 }, () => [1])),
+            )
+            .mockResolvedValueOnce(fakeResponse(Array.from({ length: 2 }, () => [2])));
+
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embedBatch(texts);
+
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+        expect(result).toHaveLength(2050);
+        // First batch results
+        expect(result[0]).toEqual([1]);
+        // Second batch results
+        expect(result[2048]).toEqual([2]);
+    });
+
+    // ── Retry logic ─────────────────────────────────────────────────────────
+
+    it('retries on RateLimitError and succeeds', async () => {
+        mockCreate
+            .mockRejectedValueOnce(new (OpenAI as any).RateLimitError('rate limited'))
+            .mockResolvedValueOnce(fakeResponse([[1, 2]]));
+
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embed('retry me');
+        expect(result).toEqual([1, 2]);
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on InternalServerError', async () => {
+        mockCreate
+            .mockRejectedValueOnce(new (OpenAI as any).InternalServerError('500'))
+            .mockResolvedValueOnce(fakeResponse([[3, 4]]));
+
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embed('retry internal');
+        expect(result).toEqual([3, 4]);
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('retries on APIConnectionError', async () => {
+        mockCreate
+            .mockRejectedValueOnce(new (OpenAI as any).APIConnectionError('timeout'))
+            .mockResolvedValueOnce(fakeResponse([[5, 6]]));
+
+        const client = new EmbeddingClient('test-key');
+        const result = await client.embed('retry connection');
+        expect(result).toEqual([5, 6]);
+        expect(mockCreate).toHaveBeenCalledTimes(2);
+    });
+
+    it('throws after MAX_RETRIES (3) exhausted', async () => {
+        const error = new (OpenAI as any).RateLimitError('persistent rate limit');
+        mockCreate
+            .mockRejectedValueOnce(error)
+            .mockRejectedValueOnce(error)
+            .mockRejectedValueOnce(error);
+
+        const client = new EmbeddingClient('test-key');
+        await expect(client.embed('fail')).rejects.toThrow('persistent rate limit');
+        expect(mockCreate).toHaveBeenCalledTimes(3);
+    });
+
+    it('does not retry on non-retryable errors', async () => {
+        const error = new Error('bad request');
+        mockCreate.mockRejectedValueOnce(error);
+
+        const client = new EmbeddingClient('test-key');
+        await expect(client.embed('bad')).rejects.toThrow('bad request');
+        expect(mockCreate).toHaveBeenCalledTimes(1);
+    });
+
+    it('uses exponential backoff delays', async () => {
+        const sleepSpy = vi.spyOn(globalThis, 'setTimeout');
+        const error = new (OpenAI as any).RateLimitError('rate limited');
+        mockCreate
+            .mockRejectedValueOnce(error)
+            .mockRejectedValueOnce(error)
+            .mockResolvedValueOnce(fakeResponse([[1]]));
+
+        const client = new EmbeddingClient('test-key');
+        await client.embed('backoff test');
+
+        // setTimeout called for sleep: first retry 1000ms, second retry 2000ms
+        const sleepCalls = sleepSpy.mock.calls.filter(
+            ([, delay]) => delay === 1000 || delay === 2000,
+        );
+        expect(sleepCalls.length).toBeGreaterThanOrEqual(2);
+    });
+});

--- a/src/__tests__/embeddings.test.ts
+++ b/src/__tests__/embeddings.test.ts
@@ -1,22 +1,20 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
 // We need a reference to the mock create fn that persists across the mock factory
-let mockCreate: ReturnType<typeof vi.fn> = vi.fn();
+let mockCreate = vi.fn();
 
 // Mock OpenAI before importing the module under test
 vi.mock('openai', () => {
-    class MockOpenAI {
-        embeddings = { create: (...args: unknown[]) => mockCreate(...args) };
-        constructor(_opts: Record<string, unknown>) {}
-    }
-    // Attach error classes so instanceof checks work in embeddings.ts
-    (MockOpenAI as any).RateLimitError = class RateLimitError extends Error {
+    const MockOpenAI = function (this: any, _opts: Record<string, unknown>) {
+        this.embeddings = { create: (...args: unknown[]) => mockCreate(...args) };
+    } as any;
+    MockOpenAI.RateLimitError = class RateLimitError extends Error {
         constructor(msg = 'rate limit') { super(msg); this.name = 'RateLimitError'; }
     };
-    (MockOpenAI as any).InternalServerError = class InternalServerError extends Error {
+    MockOpenAI.InternalServerError = class InternalServerError extends Error {
         constructor(msg = 'internal') { super(msg); this.name = 'InternalServerError'; }
     };
-    (MockOpenAI as any).APIConnectionError = class APIConnectionError extends Error {
+    MockOpenAI.APIConnectionError = class APIConnectionError extends Error {
         constructor(msg = 'connection') { super(msg); this.name = 'APIConnectionError'; }
     };
     return { default: MockOpenAI };

--- a/src/__tests__/file-provider.test.ts
+++ b/src/__tests__/file-provider.test.ts
@@ -1,14 +1,36 @@
-import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
 import { FileDataProvider } from '../indexing/providers/file.js';
 import type { FileSourceConfig } from '../types.js';
 
+// ---------------------------------------------------------------------------
+// Mock simple-git — used for all remote-repo (git) code paths
+// ---------------------------------------------------------------------------
+
+const mockGitInstance = {
+    clone: vi.fn().mockResolvedValue(undefined),
+    pull: vi.fn().mockResolvedValue(undefined),
+    revparse: vi.fn().mockResolvedValue('abc123'),
+    diff: vi.fn().mockResolvedValue(''),
+    fetch: vi.fn().mockResolvedValue(undefined),
+    listRemote: vi.fn().mockResolvedValue('abc123\tHEAD'),
+};
+
+vi.mock('simple-git', () => ({
+    simpleGit: vi.fn(() => mockGitInstance),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
 describe('FileDataProvider', () => {
     let tmpDir: string;
 
     beforeEach(async () => {
+        vi.clearAllMocks();
         tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), 'fp-test-'));
         await fs.promises.writeFile(path.join(tmpDir, 'readme.md'), '# Hello\nWorld');
         await fs.promises.writeFile(path.join(tmpDir, 'guide.md'), '# Guide\nContent here');
@@ -21,7 +43,7 @@ describe('FileDataProvider', () => {
         await fs.promises.rm(tmpDir, { recursive: true, force: true });
     });
 
-    function makeConfig(overrides?: Partial<FileSourceConfig>): FileSourceConfig {
+    function makeLocalConfig(overrides?: Partial<FileSourceConfig>): FileSourceConfig {
         return {
             name: 'test',
             type: 'markdown',
@@ -32,54 +54,700 @@ describe('FileDataProvider', () => {
         };
     }
 
-    it('fullAcquire returns matching files as ContentItems', async () => {
-        const provider = new FileDataProvider(makeConfig(), { cloneDir: '/tmp/test-clones' });
-        const result = await provider.fullAcquire();
-        expect(result.items.length).toBe(3);
-        expect(result.removedIds).toEqual([]);
-        expect(result.stateToken).toMatch(/^local-/);
-        const ids = result.items.map(i => i.id).sort();
-        expect(ids).toContain('readme.md');
-        expect(ids).toContain('guide.md');
-        expect(ids).toContain('sub/nested.md');
-        const readme = result.items.find(i => i.id === 'readme.md');
-        expect(readme?.content).toBe('# Hello\nWorld');
+    function makeGitConfig(overrides?: Partial<FileSourceConfig>): FileSourceConfig {
+        return {
+            name: 'test-git',
+            type: 'markdown',
+            repo: 'https://github.com/org/repo.git',
+            path: 'docs',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 600, overlap_tokens: 50 },
+            ...overrides,
+        };
+    }
+
+    // -----------------------------------------------------------------------
+    // Constructor
+    // -----------------------------------------------------------------------
+
+    describe('constructor', () => {
+        it('throws when given a non-file source config', () => {
+            const slackConfig = {
+                name: 'slack-src',
+                type: 'slack' as const,
+                channels: [{ id: 'C1', name: 'general' }],
+                chunk: {},
+            };
+            expect(() => new FileDataProvider(slackConfig as any, { cloneDir: '/tmp' }))
+                .toThrow('FileDataProvider cannot handle slack source type');
+        });
+
+        it('merges custom skip_dirs with defaults', async () => {
+            await fs.promises.mkdir(path.join(tmpDir, 'custom_skip'), { recursive: true });
+            await fs.promises.writeFile(path.join(tmpDir, 'custom_skip', 'file.md'), '# Skip me');
+            const provider = new FileDataProvider(
+                makeLocalConfig({ skip_dirs: ['custom_skip'] }),
+                { cloneDir: '/tmp/test-clones' },
+            );
+            const result = await provider.fullAcquire();
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('custom_skip/file.md');
+        });
+
+        it('uses custom max_file_size', async () => {
+            // Write a file larger than 10 bytes
+            await fs.promises.writeFile(path.join(tmpDir, 'big.md'), 'x'.repeat(200));
+            const provider = new FileDataProvider(
+                makeLocalConfig({ max_file_size: 10 }),
+                { cloneDir: '/tmp/test-clones' },
+            );
+            const result = await provider.fullAcquire();
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('big.md');
+        });
     });
 
-    it('fullAcquire excludes non-matching patterns', async () => {
-        const provider = new FileDataProvider(makeConfig(), { cloneDir: '/tmp/test-clones' });
-        const result = await provider.fullAcquire();
-        const ids = result.items.map(i => i.id);
-        expect(ids).not.toContain('style.css');
+    // -----------------------------------------------------------------------
+    // fullAcquire — local sources
+    // -----------------------------------------------------------------------
+
+    describe('fullAcquire (local)', () => {
+        it('returns matching files as ContentItems', async () => {
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.fullAcquire();
+            expect(result.items.length).toBe(3);
+            expect(result.removedIds).toEqual([]);
+            expect(result.stateToken).toMatch(/^local-/);
+            const ids = result.items.map(i => i.id).sort();
+            expect(ids).toContain('readme.md');
+            expect(ids).toContain('guide.md');
+            expect(ids).toContain('sub/nested.md');
+            const readme = result.items.find(i => i.id === 'readme.md');
+            expect(readme?.content).toBe('# Hello\nWorld');
+        });
+
+        it('excludes non-matching patterns', async () => {
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.fullAcquire();
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('style.css');
+        });
+
+        it('filters out low-semantic-value content', async () => {
+            const svgContent = 'M0,0 L100,100 C50,50 200.5,300.7 '.repeat(100);
+            await fs.promises.writeFile(path.join(tmpDir, 'data.md'), svgContent);
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.fullAcquire();
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('data.md');
+        });
+
+        it('throws when local path does not exist', async () => {
+            const provider = new FileDataProvider(
+                makeLocalConfig({ path: '/nonexistent/surely/missing' }),
+                { cloneDir: '/tmp/test-clones' },
+            );
+            await expect(provider.fullAcquire()).rejects.toThrow('Local source path does not exist');
+        });
+
+        it('skips default skip_dirs (node_modules, dist, build, .git)', async () => {
+            for (const dir of ['node_modules', 'dist', 'build', '.git']) {
+                await fs.promises.mkdir(path.join(tmpDir, dir), { recursive: true });
+                await fs.promises.writeFile(path.join(tmpDir, dir, 'file.md'), '# Skipped');
+            }
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.fullAcquire();
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('node_modules/file.md');
+            expect(ids).not.toContain('dist/file.md');
+            expect(ids).not.toContain('build/file.md');
+            expect(ids).not.toContain('.git/file.md');
+        });
+
+        it('handles exclude_patterns', async () => {
+            const provider = new FileDataProvider(
+                makeLocalConfig({ exclude_patterns: ['**/nested.md'] }),
+                { cloneDir: '/tmp/test-clones' },
+            );
+            const result = await provider.fullAcquire();
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('sub/nested.md');
+            expect(ids).toContain('readme.md');
+        });
+
+        it('handles file read errors gracefully', async () => {
+            // Create a file then make it unreadable
+            const unreadable = path.join(tmpDir, 'unreadable.md');
+            await fs.promises.writeFile(unreadable, '# Secret');
+            await fs.promises.chmod(unreadable, 0o000);
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const consoleSpy = vi.spyOn(console, 'error').mockImplementation(() => {});
+            const result = await provider.fullAcquire();
+            // Should still return other files, not crash
+            expect(result.items.length).toBeGreaterThanOrEqual(3);
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('unreadable.md');
+            consoleSpy.mockRestore();
+            // Restore permissions for cleanup
+            await fs.promises.chmod(unreadable, 0o644);
+        });
     });
 
-    it('fullAcquire filters out low-semantic-value content', async () => {
-        const svgContent = 'M0,0 L100,100 C50,50 200.5,300.7 '.repeat(100);
-        await fs.promises.writeFile(path.join(tmpDir, 'data.md'), svgContent);
-        const provider = new FileDataProvider(makeConfig(), { cloneDir: '/tmp/test-clones' });
-        const result = await provider.fullAcquire();
-        const ids = result.items.map(i => i.id);
-        expect(ids).not.toContain('data.md');
+    // -----------------------------------------------------------------------
+    // fullAcquire — git (remote) sources
+    // -----------------------------------------------------------------------
+
+    describe('fullAcquire (git)', () => {
+        it('clones a repo and walks the configured path', async () => {
+            // Set up the cloneDir so it exists, and create the expected repo structure
+            const cloneDir = path.join(tmpDir, 'clones');
+            await fs.promises.mkdir(cloneDir, { recursive: true });
+
+            const repoDir = path.join(cloneDir, 'repo');
+            const docsDir = path.join(repoDir, 'docs');
+            await fs.promises.mkdir(docsDir, { recursive: true });
+            await fs.promises.writeFile(path.join(docsDir, 'index.md'), '# Index');
+            // Create .git so ensureRepo sees existing clone
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.fullAcquire();
+
+            expect(result.stateToken).toBe('abc123');
+            expect(result.items.length).toBe(1);
+            expect(result.items[0].id).toBe('docs/index.md');
+        });
+
+        it('returns empty items when walkRoot does not exist', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            await fs.promises.mkdir(cloneDir, { recursive: true });
+
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+            // No docs/ subdirectory — walkRoot won't exist
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.fullAcquire();
+
+            expect(result.items).toEqual([]);
+            expect(result.removedIds).toEqual([]);
+            expect(result.stateToken).toBe('abc123');
+            warnSpy.mockRestore();
+        });
+
+        it('uses github token in authenticated URL', async () => {
+            const { simpleGit } = await import('simple-git');
+
+            const cloneDir = path.join(tmpDir, 'clones');
+            await fs.promises.mkdir(cloneDir, { recursive: true });
+            // No .git dir so it will attempt a fresh clone
+            mockGitInstance.clone.mockResolvedValue(undefined);
+
+            const provider = new FileDataProvider(
+                makeGitConfig(),
+                { cloneDir, githubToken: 'ghp_secret123' },
+            );
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            try {
+                await provider.fullAcquire();
+            } catch {
+                // May fail because cloned dir won't actually exist, that's fine
+            }
+
+            // The clone call should use the authenticated URL
+            expect(mockGitInstance.clone).toHaveBeenCalledWith(
+                'https://x-access-token:ghp_secret123@github.com/org/repo.git',
+                'repo',
+                expect.any(Array),
+            );
+            warnSpy.mockRestore();
+        });
+
+        it('passes --branch flag when config has branch', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            await fs.promises.mkdir(cloneDir, { recursive: true });
+            mockGitInstance.clone.mockResolvedValue(undefined);
+
+            const provider = new FileDataProvider(
+                makeGitConfig({ branch: 'develop' }),
+                { cloneDir },
+            );
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            try {
+                await provider.fullAcquire();
+            } catch {
+                // Clone won't create real dir
+            }
+
+            expect(mockGitInstance.clone).toHaveBeenCalledWith(
+                expect.any(String),
+                'repo',
+                ['--depth=1', '--branch', 'develop'],
+            );
+            warnSpy.mockRestore();
+        });
+
+        it('re-clones when pull fails (corrupted repo)', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+
+            mockGitInstance.pull.mockRejectedValueOnce(new Error('corrupted'));
+            mockGitInstance.clone.mockResolvedValue(undefined);
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+
+            try {
+                await provider.fullAcquire();
+            } catch {
+                // May fail downstream
+            }
+
+            expect(mockGitInstance.clone).toHaveBeenCalled();
+            warnSpy.mockRestore();
+        });
     });
 
-    it('getCurrentStateToken returns local hash for local sources', async () => {
-        const provider = new FileDataProvider(makeConfig(), { cloneDir: '/tmp/test-clones' });
-        const token = await provider.getCurrentStateToken();
-        expect(token).toMatch(/^local-/);
+    // -----------------------------------------------------------------------
+    // incrementalAcquire
+    // -----------------------------------------------------------------------
+
+    describe('incrementalAcquire', () => {
+        it('falls back to fullAcquire for local sources', async () => {
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.incrementalAcquire('old-token');
+            expect(result.items.length).toBe(3);
+        });
+
+        it('returns empty when HEAD matches lastStateToken (no new commits)', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+
+            mockGitInstance.revparse.mockResolvedValue('abc123');
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            expect(result.items).toEqual([]);
+            expect(result.removedIds).toEqual([]);
+            expect(result.stateToken).toBe('abc123');
+        });
+
+        it('returns changed files when HEAD differs from lastStateToken', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+            // Create a file that matches the diff output
+            await fs.promises.mkdir(path.join(repoDir, 'docs'), { recursive: true });
+            await fs.promises.writeFile(
+                path.join(repoDir, 'docs/updated.md'),
+                '# Updated content',
+            );
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.diff
+                .mockResolvedValueOnce('docs/updated.md\n')  // --name-only
+                .mockResolvedValueOnce('M\tdocs/updated.md\n');  // --name-status
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            expect(result.stateToken).toBe('def456');
+            expect(result.items.length).toBe(1);
+            expect(result.items[0].id).toBe('docs/updated.md');
+            expect(result.removedIds).toEqual([]);
+        });
+
+        it('reports deleted files in removedIds', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.diff
+                .mockResolvedValueOnce('docs/deleted.md\n')  // --name-only
+                .mockResolvedValueOnce('D\tdocs/deleted.md\n');  // --name-status
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            expect(result.stateToken).toBe('def456');
+            expect(result.items).toEqual([]);
+            expect(result.removedIds).toEqual(['docs/deleted.md']);
+        });
+
+        it('returns empty when no matching changes detected', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            // Changed file doesn't match *.md pattern
+            mockGitInstance.diff.mockResolvedValueOnce('src/index.ts\n');
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            expect(result.items).toEqual([]);
+            expect(result.removedIds).toEqual([]);
+        });
+
+        it('falls back to fullAcquire when git diff fails', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            const docsDir = path.join(repoDir, 'docs');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+            await fs.promises.mkdir(docsDir, { recursive: true });
+            await fs.promises.writeFile(path.join(docsDir, 'fallback.md'), '# Fallback');
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.diff.mockRejectedValueOnce(new Error('diff failed'));
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            // Should have fallen back to fullAcquire
+            expect(result.items.length).toBe(1);
+            expect(result.stateToken).toBe('def456');
+            warnSpy.mockRestore();
+        });
+
+        it('silently handles unshallow errors for already-unshallowed repos', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.fetch.mockRejectedValueOnce(
+                new Error('--unshallow on a complete repository does not make sense'),
+            );
+            mockGitInstance.diff
+                .mockResolvedValueOnce('')  // no changed files
+                .mockResolvedValueOnce('');
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            // Should not warn for expected unshallow error
+            const result = await provider.incrementalAcquire('abc123');
+
+            // Check that warn was NOT called with the unshallow message
+            const unshallowWarns = warnSpy.mock.calls.filter(
+                call => typeof call[0] === 'string' && call[0].includes('unshallow'),
+            );
+            expect(unshallowWarns).toHaveLength(0);
+            warnSpy.mockRestore();
+        });
+
+        it('warns on unexpected fetch --unshallow errors', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.fetch.mockRejectedValueOnce(
+                new Error('network timeout'),
+            );
+            mockGitInstance.diff
+                .mockResolvedValueOnce('')
+                .mockResolvedValueOnce('');
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            await provider.incrementalAcquire('abc123');
+
+            const fetchWarns = warnSpy.mock.calls.filter(
+                call => typeof call[0] === 'string' && call[0].includes('unshallow failed'),
+            );
+            expect(fetchWarns.length).toBeGreaterThan(0);
+            warnSpy.mockRestore();
+        });
+
+        it('skips files exceeding maxFileSize in incremental acquire', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+            await fs.promises.mkdir(path.join(repoDir, 'docs'), { recursive: true });
+            // Write a file larger than the default 100KB
+            await fs.promises.writeFile(
+                path.join(repoDir, 'docs/huge.md'),
+                'x'.repeat(200_000),
+            );
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.diff
+                .mockResolvedValueOnce('docs/huge.md\n')
+                .mockResolvedValueOnce('M\tdocs/huge.md\n');
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            expect(result.items).toEqual([]);
+        });
+
+        it('skips low-semantic-value files in incremental acquire', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+            await fs.promises.mkdir(path.join(repoDir, 'docs'), { recursive: true });
+            const svgContent = 'M0,0 L100,100 C50,50 200.5,300.7 '.repeat(100);
+            await fs.promises.writeFile(path.join(repoDir, 'docs/svg.md'), svgContent);
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.diff
+                .mockResolvedValueOnce('docs/svg.md\n')
+                .mockResolvedValueOnce('M\tdocs/svg.md\n');
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            expect(result.items).toEqual([]);
+        });
+
+        it('skips files that no longer exist on disk', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(path.join(repoDir, '.git'), { recursive: true });
+            // docs/gone.md is listed as modified but doesn't exist on disk
+
+            mockGitInstance.revparse.mockResolvedValue('def456');
+            mockGitInstance.diff
+                .mockResolvedValueOnce('docs/gone.md\n')
+                .mockResolvedValueOnce('M\tdocs/gone.md\n');
+
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const result = await provider.incrementalAcquire('abc123');
+
+            expect(result.items).toEqual([]);
+        });
     });
 
-    it('getCurrentStateToken returns null when path does not exist', async () => {
-        const provider = new FileDataProvider(
-            makeConfig({ path: '/nonexistent/path' }),
-            { cloneDir: '/tmp/test-clones' },
-        );
-        const token = await provider.getCurrentStateToken();
-        expect(token).toBeNull();
+    // -----------------------------------------------------------------------
+    // getCurrentStateToken
+    // -----------------------------------------------------------------------
+
+    describe('getCurrentStateToken', () => {
+        it('returns local hash for local sources', async () => {
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const token = await provider.getCurrentStateToken();
+            expect(token).toMatch(/^local-/);
+        });
+
+        it('returns null when local path does not exist', async () => {
+            const provider = new FileDataProvider(
+                makeLocalConfig({ path: '/nonexistent/path' }),
+                { cloneDir: '/tmp/test-clones' },
+            );
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBeNull();
+        });
+
+        it('returns consistent hashes for unchanged local files', async () => {
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const token1 = await provider.getCurrentStateToken();
+            const token2 = await provider.getCurrentStateToken();
+            expect(token1).toBe(token2);
+        });
+
+        it('returns different hash when local files change', async () => {
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const token1 = await provider.getCurrentStateToken();
+            // Wait a tiny bit to ensure mtime changes
+            await new Promise(r => setTimeout(r, 50));
+            await fs.promises.writeFile(path.join(tmpDir, 'readme.md'), '# Changed');
+            const token2 = await provider.getCurrentStateToken();
+            expect(token1).not.toBe(token2);
+        });
+
+        it('uses ls-remote for git sources', async () => {
+            mockGitInstance.listRemote.mockResolvedValue('deadbeef\tHEAD');
+
+            const provider = new FileDataProvider(
+                makeGitConfig(),
+                { cloneDir: '/tmp/test-clones' },
+            );
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBe('deadbeef');
+        });
+
+        it('uses authenticated URL for ls-remote when githubToken provided', async () => {
+            mockGitInstance.listRemote.mockResolvedValue('deadbeef\tHEAD');
+
+            const provider = new FileDataProvider(
+                makeGitConfig(),
+                { cloneDir: '/tmp/test-clones', githubToken: 'ghp_tok' },
+            );
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBe('deadbeef');
+            expect(mockGitInstance.listRemote).toHaveBeenCalledWith(
+                ['https://x-access-token:ghp_tok@github.com/org/repo.git', 'HEAD'],
+            );
+        });
+
+        it('falls back to local HEAD when ls-remote fails and clone exists', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(repoDir, { recursive: true });
+
+            mockGitInstance.listRemote.mockRejectedValue(new Error('network error'));
+            mockGitInstance.revparse.mockResolvedValue('localhead');
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const token = await provider.getCurrentStateToken();
+
+            expect(token).toBe('localhead');
+            warnSpy.mockRestore();
+        });
+
+        it('returns null when ls-remote fails and clone dir does not exist', async () => {
+            mockGitInstance.listRemote.mockRejectedValue(new Error('network error'));
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(
+                makeGitConfig(),
+                { cloneDir: '/tmp/nonexistent-clones-xyz' },
+            );
+            const token = await provider.getCurrentStateToken();
+
+            expect(token).toBeNull();
+            warnSpy.mockRestore();
+        });
+
+        it('returns null when ls-remote and local HEAD both fail', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            const repoDir = path.join(cloneDir, 'repo');
+            await fs.promises.mkdir(repoDir, { recursive: true });
+
+            mockGitInstance.listRemote.mockRejectedValue(new Error('network error'));
+            mockGitInstance.revparse.mockRejectedValue(new Error('not a git repo'));
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+            const token = await provider.getCurrentStateToken();
+
+            expect(token).toBeNull();
+            warnSpy.mockRestore();
+        });
+
+        it('returns null when ls-remote returns empty string', async () => {
+            mockGitInstance.listRemote.mockResolvedValue('');
+
+            const provider = new FileDataProvider(
+                makeGitConfig(),
+                { cloneDir: '/tmp/test-clones' },
+            );
+            const token = await provider.getCurrentStateToken();
+            expect(token).toBeNull();
+        });
     });
 
-    it('incrementalAcquire falls back to fullAcquire for local sources', async () => {
-        const provider = new FileDataProvider(makeConfig(), { cloneDir: '/tmp/test-clones' });
-        const result = await provider.incrementalAcquire('old-token');
-        expect(result.items.length).toBe(3);
+    // -----------------------------------------------------------------------
+    // walkFiles edge cases
+    // -----------------------------------------------------------------------
+
+    describe('walkFiles (via fullAcquire)', () => {
+        it('handles unreadable directories gracefully', async () => {
+            const unreadableDir = path.join(tmpDir, 'secret');
+            await fs.promises.mkdir(unreadableDir);
+            await fs.promises.writeFile(path.join(unreadableDir, 'file.md'), '# Secret');
+            await fs.promises.chmod(unreadableDir, 0o000);
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.fullAcquire();
+
+            // Should still return other files
+            expect(result.items.length).toBeGreaterThanOrEqual(3);
+            warnSpy.mockRestore();
+            // Restore permissions for cleanup
+            await fs.promises.chmod(unreadableDir, 0o755);
+        });
+
+        it('handles stat errors on individual files during walk', async () => {
+            // Create a broken symlink — readdir will list it but stat will fail
+            const brokenLink = path.join(tmpDir, 'broken.md');
+            await fs.promises.symlink('/nonexistent/target', brokenLink);
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.fullAcquire();
+
+            // Should still return the valid files, skipping the broken symlink
+            expect(result.items.length).toBeGreaterThanOrEqual(3);
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('broken.md');
+            warnSpy.mockRestore();
+        });
+
+        it('skips files exceeding max_file_size during walk', async () => {
+            await fs.promises.writeFile(path.join(tmpDir, 'huge.md'), 'x'.repeat(200_000));
+            const provider = new FileDataProvider(makeLocalConfig(), { cloneDir: '/tmp/test-clones' });
+            const result = await provider.fullAcquire();
+            const ids = result.items.map(i => i.id);
+            expect(ids).not.toContain('huge.md');
+        });
+    });
+
+    // -----------------------------------------------------------------------
+    // repoNameFromUrl (tested indirectly via git operations)
+    // -----------------------------------------------------------------------
+
+    describe('repoNameFromUrl (indirect)', () => {
+        it('strips .git suffix from repo URL', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            await fs.promises.mkdir(cloneDir, { recursive: true });
+
+            const provider = new FileDataProvider(
+                makeGitConfig({ repo: 'https://github.com/org/my-repo.git' }),
+                { cloneDir },
+            );
+            mockGitInstance.clone.mockResolvedValue(undefined);
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                await provider.fullAcquire();
+            } catch {
+                // Expected
+            }
+
+            // Clone should use "my-repo" as the directory name (without .git)
+            expect(mockGitInstance.clone).toHaveBeenCalledWith(
+                expect.any(String),
+                'my-repo',
+                expect.any(Array),
+            );
+            warnSpy.mockRestore();
+        });
+
+        it('handles URLs without .git suffix', async () => {
+            const cloneDir = path.join(tmpDir, 'clones');
+            await fs.promises.mkdir(cloneDir, { recursive: true });
+
+            const provider = new FileDataProvider(
+                makeGitConfig({ repo: 'https://github.com/org/my-repo' }),
+                { cloneDir },
+            );
+            mockGitInstance.clone.mockResolvedValue(undefined);
+
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+            try {
+                await provider.fullAcquire();
+            } catch {
+                // Expected
+            }
+
+            expect(mockGitInstance.clone).toHaveBeenCalledWith(
+                expect.any(String),
+                'my-repo',
+                expect.any(Array),
+            );
+            warnSpy.mockRestore();
+        });
     });
 });

--- a/src/__tests__/github-webhook.test.ts
+++ b/src/__tests__/github-webhook.test.ts
@@ -1,0 +1,394 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import crypto from 'node:crypto';
+import { createWebhookHandler, type ReindexOrchestrator } from '../webhooks/github.js';
+
+// Mock config
+const mockGetConfig = vi.fn();
+const mockGetServerConfig = vi.fn();
+
+vi.mock('../config.js', () => ({
+    getConfig: (...args: unknown[]) => mockGetConfig(...args),
+    getServerConfig: (...args: unknown[]) => mockGetServerConfig(...args),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const WEBHOOK_SECRET = 'test-webhook-secret-123';
+
+function sign(body: Buffer, secret: string = WEBHOOK_SECRET): string {
+    return 'sha256=' + crypto.createHmac('sha256', secret).update(body).digest('hex');
+}
+
+function makePushPayload(overrides: Record<string, unknown> = {}) {
+    return {
+        ref: 'refs/heads/main',
+        after: 'abc12345deadbeef',
+        before: '0000000000000000',
+        repository: {
+            clone_url: 'https://github.com/org/repo.git',
+            default_branch: 'main',
+            full_name: 'org/repo',
+        },
+        commits: [
+            {
+                added: ['docs/guide.md'],
+                modified: ['docs/index.md'],
+                removed: [],
+            },
+        ],
+        ...overrides,
+    };
+}
+
+function mockReqRes(
+    body: object | string,
+    headers: Record<string, string> = {},
+    asBuffer = true,
+) {
+    const bodyStr = typeof body === 'string' ? body : JSON.stringify(body);
+    const rawBody = asBuffer ? Buffer.from(bodyStr) : bodyStr;
+    const buf = Buffer.isBuffer(rawBody) ? rawBody : Buffer.from(bodyStr);
+
+    const req = {
+        body: asBuffer ? buf : bodyStr,
+        headers: {
+            'x-hub-signature-256': sign(buf),
+            'x-github-event': 'push',
+            ...headers,
+        },
+    } as any;
+
+    const res = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn().mockReturnThis(),
+    } as any;
+
+    return { req, res };
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('GitHub webhook handler', () => {
+    let orchestrator: ReindexOrchestrator;
+    let handler: ReturnType<typeof createWebhookHandler>;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+
+        mockGetConfig.mockReturnValue({
+            githubWebhookSecret: WEBHOOK_SECRET,
+        });
+
+        mockGetServerConfig.mockReturnValue({
+            webhook: {
+                repo_sources: {
+                    'org/repo': ['docs-source'],
+                },
+                path_triggers: {
+                    'docs-source': ['docs/'],
+                },
+            },
+        });
+
+        orchestrator = { queueIncrementalReindex: vi.fn() };
+        handler = createWebhookHandler(orchestrator);
+    });
+
+    // -- Signature verification -------------------------------------------
+
+    describe('signature verification', () => {
+        it('rejects when req.body is not a Buffer', async () => {
+            const { req, res } = mockReqRes(makePushPayload(), {}, false);
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(500);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ error: expect.stringContaining('raw body') }),
+            );
+        });
+
+        it('rejects when webhook secret is not configured', async () => {
+            mockGetConfig.mockReturnValue({ githubWebhookSecret: '' });
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(403);
+        });
+
+        it('rejects when webhook secret is undefined', async () => {
+            mockGetConfig.mockReturnValue({ githubWebhookSecret: undefined });
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(403);
+        });
+
+        it('rejects when webhook secret is whitespace-only', async () => {
+            mockGetConfig.mockReturnValue({ githubWebhookSecret: '   ' });
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(403);
+        });
+
+        it('rejects when x-hub-signature-256 header is missing', async () => {
+            const payload = makePushPayload();
+            const buf = Buffer.from(JSON.stringify(payload));
+            const req = {
+                body: buf,
+                headers: { 'x-github-event': 'push' },
+            } as any;
+            const res = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() } as any;
+
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(401);
+        });
+
+        it('rejects when signature is invalid', async () => {
+            const payload = makePushPayload();
+            const { req, res } = mockReqRes(payload, {
+                'x-hub-signature-256': 'sha256=0000000000000000000000000000000000000000000000000000000000000000',
+            });
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(401);
+        });
+
+        it('rejects when signature has wrong length', async () => {
+            const payload = makePushPayload();
+            const { req, res } = mockReqRes(payload, {
+                'x-hub-signature-256': 'sha256=tooshort',
+            });
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(401);
+        });
+
+        it('accepts a valid signature', async () => {
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            // Should not be 401 or 403
+            expect(res.status).not.toHaveBeenCalledWith(401);
+            expect(res.status).not.toHaveBeenCalledWith(403);
+        });
+    });
+
+    // -- Event routing ----------------------------------------------------
+
+    describe('event routing', () => {
+        it('ignores non-push events (e.g. ping)', async () => {
+            const { req, res } = mockReqRes(makePushPayload(), {
+                'x-github-event': 'ping',
+            });
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ ignored: true, reason: 'not a push event' }),
+            );
+            expect(orchestrator.queueIncrementalReindex).not.toHaveBeenCalled();
+        });
+
+        it('ignores issues events', async () => {
+            const { req, res } = mockReqRes(makePushPayload(), {
+                'x-github-event': 'issues',
+            });
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ ignored: true }),
+            );
+        });
+    });
+
+    // -- Payload parsing --------------------------------------------------
+
+    describe('payload parsing', () => {
+        it('rejects malformed JSON', async () => {
+            const badBody = Buffer.from('not json at all');
+            const req = {
+                body: badBody,
+                headers: {
+                    'x-hub-signature-256': sign(badBody),
+                    'x-github-event': 'push',
+                },
+            } as any;
+            const res = { status: vi.fn().mockReturnThis(), json: vi.fn().mockReturnThis() } as any;
+
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(400);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ error: 'Malformed JSON payload' }),
+            );
+        });
+    });
+
+    // -- Branch filtering -------------------------------------------------
+
+    describe('branch filtering', () => {
+        it('ignores pushes to non-default branches', async () => {
+            const payload = makePushPayload({ ref: 'refs/heads/feature/my-branch' });
+            const { req, res } = mockReqRes(payload);
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ ignored: true, reason: 'not the default branch' }),
+            );
+            expect(orchestrator.queueIncrementalReindex).not.toHaveBeenCalled();
+        });
+
+        it('processes pushes to the default branch', async () => {
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ queued: true }));
+        });
+    });
+
+    // -- Repo-to-source mapping -------------------------------------------
+
+    describe('repo → source mapping', () => {
+        it('ignores repos not in webhook config', async () => {
+            const payload = makePushPayload({
+                repository: {
+                    clone_url: 'https://github.com/other/repo.git',
+                    default_branch: 'main',
+                    full_name: 'other/repo',
+                },
+            });
+            const { req, res } = mockReqRes(payload);
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ ignored: true, reason: 'repo not in webhook config' }),
+            );
+            expect(orchestrator.queueIncrementalReindex).not.toHaveBeenCalled();
+        });
+
+        it('works when webhook config has no repo_sources', async () => {
+            mockGetServerConfig.mockReturnValue({ webhook: {} });
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ ignored: true, reason: 'repo not in webhook config' }),
+            );
+        });
+
+        it('works when webhook config is undefined', async () => {
+            mockGetServerConfig.mockReturnValue({});
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ ignored: true, reason: 'repo not in webhook config' }),
+            );
+        });
+    });
+
+    // -- Path-based filtering (path_triggers) -----------------------------
+
+    describe('path_triggers filtering', () => {
+        it('queues reindex when committed files match path triggers', async () => {
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ queued: true });
+            expect(orchestrator.queueIncrementalReindex).toHaveBeenCalledWith(
+                'https://github.com/org/repo.git',
+            );
+        });
+
+        it('ignores push when no committed files match path triggers', async () => {
+            const payload = makePushPayload({
+                commits: [
+                    {
+                        added: ['src/index.ts'],
+                        modified: ['src/main.ts'],
+                        removed: [],
+                    },
+                ],
+            });
+            const { req, res } = mockReqRes(payload);
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith(
+                expect.objectContaining({ ignored: true, reason: 'no path triggers matched' }),
+            );
+            expect(orchestrator.queueIncrementalReindex).not.toHaveBeenCalled();
+        });
+
+        it('queues reindex when source has no path triggers (match all)', async () => {
+            mockGetServerConfig.mockReturnValue({
+                webhook: {
+                    repo_sources: { 'org/repo': ['all-source'] },
+                    path_triggers: {},
+                },
+            });
+            const payload = makePushPayload({
+                commits: [
+                    { added: ['any/random/file.txt'], modified: [], removed: [] },
+                ],
+            });
+            const { req, res } = mockReqRes(payload);
+            await handler(req, res);
+            expect(res.json).toHaveBeenCalledWith({ queued: true });
+            expect(orchestrator.queueIncrementalReindex).toHaveBeenCalled();
+        });
+
+        it('matches removed files against path triggers', async () => {
+            const payload = makePushPayload({
+                commits: [
+                    { added: [], modified: [], removed: ['docs/old-page.md'] },
+                ],
+            });
+            const { req, res } = mockReqRes(payload);
+            await handler(req, res);
+            expect(res.json).toHaveBeenCalledWith({ queued: true });
+        });
+
+        it('checks multiple commits for path matches', async () => {
+            const payload = makePushPayload({
+                commits: [
+                    { added: ['src/index.ts'], modified: [], removed: [] },
+                    { added: [], modified: ['docs/guide.md'], removed: [] },
+                ],
+            });
+            const { req, res } = mockReqRes(payload);
+            await handler(req, res);
+            expect(res.json).toHaveBeenCalledWith({ queued: true });
+        });
+
+        it('handles multiple sources for same repo, only one matching', async () => {
+            mockGetServerConfig.mockReturnValue({
+                webhook: {
+                    repo_sources: { 'org/repo': ['src-source', 'docs-source'] },
+                    path_triggers: {
+                        'src-source': ['src/'],
+                        'docs-source': ['docs/'],
+                    },
+                },
+            });
+            const payload = makePushPayload({
+                commits: [
+                    { added: ['docs/new.md'], modified: [], removed: [] },
+                ],
+            });
+            const { req, res } = mockReqRes(payload);
+            await handler(req, res);
+            expect(res.json).toHaveBeenCalledWith({ queued: true });
+            // Should only call once even though there are two sources
+            expect(orchestrator.queueIncrementalReindex).toHaveBeenCalledTimes(1);
+        });
+    });
+
+    // -- Happy path end-to-end --------------------------------------------
+
+    describe('happy path', () => {
+        it('queues reindex and returns 200 for valid push', async () => {
+            const { req, res } = mockReqRes(makePushPayload());
+            await handler(req, res);
+            expect(res.status).toHaveBeenCalledWith(200);
+            expect(res.json).toHaveBeenCalledWith({ queued: true });
+            expect(orchestrator.queueIncrementalReindex).toHaveBeenCalledWith(
+                'https://github.com/org/repo.git',
+            );
+        });
+    });
+});

--- a/src/__tests__/knowledge-mcp.test.ts
+++ b/src/__tests__/knowledge-mcp.test.ts
@@ -1,0 +1,442 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { KnowledgeToolConfig, FaqChunkResult, ChunkResult } from '../types.js';
+
+vi.mock('../db/queries.js', () => ({
+    getFaqChunks: vi.fn(),
+    searchChunks: vi.fn(),
+}));
+
+import { registerKnowledgeTool } from '../mcp/tools/knowledge.js';
+import { getFaqChunks, searchChunks } from '../db/queries.js';
+
+const mockGetFaqChunks = vi.mocked(getFaqChunks);
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockEmbed = vi.fn();
+
+function makeFaqResult(overrides: Partial<FaqChunkResult> = {}): FaqChunkResult {
+    return {
+        id: 1,
+        source_name: 'slack-support',
+        source_url: 'https://slack.com/archives/C123/p456',
+        title: 'How to configure headers?',
+        content: 'Q: How to configure headers?\n\nA: Use the headers property in the constructor.',
+        repo_url: null,
+        file_path: 'C123:456:0',
+        start_line: null,
+        end_line: null,
+        language: null,
+        similarity: 0.0,
+        metadata: { channel: 'C123', confidence: 0.85 },
+        confidence: 0.85,
+        ...overrides,
+    };
+}
+
+function makeChunkResult(overrides: Partial<ChunkResult> = {}): ChunkResult {
+    return {
+        id: 1,
+        source_name: 'slack-support',
+        source_url: 'https://slack.com/archives/C123/p456',
+        title: 'How to configure headers?',
+        content: 'Q: How to configure headers?\n\nA: Use the headers property.',
+        repo_url: null,
+        file_path: 'C123:456:0',
+        start_line: null,
+        end_line: null,
+        language: null,
+        similarity: 0.92,
+        ...overrides,
+    };
+}
+
+const toolConfig: KnowledgeToolConfig = {
+    name: 'get-faq',
+    type: 'knowledge',
+    description: 'Get FAQ knowledge base entries.',
+    sources: ['slack-support', 'discord-faq'],
+    min_confidence: 0.7,
+    default_limit: 20,
+    max_limit: 100,
+};
+
+// ── Browse mode (no query) ────────────────────────────────────────────────
+
+describe('knowledge tool browse mode (no query)', () => {
+    let client: Client;
+    let server: McpServer;
+
+    beforeAll(async () => {
+        server = new McpServer({ name: 'test-knowledge', version: '1.0.0' });
+        const embeddingClient = { embed: mockEmbed };
+        registerKnowledgeTool(server as never, embeddingClient as never, toolConfig);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        client = new Client({ name: 'test-client', version: '1.0.0' });
+        await client.connect(clientTransport);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    it('lists the knowledge tool with correct name and description', async () => {
+        const { tools } = await client.listTools();
+        const tool = tools.find(t => t.name === 'get-faq');
+        expect(tool).toBeDefined();
+        expect(tool!.description).toBe('Get FAQ knowledge base entries.');
+    });
+
+    it('returns FAQ entries when called without a query', async () => {
+        mockGetFaqChunks.mockResolvedValueOnce([
+            makeFaqResult({ title: 'How to authenticate?', confidence: 0.9 }),
+            makeFaqResult({ id: 2, title: 'How to paginate?', confidence: 0.8 }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: {},
+        });
+
+        expect(result.isError).toBeFalsy();
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('Q&A 1');
+        expect(text).toContain('QUESTION: How to authenticate?');
+        expect(text).toContain('Q&A 2');
+        expect(text).toContain('QUESTION: How to paginate?');
+
+        // Verify getFaqChunks called with config defaults
+        expect(mockGetFaqChunks).toHaveBeenCalledWith(
+            ['slack-support', 'discord-faq'],
+            0.7,
+            20,
+        );
+        // Should NOT call embed or searchChunks in browse mode
+        expect(mockEmbed).not.toHaveBeenCalled();
+        expect(mockSearchChunks).not.toHaveBeenCalled();
+    });
+
+    it('treats empty string query as browse mode', async () => {
+        mockGetFaqChunks.mockResolvedValueOnce([]);
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: '' },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toBe('No FAQ results found.');
+        expect(mockGetFaqChunks).toHaveBeenCalled();
+        expect(mockEmbed).not.toHaveBeenCalled();
+    });
+
+    it('treats whitespace-only query as browse mode', async () => {
+        mockGetFaqChunks.mockResolvedValueOnce([]);
+
+        await client.callTool({
+            name: 'get-faq',
+            arguments: { query: '   ' },
+        });
+
+        expect(mockGetFaqChunks).toHaveBeenCalled();
+        expect(mockEmbed).not.toHaveBeenCalled();
+    });
+
+    it('uses provided limit in browse mode', async () => {
+        mockGetFaqChunks.mockResolvedValueOnce([]);
+
+        await client.callTool({
+            name: 'get-faq',
+            arguments: { limit: 5 },
+        });
+
+        expect(mockGetFaqChunks).toHaveBeenCalledWith(
+            ['slack-support', 'discord-faq'],
+            0.7,
+            5,
+        );
+    });
+
+    it('uses provided min_confidence in browse mode', async () => {
+        mockGetFaqChunks.mockResolvedValueOnce([]);
+
+        await client.callTool({
+            name: 'get-faq',
+            arguments: { min_confidence: 0.9 },
+        });
+
+        expect(mockGetFaqChunks).toHaveBeenCalledWith(
+            ['slack-support', 'discord-faq'],
+            0.9,
+            20,
+        );
+    });
+});
+
+// ── Search mode (with query) ──────────────────────────────────────────────
+
+describe('knowledge tool search mode (with query)', () => {
+    let client: Client;
+    let server: McpServer;
+
+    beforeAll(async () => {
+        server = new McpServer({ name: 'test-knowledge-search', version: '1.0.0' });
+        const embeddingClient = { embed: mockEmbed };
+        registerKnowledgeTool(server as never, embeddingClient as never, toolConfig);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        client = new Client({ name: 'test-client', version: '1.0.0' });
+        await client.connect(clientTransport);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    it('embeds query and searches each source then merges with FAQ data', async () => {
+        const embedding = [0.1, 0.2, 0.3];
+        mockEmbed.mockResolvedValueOnce(embedding);
+
+        // searchChunks called once per source
+        mockSearchChunks
+            .mockResolvedValueOnce([makeChunkResult({ id: 10, similarity: 0.95 })])
+            .mockResolvedValueOnce([makeChunkResult({ id: 20, similarity: 0.85 })]);
+
+        // getFaqChunks returns FAQ metadata for cross-reference
+        mockGetFaqChunks.mockResolvedValueOnce([
+            makeFaqResult({ id: 10, confidence: 0.9, title: 'Matched FAQ' }),
+            makeFaqResult({ id: 20, confidence: 0.8, title: 'Another FAQ' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'how to auth' },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('Q&A 1');
+        expect(text).toContain('Matched FAQ');
+        expect(text).toContain('Q&A 2');
+
+        expect(mockEmbed).toHaveBeenCalledWith('how to auth');
+        // searchChunks called once for each source
+        expect(mockSearchChunks).toHaveBeenCalledTimes(2);
+        expect(mockSearchChunks).toHaveBeenCalledWith(embedding, 20, 'slack-support');
+        expect(mockSearchChunks).toHaveBeenCalledWith(embedding, 20, 'discord-faq');
+        // getFaqChunks called with confidence=0, limit=100 (effectiveLimit*5)
+        expect(mockGetFaqChunks).toHaveBeenCalledWith(
+            ['slack-support', 'discord-faq'],
+            0,
+            100,
+        );
+    });
+
+    it('filters out search results whose FAQ confidence is below threshold', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks
+            .mockResolvedValueOnce([
+                makeChunkResult({ id: 10, similarity: 0.95 }),
+                makeChunkResult({ id: 11, similarity: 0.90 }),
+            ])
+            .mockResolvedValueOnce([]);
+
+        mockGetFaqChunks.mockResolvedValueOnce([
+            makeFaqResult({ id: 10, confidence: 0.9, title: 'High Confidence' }),
+            makeFaqResult({ id: 11, confidence: 0.3, title: 'Low Confidence' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'test' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('High Confidence');
+        expect(text).not.toContain('Low Confidence');
+    });
+
+    it('returns empty FAQ results when no search results have FAQ metadata', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks
+            .mockResolvedValueOnce([makeChunkResult({ id: 99, similarity: 0.95 })])
+            .mockResolvedValueOnce([]);
+
+        // FAQ data does not include id=99
+        mockGetFaqChunks.mockResolvedValueOnce([
+            makeFaqResult({ id: 1, confidence: 0.9 }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'unmatched' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toBe('No FAQ results found.');
+    });
+
+    it('sorts merged results by similarity descending', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        // source 1 returns lower similarity
+        mockSearchChunks
+            .mockResolvedValueOnce([makeChunkResult({ id: 10, similarity: 0.70 })])
+            .mockResolvedValueOnce([makeChunkResult({ id: 20, similarity: 0.95 })]);
+
+        mockGetFaqChunks.mockResolvedValueOnce([
+            makeFaqResult({ id: 10, confidence: 0.9, title: 'Lower Sim' }),
+            makeFaqResult({ id: 20, confidence: 0.9, title: 'Higher Sim' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'test' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        // Higher similarity should come first (Q&A 1)
+        const higherIdx = text.indexOf('Higher Sim');
+        const lowerIdx = text.indexOf('Lower Sim');
+        expect(higherIdx).toBeLessThan(lowerIdx);
+    });
+
+    it('respects custom limit in search mode', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks
+            .mockResolvedValueOnce([])
+            .mockResolvedValueOnce([]);
+        mockGetFaqChunks.mockResolvedValueOnce([]);
+
+        await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'test', limit: 3 },
+        });
+
+        // searchChunks should use limit=3
+        expect(mockSearchChunks).toHaveBeenCalledWith(expect.anything(), 3, 'slack-support');
+        // getFaqChunks should use limit=15 (3*5)
+        expect(mockGetFaqChunks).toHaveBeenCalledWith(
+            ['slack-support', 'discord-faq'],
+            0,
+            15,
+        );
+    });
+
+    it('respects custom min_confidence in search mode', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks
+            .mockResolvedValueOnce([makeChunkResult({ id: 10, similarity: 0.9 })])
+            .mockResolvedValueOnce([]);
+
+        mockGetFaqChunks.mockResolvedValueOnce([
+            makeFaqResult({ id: 10, confidence: 0.85, title: 'Borderline' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'test', min_confidence: 0.9 },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        // 0.85 < 0.9, should be filtered out
+        expect(text).toBe('No FAQ results found.');
+    });
+});
+
+// ── Error handling ────────────────────────────────────────────────────────
+
+describe('knowledge tool error handling', () => {
+    let client: Client;
+    let server: McpServer;
+
+    beforeAll(async () => {
+        server = new McpServer({ name: 'test-knowledge-errors', version: '1.0.0' });
+        const embeddingClient = { embed: mockEmbed };
+        registerKnowledgeTool(server as never, embeddingClient as never, toolConfig);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        client = new Client({ name: 'test-client', version: '1.0.0' });
+        await client.connect(clientTransport);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    it('returns error response on browse mode DB failure', async () => {
+        mockGetFaqChunks.mockRejectedValueOnce(new Error('connection refused'));
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: {},
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('Error querying FAQ:');
+        expect(text).toContain('connection refused');
+    });
+
+    it('returns error response on embedding failure in search mode', async () => {
+        mockEmbed.mockRejectedValueOnce(new Error('API key invalid'));
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'test' },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('Error querying FAQ:');
+        expect(text).toContain('API key invalid');
+    });
+
+    it('returns error response on searchChunks failure in search mode', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockRejectedValueOnce(new Error('query timeout'));
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: { query: 'test' },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('Error querying FAQ:');
+        expect(text).toContain('query timeout');
+    });
+
+    it('handles non-Error thrown values', async () => {
+        mockGetFaqChunks.mockRejectedValueOnce('string error');
+
+        const result = await client.callTool({
+            name: 'get-faq',
+            arguments: {},
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('string error');
+    });
+});

--- a/src/__tests__/markdown-chunker.test.ts
+++ b/src/__tests__/markdown-chunker.test.ts
@@ -1,0 +1,309 @@
+import { describe, it, expect } from 'vitest';
+import { chunkMarkdown } from '../indexing/chunking/markdown.js';
+import type { SourceConfig } from '../types.js';
+
+// Helper to build a minimal SourceConfig for markdown chunking
+function mkConfig(overrides: { target_tokens?: number; overlap_tokens?: number } = {}): SourceConfig {
+    return {
+        name: 'test',
+        type: 'markdown',
+        path: '/tmp',
+        file_patterns: ['*.md'],
+        chunk: {
+            target_tokens: overrides.target_tokens,
+            overlap_tokens: overrides.overlap_tokens,
+        },
+    } as SourceConfig;
+}
+
+describe('chunkMarkdown', () => {
+    // ── Empty / whitespace input ────────────────────────────────────────
+
+    it('returns empty array for empty string', () => {
+        expect(chunkMarkdown('', 'test.md', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array for whitespace-only string', () => {
+        expect(chunkMarkdown('   \n\n  ', 'test.md', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array for null/undefined content', () => {
+        expect(chunkMarkdown(null as any, 'test.md', mkConfig())).toEqual([]);
+        expect(chunkMarkdown(undefined as any, 'test.md', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array when content is only frontmatter with no body', () => {
+        const content = '---\ntitle: Empty\n---\n';
+        expect(chunkMarkdown(content, 'test.md', mkConfig())).toEqual([]);
+    });
+
+    // ── Frontmatter parsing ─────────────────────────────────────────────
+
+    it('extracts title from frontmatter', () => {
+        const content = '---\ntitle: My Title\n---\n\nSome body text here.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks[0].title).toBe('My Title');
+    });
+
+    it('extracts title from quoted frontmatter', () => {
+        const content = '---\ntitle: "Quoted Title"\n---\n\nBody text.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].title).toBe('Quoted Title');
+    });
+
+    it('extracts title from single-quoted frontmatter', () => {
+        const content = "---\ntitle: 'Single Quoted'\n---\n\nBody text.";
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].title).toBe('Single Quoted');
+    });
+
+    it('falls back to first heading when no frontmatter title', () => {
+        const content = '# My Heading\n\nSome content.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].title).toBe('My Heading');
+    });
+
+    it('falls back to filename when no title or heading', () => {
+        const content = 'Just some plain text without any heading.';
+        const chunks = chunkMarkdown(content, 'docs/guide.md', mkConfig());
+        expect(chunks[0].title).toBe('guide.md');
+    });
+
+    it('falls back to full path when filename extraction fails', () => {
+        const content = 'Plain text.';
+        const chunks = chunkMarkdown(content, 'noext', mkConfig());
+        expect(chunks[0].title).toBe('noext');
+    });
+
+    it('strips frontmatter from chunk content', () => {
+        const content = '---\ntitle: Test\nother: value\n---\n\nActual body.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].content).not.toContain('---');
+        expect(chunks[0].content).toContain('Actual body');
+    });
+
+    // ── MDX stripping ───────────────────────────────────────────────────
+
+    it('strips import statements', () => {
+        const content = "import Foo from 'bar';\n\nSome text after the removed line.";
+        const chunks = chunkMarkdown(content, 'test.mdx', mkConfig());
+        expect(chunks[0].content).not.toContain("from 'bar'");
+        expect(chunks[0].content).toContain('Some text after the removed line');
+    });
+
+    it('strips self-closing JSX tags', () => {
+        const content = 'Before\n\n<Component prop="val" />\n\nAfter the component.';
+        const chunks = chunkMarkdown(content, 'test.mdx', mkConfig());
+        expect(chunks[0].content).not.toContain('<Component');
+        expect(chunks[0].content).toContain('Before');
+        expect(chunks[0].content).toContain('After the component');
+    });
+
+    it('strips JSX wrapper tags but keeps inner content', () => {
+        const content = '<Wrapper>\nInner content here\n</Wrapper>';
+        const chunks = chunkMarkdown(content, 'test.mdx', mkConfig());
+        expect(chunks[0].content).toContain('Inner content here');
+        expect(chunks[0].content).not.toContain('<Wrapper');
+        expect(chunks[0].content).not.toContain('</Wrapper');
+    });
+
+    it('strips nested JSX tags', () => {
+        const content = '<Outer><Inner>Deep content</Inner></Outer>';
+        const chunks = chunkMarkdown(content, 'test.mdx', mkConfig());
+        expect(chunks[0].content).toContain('Deep content');
+        expect(chunks[0].content).not.toContain('<Outer');
+        expect(chunks[0].content).not.toContain('<Inner');
+    });
+
+    // ── Basic chunking ──────────────────────────────────────────────────
+
+    it('returns a single chunk for small content', () => {
+        const content = '# Title\n\nShort paragraph.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].chunkIndex).toBe(0);
+        expect(chunks[0].content).toContain('Short paragraph');
+    });
+
+    it('sets chunkIndex sequentially', () => {
+        // Generate content large enough to produce multiple chunks
+        const sections = Array.from({ length: 10 }, (_, i) =>
+            `## Section ${i}\n\n${'Lorem ipsum dolor sit amet. '.repeat(100)}`
+        ).join('\n\n');
+        const chunks = chunkMarkdown(sections, 'test.md', mkConfig({ target_tokens: 100 }));
+        expect(chunks.length).toBeGreaterThan(1);
+        for (let i = 0; i < chunks.length; i++) {
+            expect(chunks[i].chunkIndex).toBe(i);
+        }
+    });
+
+    // ── Heading-based splitting ─────────────────────────────────────────
+
+    it('splits on h2 headings', () => {
+        const section = 'Word '.repeat(200);
+        const content = `## Section A\n\n${section}\n\n## Section B\n\n${section}`;
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig({ target_tokens: 100 }));
+        expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    it('splits on h3 headings when h2 sections are still large', () => {
+        const para = 'Word '.repeat(200);
+        const content = `## Big Section\n\n### Sub A\n\n${para}\n\n### Sub B\n\n${para}`;
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig({ target_tokens: 100 }));
+        expect(chunks.length).toBeGreaterThanOrEqual(2);
+    });
+
+    // ── Heading path tracking ───────────────────────────────────────────
+
+    it('tracks heading path for chunks under h2', () => {
+        const content = '## Getting Started\n\nContent under getting started.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].headingPath).toBeDefined();
+        // The heading path should include "Getting Started"
+        if (chunks[0].headingPath && chunks[0].headingPath.length > 0) {
+            expect(chunks[0].headingPath).toContain('Getting Started');
+        }
+    });
+
+    it('tracks nested heading hierarchy', () => {
+        const body = 'Content here. '.repeat(5);
+        const content = `## Parent\n\n### Child\n\n${body}`;
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        // At least one chunk should have heading path with Parent and Child
+        const lastChunk = chunks[chunks.length - 1];
+        expect(lastChunk.headingPath).toBeDefined();
+    });
+
+    // ── Code block preservation ─────────────────────────────────────────
+
+    it('does not split inside fenced code blocks', () => {
+        const codeBlock = '```python\ndef hello():\n    print("hello")\n\n\n    return True\n```';
+        const content = `## Intro\n\n${codeBlock}\n\nAfter code.`;
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        // At least one chunk should contain the complete code block
+        const hasCompleteBlock = chunks.some(c =>
+            c.content.includes('def hello()') && c.content.includes('return True')
+        );
+        expect(hasCompleteBlock).toBe(true);
+    });
+
+    it('preserves triple-backtick code blocks with language tag', () => {
+        const content = '# Title\n\n```typescript\nconst x = 1;\nconst y = 2;\n```\n\nEnd.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        const hasBlock = chunks.some(c => c.content.includes('const x = 1'));
+        expect(hasBlock).toBe(true);
+    });
+
+    // ── Overlap ─────────────────────────────────────────────────────────
+
+    it('applies overlap between chunks', () => {
+        const sections = Array.from({ length: 5 }, (_, i) =>
+            `## Section ${i}\n\n${'Word '.repeat(200)}`
+        ).join('\n\n');
+        const chunks = chunkMarkdown(sections, 'test.md', mkConfig({ target_tokens: 100, overlap_tokens: 20 }));
+        if (chunks.length >= 2) {
+            // Second chunk should contain some text from the end of the first chunk
+            // (overlap means shared content)
+            const firstEnd = chunks[0].content.slice(-50);
+            // At least some portion should appear in chunk 1
+            // This is a loose check since overlap is character-based and may break at word boundaries
+            expect(chunks[1].content.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('does not apply overlap when overlap_tokens is 0', () => {
+        const sections = Array.from({ length: 5 }, (_, i) =>
+            `## Section ${i}\n\n${'Word '.repeat(200)}`
+        ).join('\n\n');
+        const chunks = chunkMarkdown(sections, 'test.md', mkConfig({ target_tokens: 100, overlap_tokens: 0 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    // ── Chunk config parameters ─────────────────────────────────────────
+
+    it('uses default target_tokens when not specified', () => {
+        const content = 'Short content.';
+        const config = mkConfig();
+        delete (config as any).chunk.target_tokens;
+        const chunks = chunkMarkdown(content, 'test.md', config);
+        expect(chunks).toHaveLength(1);
+    });
+
+    it('respects custom target_tokens for smaller chunks', () => {
+        // Use paragraphs so the splitter has boundaries to split on
+        const para = 'Word '.repeat(100);
+        const content = Array.from({ length: 10 }, () => para).join('\n\n');
+        const smallChunks = chunkMarkdown(content, 'test.md', mkConfig({ target_tokens: 50 }));
+        const largeChunks = chunkMarkdown(content, 'test.md', mkConfig({ target_tokens: 500 }));
+        expect(smallChunks.length).toBeGreaterThan(largeChunks.length);
+    });
+
+    // ── Paragraph splitting ─────────────────────────────────────────────
+
+    it('splits on paragraph boundaries when headings are not enough', () => {
+        const paragraphs = Array.from({ length: 20 }, (_, i) =>
+            `Paragraph ${i}: ${'Word '.repeat(50)}`
+        ).join('\n\n');
+        const chunks = chunkMarkdown(paragraphs, 'test.md', mkConfig({ target_tokens: 100 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    // ── Special characters ──────────────────────────────────────────────
+
+    it('handles content with special regex characters', () => {
+        const content = '## Title\n\nContent with $pecial ch@racters: [brackets] (parens) {braces} *stars*';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        expect(chunks[0].content).toContain('$pecial');
+    });
+
+    it('handles content with unicode characters', () => {
+        const content = '## Unicode\n\nContent with emoji: \u{1F680}\u{1F30D}\u{1F4DA} and CJK: \u4F60\u597D\u4E16\u754C';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].content).toContain('\u{1F680}');
+    });
+
+    // ── Windows line endings ────────────────────────────────────────────
+
+    it('handles CRLF line endings in frontmatter', () => {
+        const content = '---\r\ntitle: CRLF Test\r\n---\r\n\r\nBody text.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].title).toBe('CRLF Test');
+        expect(chunks[0].content).toContain('Body text');
+    });
+
+    // ── Line splitting fallback ─────────────────────────────────────────
+
+    it('falls back to line splitting for very long paragraphs', () => {
+        // Single paragraph with many lines but no headings or double newlines
+        const lines = Array.from({ length: 50 }, (_, i) => `Line ${i} with some content.`).join('\n');
+        const chunks = chunkMarkdown(lines, 'test.md', mkConfig({ target_tokens: 20 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    // ── Very long single line ───────────────────────────────────────────
+
+    it('handles a very long single line', () => {
+        const content = 'A'.repeat(10000);
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig({ target_tokens: 50 }));
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        // Content should be preserved even if it cannot be split further
+    });
+
+    // ── Multiple frontmatter fields ─────────────────────────────────────
+
+    it('handles frontmatter with many fields', () => {
+        const content = '---\ntitle: Multi\nauthor: Test\ndate: 2024-01-01\ntags: [a, b]\n---\n\nBody.';
+        const chunks = chunkMarkdown(content, 'test.md', mkConfig());
+        expect(chunks[0].title).toBe('Multi');
+    });
+
+    // ── Content after MDX stripping is empty ────────────────────────────
+
+    it('returns empty when content after MDX stripping is only whitespace', () => {
+        const content = "import Foo from 'bar';\nimport Baz from 'qux';";
+        const chunks = chunkMarkdown(content, 'test.mdx', mkConfig());
+        expect(chunks).toEqual([]);
+    });
+});

--- a/src/__tests__/notion-api.test.ts
+++ b/src/__tests__/notion-api.test.ts
@@ -154,6 +154,14 @@ describe('NotionApiClient', () => {
             expect(md).toContain('> **💡** Important note');
         });
 
+        it('converts callout with no icon', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('callout', { callout: { rich_text: richText('No icon callout'), icon: null } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('> **** No icon callout');
+        });
+
         it('converts code block with language', async () => {
             mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
                 block('code', { code: { rich_text: richText('const x = 1;'), language: 'typescript' } }),
@@ -178,12 +186,28 @@ describe('NotionApiClient', () => {
             expect(md).toContain('[Example](https://example.com)');
         });
 
+        it('converts bookmark with no caption to [url](url)', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('bookmark', { bookmark: { url: 'https://example.com' } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('[https://example.com](https://example.com)');
+        });
+
         it('converts equation to $$expression$$', async () => {
             mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
                 block('equation', { equation: { expression: 'E = mc^2' } }),
             ]));
             const md = await client.getPageContent('page-1');
             expect(md).toContain('$$E = mc^2$$');
+        });
+
+        it('converts image with file URL', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('image', { image: { type: 'file', file: { url: 'https://s3.aws.com/notion/pic.png' }, caption: richText('Uploaded pic') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('![Uploaded pic](https://s3.aws.com/notion/pic.png)');
         });
 
         it('converts image with external URL', async () => {
@@ -249,6 +273,22 @@ describe('NotionApiClient', () => {
             expect(md).toContain('| Header A | Header B |');
             expect(md).toContain('| --- | --- |');
             expect(md).toContain('| Cell 1 | Cell 2 |');
+        });
+
+        it('converts table without column header (no separator row)', async () => {
+            const tableBlock = block('table', {
+                table: { has_column_header: false, has_row_header: false, table_width: 2 },
+            }, true);
+            mockBlocksChildrenList
+                .mockResolvedValueOnce(blocksResponse([tableBlock]))
+                .mockResolvedValueOnce(blocksResponse([
+                    block('table_row', { table_row: { cells: [richText('A1'), richText('B1')] } }),
+                    block('table_row', { table_row: { cells: [richText('A2'), richText('B2')] } }),
+                ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('| A1 | B1 |');
+            expect(md).toContain('| A2 | B2 |');
+            expect(md).not.toContain('| --- | --- |');
         });
     });
 
@@ -668,6 +708,114 @@ describe('NotionApiClient', () => {
             expect(result).not.toHaveProperty('Relation');
             expect(result).not.toHaveProperty('CreatedBy');
             expect(result).not.toHaveProperty('EditedBy');
+        });
+    });
+
+    // ── MAX_PAGES safety bound ───────────────────────────────────────────
+
+    describe('MAX_PAGES safety bound', () => {
+        it('searchPages stops paginating at MAX_PAGES (100)', async () => {
+            // Return has_more=true for 100 pages, then it should stop
+            for (let i = 0; i < 100; i++) {
+                mockSearch.mockResolvedValueOnce({
+                    results: [notionPage(`p${i}`, `Page ${i}`, '2024-06-01T00:00:00Z')],
+                    has_more: true,
+                    next_cursor: `cursor-${i + 1}`,
+                });
+            }
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const pages = await client.searchPages();
+
+            expect(pages).toHaveLength(100);
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('searchPages hit max pages'));
+            // Should NOT have made a 101st call
+            expect(mockSearch).toHaveBeenCalledTimes(100);
+            warnSpy.mockRestore();
+        });
+
+        it('queryDatabase stops paginating at MAX_PAGES (100)', async () => {
+            for (let i = 0; i < 100; i++) {
+                mockDatabasesQuery.mockResolvedValueOnce({
+                    results: [notionPage(`p${i}`, `Entry ${i}`, '2024-06-01T00:00:00Z', 'database_id', 'db1')],
+                    has_more: true,
+                    next_cursor: `cursor-${i + 1}`,
+                });
+            }
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const entries = await client.queryDatabase('db1');
+
+            expect(entries).toHaveLength(100);
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('queryDatabase hit max pages'));
+            expect(mockDatabasesQuery).toHaveBeenCalledTimes(100);
+            warnSpy.mockRestore();
+        });
+
+        it('paginateBlockChildren stops at MAX_PAGES (100)', async () => {
+            // Use a fresh client to avoid leftover mocks from other tests
+            const freshClient = new NotionApiClient('test-token', { minRequestInterval: 0 });
+            mockBlocksChildrenList.mockReset();
+
+            for (let i = 0; i < 100; i++) {
+                mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse(
+                    [block('paragraph', { paragraph: { rich_text: richText(`Block ${i}`) } })],
+                    true, `cursor-${i + 1}`,
+                ));
+            }
+            const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+            const md = await freshClient.getPageContent('page-1');
+
+            expect(md).toContain('Block 0');
+            expect(md).toContain('Block 99');
+            expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('paginateBlockChildren hit max pages'));
+            expect(mockBlocksChildrenList).toHaveBeenCalledTimes(100);
+            warnSpy.mockRestore();
+        });
+    });
+
+    // ── extractTitle edge case ─────────────────────────────────────────────
+
+    describe('extractTitle', () => {
+        it('returns empty string when page has no title property', async () => {
+            mockSearch.mockResolvedValueOnce({
+                results: [{
+                    object: 'page',
+                    id: 'no-title',
+                    url: 'https://www.notion.so/notitle',
+                    last_edited_time: '2024-06-01T00:00:00Z',
+                    parent: { type: 'workspace', workspace: true },
+                    properties: {
+                        Description: { type: 'rich_text', rich_text: richText('Just a description') },
+                    },
+                }],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const pages = await client.searchPages();
+            expect(pages).toHaveLength(1);
+            expect(pages[0].title).toBe('');
+        });
+
+        it('returns empty string when page has no properties at all', async () => {
+            mockSearch.mockResolvedValueOnce({
+                results: [{
+                    object: 'page',
+                    id: 'no-props',
+                    url: 'https://www.notion.so/noprops',
+                    last_edited_time: '2024-06-01T00:00:00Z',
+                    parent: { type: 'workspace', workspace: true },
+                    properties: {},
+                }],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const pages = await client.searchPages();
+            expect(pages).toHaveLength(1);
+            expect(pages[0].title).toBe('');
         });
     });
 

--- a/src/__tests__/notion-api.test.ts
+++ b/src/__tests__/notion-api.test.ts
@@ -1,0 +1,635 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// Mock @notionhq/client before importing the module under test
+const mockSearch = vi.fn();
+const mockPagesRetrieve = vi.fn();
+const mockBlocksChildrenList = vi.fn();
+const mockDatabasesRetrieve = vi.fn();
+const mockDatabasesQuery = vi.fn();
+const mockUsersRetrieve = vi.fn();
+
+vi.mock('@notionhq/client', () => ({
+    Client: class MockClient {
+        search = mockSearch;
+        pages = { retrieve: mockPagesRetrieve };
+        blocks = { children: { list: mockBlocksChildrenList } };
+        databases = { retrieve: mockDatabasesRetrieve, query: mockDatabasesQuery };
+        users = { retrieve: mockUsersRetrieve };
+        constructor(_opts: any) {}
+    },
+}));
+
+import { NotionApiClient, type NotionPageMeta, type NotionDatabaseMeta } from '../indexing/providers/notion-api.js';
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/** Build a minimal Notion rich-text array. */
+function richText(text: string, link?: string): any[] {
+    return [{
+        type: 'text',
+        plain_text: text,
+        href: link ?? null,
+    }];
+}
+
+/** Build a block object for mockBlocksChildrenList. */
+function block(type: string, extra: Record<string, any> = {}, hasChildren = false): any {
+    return { id: `blk-${Math.random().toString(36).slice(2, 8)}`, type, has_children: hasChildren, ...extra };
+}
+
+/** Wrap blocks in a paginated response (single page). */
+function blocksResponse(blocks: any[], hasMore = false, nextCursor: string | null = null) {
+    return { results: blocks, has_more: hasMore, next_cursor: nextCursor };
+}
+
+/** Build a Notion page object for search/retrieve responses. */
+function notionPage(id: string, title: string, lastEdited: string, parentType: 'workspace' | 'page_id' | 'database_id' = 'workspace', parentId?: string): any {
+    const parent: any =
+        parentType === 'workspace' ? { type: 'workspace', workspace: true } :
+        parentType === 'page_id' ? { type: 'page_id', page_id: parentId } :
+        { type: 'database_id', database_id: parentId };
+    return {
+        object: 'page',
+        id,
+        url: `https://www.notion.so/${id.replace(/-/g, '')}`,
+        last_edited_time: lastEdited,
+        parent,
+        properties: {
+            title: { type: 'title', title: richText(title) },
+        },
+    };
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('NotionApiClient', () => {
+    let client: NotionApiClient;
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+        // Disable real timers/delays — we stub the throttle internally via setting minDelay to 0
+        client = new NotionApiClient('test-token', { minRequestInterval: 0 });
+    });
+
+    // ── Block-to-markdown conversion ────────────────────────────────────────
+
+    describe('block-to-markdown', () => {
+        it('converts paragraph to plain text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('paragraph', { paragraph: { rich_text: richText('Hello world') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('Hello world');
+        });
+
+        it('converts heading_1 to # text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('heading_1', { heading_1: { rich_text: richText('Title') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('# Title');
+        });
+
+        it('converts heading_2 to ## text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('heading_2', { heading_2: { rich_text: richText('Subtitle') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('## Subtitle');
+        });
+
+        it('converts heading_3 to ### text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('heading_3', { heading_3: { rich_text: richText('Section') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('### Section');
+        });
+
+        it('converts bulleted_list_item to - text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('bulleted_list_item', { bulleted_list_item: { rich_text: richText('Bullet point') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('- Bullet point');
+        });
+
+        it('converts numbered_list_item to 1. text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('numbered_list_item', { numbered_list_item: { rich_text: richText('First item') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('1. First item');
+        });
+
+        it('converts to_do (checked) to - [x] text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('to_do', { to_do: { rich_text: richText('Done task'), checked: true } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('- [x] Done task');
+        });
+
+        it('converts to_do (unchecked) to - [ ] text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('to_do', { to_do: { rich_text: richText('Open task'), checked: false } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('- [ ] Open task');
+        });
+
+        it('converts quote to > text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('quote', { quote: { rich_text: richText('A wise saying') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('> A wise saying');
+        });
+
+        it('converts callout to > **icon** text', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('callout', { callout: { rich_text: richText('Important note'), icon: { type: 'emoji', emoji: '💡' } } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('> **💡** Important note');
+        });
+
+        it('converts code block with language', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('code', { code: { rich_text: richText('const x = 1;'), language: 'typescript' } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('```typescript\nconst x = 1;\n```');
+        });
+
+        it('converts divider to ---', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('divider', { divider: {} }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('---');
+        });
+
+        it('converts bookmark to [caption](url)', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('bookmark', { bookmark: { url: 'https://example.com', caption: richText('Example') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('[Example](https://example.com)');
+        });
+
+        it('converts equation to $$expression$$', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('equation', { equation: { expression: 'E = mc^2' } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('$$E = mc^2$$');
+        });
+
+        it('converts image with external URL', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('image', { image: { type: 'external', external: { url: 'https://img.com/pic.png' }, caption: richText('A picture') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('![A picture](https://img.com/pic.png)');
+        });
+
+        it('converts child_page to [Page: title]', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('child_page', { child_page: { title: 'Sub Page' } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('[Page: Sub Page]');
+        });
+
+        it('converts child_database to [Database: title]', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('child_database', { child_database: { title: 'My DB' } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('[Database: My DB]');
+        });
+
+        it('silently skips unsupported block types', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('paragraph', { paragraph: { rich_text: richText('Before') } }),
+                block('unsupported', { unsupported: {} }),
+                block('paragraph', { paragraph: { rich_text: richText('After') } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('Before');
+            expect(md).toContain('After');
+            expect(md).not.toContain('unsupported');
+        });
+
+        it('renders rich text with links as [text](url)', async () => {
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('paragraph', { paragraph: { rich_text: [
+                    { type: 'text', plain_text: 'Click ', href: null },
+                    { type: 'text', plain_text: 'here', href: 'https://example.com' },
+                    { type: 'text', plain_text: ' to continue', href: null },
+                ] } }),
+            ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('Click [here](https://example.com) to continue');
+        });
+
+        it('converts table blocks to markdown table', async () => {
+            const tableBlock = block('table', {
+                table: { has_column_header: true, has_row_header: false, table_width: 2 },
+            }, true);
+            mockBlocksChildrenList
+                .mockResolvedValueOnce(blocksResponse([tableBlock]))
+                // Children of the table block (rows)
+                .mockResolvedValueOnce(blocksResponse([
+                    block('table_row', { table_row: { cells: [richText('Header A'), richText('Header B')] } }),
+                    block('table_row', { table_row: { cells: [richText('Cell 1'), richText('Cell 2')] } }),
+                ]));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('| Header A | Header B |');
+            expect(md).toContain('| --- | --- |');
+            expect(md).toContain('| Cell 1 | Cell 2 |');
+        });
+    });
+
+    // ── Pagination ──────────────────────────────────────────────────────────
+
+    describe('pagination', () => {
+        it('paginates block children with has_more + next_cursor', async () => {
+            mockBlocksChildrenList
+                .mockResolvedValueOnce(blocksResponse(
+                    [block('paragraph', { paragraph: { rich_text: richText('Page 1') } })],
+                    true, 'cursor-2',
+                ))
+                .mockResolvedValueOnce(blocksResponse(
+                    [block('paragraph', { paragraph: { rich_text: richText('Page 2') } })],
+                    false, null,
+                ));
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('Page 1');
+            expect(md).toContain('Page 2');
+            expect(mockBlocksChildrenList).toHaveBeenCalledTimes(2);
+        });
+    });
+
+    // ── Recursion ───────────────────────────────────────────────────────────
+
+    describe('recursion', () => {
+        it('recurses into child blocks (toggle with children)', async () => {
+            const toggleBlock = block('toggle', {
+                toggle: { rich_text: richText('Toggle title') },
+            }, true);
+
+            mockBlocksChildrenList
+                // Top-level blocks
+                .mockResolvedValueOnce(blocksResponse([toggleBlock]))
+                // Children of toggle
+                .mockResolvedValueOnce(blocksResponse([
+                    block('paragraph', { paragraph: { rich_text: richText('Inside toggle') } }),
+                ]));
+
+            const md = await client.getPageContent('page-1');
+            expect(md).toContain('**Toggle title**');
+            expect(md).toContain('Inside toggle');
+        });
+
+        it('respects max recursion depth', async () => {
+            // Build a chain of deeply nested toggles (depth 12)
+            // Each level returns a toggle with has_children=true
+            for (let i = 0; i < 12; i++) {
+                const nestedToggle = block('toggle', {
+                    toggle: { rich_text: richText(`Level ${i}`) },
+                }, true);
+                mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([nestedToggle]));
+            }
+            // Final level — should not be reached (depth 10 cap)
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('paragraph', { paragraph: { rich_text: richText('Too deep') } }),
+            ]));
+
+            const md = await client.getPageContent('page-1');
+            // Depth 0-9 should be present (10 levels), depth 10+ should not
+            expect(md).toContain('Level 0');
+            expect(md).toContain('Level 9');
+            // The block at depth 11 should not have its children fetched
+            // (we allow the toggle text at level 10 but don't recurse into it)
+            expect(md).not.toContain('Too deep');
+        });
+    });
+
+    // ── searchPages ─────────────────────────────────────────────────────────
+
+    describe('searchPages', () => {
+        it('returns page metadata from search', async () => {
+            mockSearch.mockResolvedValueOnce({
+                results: [notionPage('p1', 'My Page', '2024-06-01T00:00:00Z')],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const pages = await client.searchPages();
+            expect(pages).toHaveLength(1);
+            expect(pages[0].id).toBe('p1');
+            expect(pages[0].title).toBe('My Page');
+            expect(pages[0].lastEditedTime).toBe('2024-06-01T00:00:00Z');
+            expect(pages[0].parentType).toBe('workspace');
+        });
+
+        it('paginates search results', async () => {
+            mockSearch
+                .mockResolvedValueOnce({
+                    results: [notionPage('p1', 'Page 1', '2024-06-01T00:00:00Z')],
+                    has_more: true,
+                    next_cursor: 'cursor-2',
+                })
+                .mockResolvedValueOnce({
+                    results: [notionPage('p2', 'Page 2', '2024-06-02T00:00:00Z')],
+                    has_more: false,
+                    next_cursor: null,
+                });
+
+            const pages = await client.searchPages();
+            expect(pages).toHaveLength(2);
+            expect(pages[0].id).toBe('p1');
+            expect(pages[1].id).toBe('p2');
+        });
+
+        it('filters out database objects from search', async () => {
+            mockSearch.mockResolvedValueOnce({
+                results: [
+                    notionPage('p1', 'A Page', '2024-06-01T00:00:00Z'),
+                    { object: 'database', id: 'db1', title: [{ plain_text: 'A DB' }] },
+                ],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const pages = await client.searchPages();
+            expect(pages).toHaveLength(1);
+            expect(pages[0].id).toBe('p1');
+        });
+
+        it('filters by editedAfter timestamp', async () => {
+            mockSearch.mockResolvedValueOnce({
+                results: [
+                    notionPage('p1', 'Old Page', '2024-01-01T00:00:00Z'),
+                    notionPage('p2', 'New Page', '2024-07-01T00:00:00Z'),
+                ],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const pages = await client.searchPages('2024-06-01T00:00:00Z');
+            expect(pages).toHaveLength(1);
+            expect(pages[0].id).toBe('p2');
+        });
+    });
+
+    // ── queryDatabase ───────────────────────────────────────────────────────
+
+    describe('queryDatabase', () => {
+        it('returns entries from a database', async () => {
+            mockDatabasesQuery.mockResolvedValueOnce({
+                results: [notionPage('p1', 'Entry 1', '2024-06-01T00:00:00Z', 'database_id', 'db1')],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const entries = await client.queryDatabase('db1');
+            expect(entries).toHaveLength(1);
+            expect(entries[0].id).toBe('p1');
+            expect(entries[0].parentType).toBe('database');
+        });
+
+        it('filters entries by editedAfter', async () => {
+            mockDatabasesQuery.mockResolvedValueOnce({
+                results: [
+                    notionPage('p1', 'Old', '2024-01-01T00:00:00Z', 'database_id', 'db1'),
+                    notionPage('p2', 'New', '2024-07-01T00:00:00Z', 'database_id', 'db1'),
+                ],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const entries = await client.queryDatabase('db1', '2024-06-01T00:00:00Z');
+            expect(entries).toHaveLength(1);
+            expect(entries[0].id).toBe('p2');
+        });
+    });
+
+    // ── getPageMeta ─────────────────────────────────────────────────────────
+
+    describe('getPageMeta', () => {
+        it('returns page metadata from retrieve', async () => {
+            mockPagesRetrieve.mockResolvedValueOnce(
+                notionPage('p1', 'Retrieved Page', '2024-06-15T12:00:00Z', 'page_id', 'parent-1'),
+            );
+
+            const meta = await client.getPageMeta('p1');
+            expect(meta.id).toBe('p1');
+            expect(meta.title).toBe('Retrieved Page');
+            expect(meta.parentType).toBe('page');
+            expect(meta.parentId).toBe('parent-1');
+        });
+    });
+
+    // ── getDatabaseMeta ─────────────────────────────────────────────────────
+
+    describe('getDatabaseMeta', () => {
+        it('returns database metadata', async () => {
+            mockDatabasesRetrieve.mockResolvedValueOnce({
+                id: 'db1',
+                title: [{ plain_text: 'Projects DB' }],
+                url: 'https://www.notion.so/db1',
+                properties: {
+                    Name: { id: 'prop1', type: 'title' },
+                    Status: { id: 'prop2', type: 'select' },
+                    Priority: { id: 'prop3', type: 'number' },
+                },
+            });
+
+            const meta = await client.getDatabaseMeta('db1');
+            expect(meta.id).toBe('db1');
+            expect(meta.title).toBe('Projects DB');
+            expect(meta.propertyNames).toEqual(expect.arrayContaining(['Name', 'Status', 'Priority']));
+        });
+    });
+
+    // ── resolveUser ─────────────────────────────────────────────────────────
+
+    describe('resolveUser', () => {
+        it('resolves user name', async () => {
+            mockUsersRetrieve.mockResolvedValueOnce({
+                id: 'u1',
+                name: 'Alice',
+                type: 'person',
+            });
+
+            const name = await client.resolveUser('u1');
+            expect(name).toBe('Alice');
+        });
+
+        it('caches user resolution', async () => {
+            mockUsersRetrieve.mockResolvedValueOnce({
+                id: 'u1',
+                name: 'Alice',
+                type: 'person',
+            });
+
+            await client.resolveUser('u1');
+            const name = await client.resolveUser('u1');
+            expect(name).toBe('Alice');
+            expect(mockUsersRetrieve).toHaveBeenCalledTimes(1);
+        });
+
+        it('falls back to "Unknown User" on error', async () => {
+            mockUsersRetrieve.mockRejectedValueOnce(new Error('Not found'));
+
+            const name = await client.resolveUser('u-bad');
+            expect(name).toBe('Unknown User');
+        });
+    });
+
+    // ── serializeProperties ─────────────────────────────────────────────────
+
+    describe('serializeProperties', () => {
+        it('serializes title property', () => {
+            const props = { Name: { type: 'title', title: richText('Hello') } };
+            const result = client.serializeProperties(props);
+            expect(result.Name).toBe('Hello');
+        });
+
+        it('serializes rich_text property', () => {
+            const props = { Description: { type: 'rich_text', rich_text: richText('Some text') } };
+            const result = client.serializeProperties(props);
+            expect(result.Description).toBe('Some text');
+        });
+
+        it('serializes number property', () => {
+            const props = { Count: { type: 'number', number: 42 } };
+            const result = client.serializeProperties(props);
+            expect(result.Count).toBe('42');
+        });
+
+        it('serializes select property', () => {
+            const props = { Status: { type: 'select', select: { name: 'Active' } } };
+            const result = client.serializeProperties(props);
+            expect(result.Status).toBe('Active');
+        });
+
+        it('serializes multi_select property', () => {
+            const props = { Tags: { type: 'multi_select', multi_select: [{ name: 'A' }, { name: 'B' }] } };
+            const result = client.serializeProperties(props);
+            expect(result.Tags).toBe('A, B');
+        });
+
+        it('serializes date property', () => {
+            const props = { Due: { type: 'date', date: { start: '2024-06-01', end: null } } };
+            const result = client.serializeProperties(props);
+            expect(result.Due).toBe('2024-06-01');
+        });
+
+        it('serializes date property with range', () => {
+            const props = { Range: { type: 'date', date: { start: '2024-06-01', end: '2024-06-30' } } };
+            const result = client.serializeProperties(props);
+            expect(result.Range).toBe('2024-06-01 → 2024-06-30');
+        });
+
+        it('serializes checkbox property', () => {
+            const props = { Done: { type: 'checkbox', checkbox: true } };
+            const result = client.serializeProperties(props);
+            expect(result.Done).toBe('true');
+        });
+
+        it('serializes url property', () => {
+            const props = { Link: { type: 'url', url: 'https://example.com' } };
+            const result = client.serializeProperties(props);
+            expect(result.Link).toBe('https://example.com');
+        });
+
+        it('serializes email property', () => {
+            const props = { Email: { type: 'email', email: 'a@b.com' } };
+            const result = client.serializeProperties(props);
+            expect(result.Email).toBe('a@b.com');
+        });
+
+        it('serializes phone_number property', () => {
+            const props = { Phone: { type: 'phone_number', phone_number: '555-1234' } };
+            const result = client.serializeProperties(props);
+            expect(result.Phone).toBe('555-1234');
+        });
+
+        it('serializes status property', () => {
+            const props = { Status: { type: 'status', status: { name: 'In Progress' } } };
+            const result = client.serializeProperties(props);
+            expect(result.Status).toBe('In Progress');
+        });
+
+        it('serializes people property', () => {
+            const props = { Assignee: { type: 'people', people: [{ name: 'Alice' }, { name: 'Bob' }] } };
+            const result = client.serializeProperties(props);
+            expect(result.Assignee).toBe('Alice, Bob');
+        });
+
+        it('serializes created_time property', () => {
+            const props = { Created: { type: 'created_time', created_time: '2024-06-01T00:00:00Z' } };
+            const result = client.serializeProperties(props);
+            expect(result.Created).toBe('2024-06-01T00:00:00Z');
+        });
+
+        it('serializes last_edited_time property', () => {
+            const props = { Updated: { type: 'last_edited_time', last_edited_time: '2024-06-15T00:00:00Z' } };
+            const result = client.serializeProperties(props);
+            expect(result.Updated).toBe('2024-06-15T00:00:00Z');
+        });
+
+        it('serializes files property', () => {
+            const props = { Attachments: { type: 'files', files: [
+                { type: 'external', name: 'doc.pdf', external: { url: 'https://example.com/doc.pdf' } },
+            ] } };
+            const result = client.serializeProperties(props);
+            expect(result.Attachments).toBe('https://example.com/doc.pdf');
+        });
+
+        it('skips unsupported property types (formula, rollup, relation)', () => {
+            const props = {
+                Name: { type: 'title', title: richText('Test') },
+                Formula: { type: 'formula', formula: { type: 'string', string: 'computed' } },
+                Rollup: { type: 'rollup', rollup: {} },
+                Relation: { type: 'relation', relation: [] },
+                CreatedBy: { type: 'created_by', created_by: { name: 'X' } },
+                EditedBy: { type: 'last_edited_by', last_edited_by: { name: 'Y' } },
+            };
+            const result = client.serializeProperties(props);
+            expect(result.Name).toBe('Test');
+            expect(result).not.toHaveProperty('Formula');
+            expect(result).not.toHaveProperty('Rollup');
+            expect(result).not.toHaveProperty('Relation');
+            expect(result).not.toHaveProperty('CreatedBy');
+            expect(result).not.toHaveProperty('EditedBy');
+        });
+    });
+
+    // ── Throttling ──────────────────────────────────────────────────────────
+
+    describe('throttling', () => {
+        it('enforces minimum delay between API calls', async () => {
+            // Create a client with real throttling (340ms)
+            const throttledClient = new NotionApiClient('test-token', { minRequestInterval: 340 });
+
+            mockBlocksChildrenList
+                .mockResolvedValue(blocksResponse([
+                    block('paragraph', { paragraph: { rich_text: richText('Text') } }),
+                ]));
+
+            const start = Date.now();
+            // Make 3 sequential calls — should take >= 680ms (2 intervals between 3 calls)
+            await throttledClient.getPageContent('p1');
+            await throttledClient.getPageContent('p2');
+            await throttledClient.getPageContent('p3');
+            const elapsed = Date.now() - start;
+
+            expect(elapsed).toBeGreaterThanOrEqual(600); // Allow small timing margin
+        });
+    });
+});

--- a/src/__tests__/notion-api.test.ts
+++ b/src/__tests__/notion-api.test.ts
@@ -315,6 +315,28 @@ describe('NotionApiClient', () => {
             // (we allow the toggle text at level 10 but don't recurse into it)
             expect(md).not.toContain('Too deep');
         });
+
+        it('respects custom maxDepth from constructor options', async () => {
+            const shallowClient = new NotionApiClient('test-token', { minRequestInterval: 0, maxDepth: 3 });
+            mockBlocksChildrenList.mockReset();
+
+            // Build a chain of deeply nested toggles (depth 5)
+            for (let i = 0; i < 5; i++) {
+                const nestedToggle = block('toggle', {
+                    toggle: { rich_text: richText(`Level ${i}`) },
+                }, true);
+                mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([nestedToggle]));
+            }
+            mockBlocksChildrenList.mockResolvedValueOnce(blocksResponse([
+                block('paragraph', { paragraph: { rich_text: richText('Too deep for shallow') } }),
+            ]));
+
+            const md = await shallowClient.getPageContent('page-1');
+            // Depth 0-2 should be present (3 levels), depth 3+ should not recurse
+            expect(md).toContain('Level 0');
+            expect(md).toContain('Level 2');
+            expect(md).not.toContain('Too deep for shallow');
+        });
     });
 
     // ── searchPages ─────────────────────────────────────────────────────────
@@ -414,6 +436,45 @@ describe('NotionApiClient', () => {
             const entries = await client.queryDatabase('db1', '2024-06-01T00:00:00Z');
             expect(entries).toHaveLength(1);
             expect(entries[0].id).toBe('p2');
+        });
+
+        it('returns serialized properties for database entries', async () => {
+            const dbPage = {
+                object: 'page',
+                id: 'dp1',
+                url: 'https://www.notion.so/dp1',
+                last_edited_time: '2024-06-01T00:00:00Z',
+                parent: { type: 'database_id', database_id: 'db1' },
+                properties: {
+                    Name: { type: 'title', title: richText('Task Name') },
+                    Status: { type: 'select', select: { name: 'In Progress' } },
+                    Priority: { type: 'number', number: 3 },
+                },
+            };
+            mockDatabasesQuery.mockResolvedValueOnce({
+                results: [dbPage],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const entries = await client.queryDatabase('db1');
+            expect(entries).toHaveLength(1);
+            expect(entries[0].properties).toBeDefined();
+            expect(entries[0].properties!['Name']).toBe('Task Name');
+            expect(entries[0].properties!['Status']).toBe('In Progress');
+            expect(entries[0].properties!['Priority']).toBe('3');
+        });
+
+        it('does not return properties for non-database pages', async () => {
+            mockSearch.mockResolvedValueOnce({
+                results: [notionPage('p1', 'Regular Page', '2024-06-01T00:00:00Z', 'workspace')],
+                has_more: false,
+                next_cursor: null,
+            });
+
+            const pages = await client.searchPages();
+            expect(pages).toHaveLength(1);
+            expect(pages[0].properties).toBeUndefined();
         });
     });
 

--- a/src/__tests__/notion-config.test.ts
+++ b/src/__tests__/notion-config.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { SourceConfigSchema, NotionSourceConfigSchema } from '../types.js';
+
+describe('NotionSourceConfigSchema', () => {
+    it('accepts valid notion source config', () => {
+        const config = {
+            name: 'notion-docs',
+            type: 'notion',
+            root_pages: ['page-id-1', 'page-id-2'],
+            databases: ['db-id-1'],
+            max_depth: 3,
+            include_properties: false,
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success && result.data.type === 'notion') {
+            expect(result.data.root_pages).toEqual(['page-id-1', 'page-id-2']);
+            expect(result.data.databases).toEqual(['db-id-1']);
+            expect(result.data.max_depth).toBe(3);
+            expect(result.data.include_properties).toBe(false);
+        }
+    });
+
+    it('applies defaults for optional fields', () => {
+        const config = {
+            name: 'notion-minimal',
+            type: 'notion',
+            chunk: {},
+        };
+        const result = NotionSourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.root_pages).toEqual([]);
+            expect(result.data.databases).toEqual([]);
+            expect(result.data.max_depth).toBe(5);
+            expect(result.data.include_properties).toBe(true);
+        }
+    });
+
+    it('rejects max_depth below 1', () => {
+        const config = {
+            name: 'notion-bad-depth',
+            type: 'notion',
+            max_depth: 0,
+            chunk: {},
+        };
+        const result = NotionSourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects max_depth above 20', () => {
+        const config = {
+            name: 'notion-deep',
+            type: 'notion',
+            max_depth: 21,
+            chunk: {},
+        };
+        const result = NotionSourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects empty strings in root_pages', () => {
+        const config = {
+            name: 'notion-empty-page',
+            type: 'notion',
+            root_pages: ['valid-id', ''],
+            chunk: {},
+        };
+        const result = NotionSourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('rejects empty strings in databases', () => {
+        const config = {
+            name: 'notion-empty-db',
+            type: 'notion',
+            databases: [''],
+            chunk: {},
+        };
+        const result = NotionSourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(false);
+    });
+
+    it('allows category to be set to faq explicitly', () => {
+        const config = {
+            name: 'notion-faq',
+            type: 'notion',
+            category: 'faq',
+            chunk: {},
+        };
+        const result = NotionSourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.category).toBe('faq');
+        }
+    });
+
+    it('category is undefined by default', () => {
+        const config = {
+            name: 'notion-no-cat',
+            type: 'notion',
+            chunk: {},
+        };
+        const result = NotionSourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.category).toBeUndefined();
+        }
+    });
+
+    it('resolves correctly in discriminated union', () => {
+        const config = {
+            name: 'notion-union',
+            type: 'notion',
+            chunk: {},
+        };
+        const result = SourceConfigSchema.safeParse(config);
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.data.type).toBe('notion');
+        }
+    });
+});

--- a/src/__tests__/notion-provider.test.ts
+++ b/src/__tests__/notion-provider.test.ts
@@ -10,6 +10,7 @@ const mockSearchPages = vi.fn();
 const mockGetPageContent = vi.fn();
 const mockGetPageMeta = vi.fn();
 const mockQueryDatabase = vi.fn();
+const mockConstructorArgs = vi.fn();
 
 vi.mock('../indexing/providers/notion-api.js', () => ({
     NotionApiClient: class {
@@ -17,7 +18,9 @@ vi.mock('../indexing/providers/notion-api.js', () => ({
         getPageContent = mockGetPageContent;
         getPageMeta = mockGetPageMeta;
         queryDatabase = mockQueryDatabase;
-        constructor(_token: string) {}
+        constructor(token: string, options?: any) {
+            mockConstructorArgs(token, options);
+        }
     },
 }));
 
@@ -92,6 +95,12 @@ describe('NotionDataProvider', () => {
             makeConfig(),
             { cloneDir: '/tmp' },
         )).toThrow('notionToken');
+    });
+
+    it('passes max_depth from config to API client', async () => {
+        mockConstructorArgs.mockClear();
+        await createProvider(makeConfig({ max_depth: 15 }), 'tok-123');
+        expect(mockConstructorArgs).toHaveBeenCalledWith('tok-123', { maxDepth: 15 });
     });
 
     // ── fullAcquire ─────────────────────────────────────────────────────

--- a/src/__tests__/notion-provider.test.ts
+++ b/src/__tests__/notion-provider.test.ts
@@ -295,6 +295,123 @@ describe('NotionDataProvider', () => {
         expect(result.items[0].id).toBe('p2');
     });
 
+    // ── discoverAllPages error handling ──────────────────────────────
+
+    it('fullAcquire continues when root page fetch fails in discoverAllPages', async () => {
+        mockGetPageMeta
+            .mockRejectedValueOnce(new Error('Page not found'))
+            .mockResolvedValueOnce(makePage('rp2', 'Good Page', '2025-01-01T00:00:00Z'));
+        mockGetPageContent.mockResolvedValue('Content');
+
+        const provider = await createProvider(makeConfig({ root_pages: ['bad-id', 'rp2'] }));
+        const result = await provider.fullAcquire();
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('rp2');
+    });
+
+    it('fullAcquire continues when database query fails in discoverAllPages', async () => {
+        mockQueryDatabase
+            .mockRejectedValueOnce(new Error('DB access denied'))
+            .mockResolvedValueOnce([makePage('dp1', 'DB Page', '2025-01-01T00:00:00Z')]);
+        mockGetPageContent.mockResolvedValue('Content');
+
+        const provider = await createProvider(makeConfig({ databases: ['bad-db', 'good-db'] }));
+        const result = await provider.fullAcquire();
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('dp1');
+    });
+
+    // ── discoverEditedPages with root_pages ────────────────────────────
+
+    it('incrementalAcquire with root_pages filters to recently edited', async () => {
+        const oldPage = makePage('rp1', 'Old Root', '2025-01-01T00:00:00Z');
+        const newPage = makePage('rp2', 'New Root', '2025-06-01T00:00:00Z');
+
+        // discoverAllPages: getPageMeta called for each root page
+        mockGetPageMeta
+            .mockResolvedValueOnce(oldPage)   // discoverAllPages rp1
+            .mockResolvedValueOnce(newPage)   // discoverAllPages rp2
+            .mockResolvedValueOnce(oldPage)   // discoverEditedPages rp1 (filtered out by time)
+            .mockResolvedValueOnce(newPage);  // discoverEditedPages rp2 (passes time filter)
+        mockGetPageContent.mockResolvedValue('Updated content');
+        mockGetIndexedItemIds.mockResolvedValue(new Set(['rp1', 'rp2']));
+
+        const provider = await createProvider(makeConfig({ root_pages: ['rp1', 'rp2'] }));
+        const result = await provider.incrementalAcquire('2025-03-01T00:00:00Z');
+
+        // Only rp2 was edited after the cutoff
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('rp2');
+        expect(result.removedIds).toHaveLength(0);
+    });
+
+    // ── discoverEditedPages with databases ─────────────────────────────
+
+    it('incrementalAcquire with databases passes editedAfter to queryDatabase', async () => {
+        const dbPage = makePage('dp1', 'DB Entry', '2025-06-01T00:00:00Z', 'database');
+
+        // discoverAllPages: queryDatabase without filter
+        mockQueryDatabase
+            .mockResolvedValueOnce([dbPage])   // discoverAllPages
+            .mockResolvedValueOnce([dbPage]);  // discoverEditedPages
+        mockGetPageContent.mockResolvedValue('Content');
+        mockGetIndexedItemIds.mockResolvedValue(new Set(['dp1']));
+
+        const provider = await createProvider(makeConfig({ databases: ['db1'] }));
+        const result = await provider.incrementalAcquire('2025-03-01T00:00:00Z');
+
+        // discoverEditedPages should call queryDatabase with editedAfter
+        expect(mockQueryDatabase).toHaveBeenCalledTimes(2);
+        expect(mockQueryDatabase).toHaveBeenNthCalledWith(2, 'db1', '2025-03-01T00:00:00Z');
+        expect(result.items).toHaveLength(1);
+    });
+
+    // ── discoverEditedPages error handling ──────────────────────────────
+
+    it('incrementalAcquire continues when root page fetch fails in discoverEditedPages', async () => {
+        const goodPage = makePage('rp2', 'Good Page', '2025-06-01T00:00:00Z');
+
+        // discoverAllPages: both succeed
+        mockGetPageMeta
+            .mockResolvedValueOnce(makePage('rp1', 'Page 1', '2025-06-01T00:00:00Z'))
+            .mockResolvedValueOnce(goodPage)
+            // discoverEditedPages: rp1 fails, rp2 succeeds
+            .mockRejectedValueOnce(new Error('API error'))
+            .mockResolvedValueOnce(goodPage);
+        mockGetPageContent.mockResolvedValue('Content');
+        mockGetIndexedItemIds.mockResolvedValue(new Set(['rp1', 'rp2']));
+
+        const provider = await createProvider(makeConfig({ root_pages: ['rp1', 'rp2'] }));
+        const result = await provider.incrementalAcquire('2025-03-01T00:00:00Z');
+
+        // Only rp2 succeeded in discoverEditedPages
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('rp2');
+    });
+
+    it('incrementalAcquire continues when database query fails in discoverEditedPages', async () => {
+        const dbPage = makePage('dp1', 'DB Entry', '2025-06-01T00:00:00Z', 'database');
+
+        // discoverAllPages: both DBs succeed
+        mockQueryDatabase
+            .mockResolvedValueOnce([dbPage])                 // discoverAllPages db1
+            .mockResolvedValueOnce([])                       // discoverAllPages db2
+            // discoverEditedPages: db1 fails, db2 succeeds
+            .mockRejectedValueOnce(new Error('DB error'))
+            .mockResolvedValueOnce([]);
+        mockGetPageContent.mockResolvedValue('Content');
+        mockGetIndexedItemIds.mockResolvedValue(new Set(['dp1']));
+
+        const provider = await createProvider(makeConfig({ databases: ['db1', 'db2'] }));
+        const result = await provider.incrementalAcquire('2025-03-01T00:00:00Z');
+
+        // db1 failed in discoverEditedPages, but dp1 is still in allPages so not removed
+        expect(mockQueryDatabase).toHaveBeenCalledTimes(4);
+        expect(result.removedIds).toHaveLength(0);
+    });
+
     it('all pages fail: throws', async () => {
         mockSearchPages.mockResolvedValue([
             makePage('p1', 'One', '2025-01-01T00:00:00Z'),

--- a/src/__tests__/notion-provider.test.ts
+++ b/src/__tests__/notion-provider.test.ts
@@ -1,0 +1,312 @@
+// Tests for NotionDataProvider — page discovery, content acquisition, deletion detection.
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import type { NotionPageMeta } from '../indexing/providers/notion-api.js';
+import type { SourceConfig } from '../types.js';
+
+// ── Mocks ───────────────────────────────────────────────────────────────────
+
+const mockSearchPages = vi.fn();
+const mockGetPageContent = vi.fn();
+const mockGetPageMeta = vi.fn();
+const mockQueryDatabase = vi.fn();
+
+vi.mock('../indexing/providers/notion-api.js', () => ({
+    NotionApiClient: class {
+        searchPages = mockSearchPages;
+        getPageContent = mockGetPageContent;
+        getPageMeta = mockGetPageMeta;
+        queryDatabase = mockQueryDatabase;
+        constructor(_token: string) {}
+    },
+}));
+
+const mockGetIndexedItemIds = vi.fn();
+vi.mock('../db/queries.js', () => ({
+    getIndexedItemIds: (...args: unknown[]) => mockGetIndexedItemIds(...args),
+}));
+
+vi.mock('../config.js', () => ({
+    getConfig: () => ({ openaiApiKey: 'test-key' }),
+}));
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+function makePage(
+    id: string,
+    title: string,
+    time: string,
+    parentType: 'workspace' | 'page' | 'database' = 'workspace',
+    properties?: Record<string, string>,
+): NotionPageMeta {
+    return {
+        id,
+        title,
+        lastEditedTime: time,
+        url: `https://notion.so/${id}`,
+        parentType,
+        parentId: null,
+        properties,
+    };
+}
+
+function makeConfig(overrides: Partial<SourceConfig & { type: 'notion' }> = {}): SourceConfig {
+    return {
+        type: 'notion',
+        name: 'test-notion',
+        chunk: { target_tokens: 500 },
+        root_pages: [],
+        databases: [],
+        max_depth: 5,
+        include_properties: true,
+        ...overrides,
+    } as SourceConfig;
+}
+
+// ── Tests ───────────────────────────────────────────────────────────────────
+
+describe('NotionDataProvider', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockGetIndexedItemIds.mockResolvedValue(new Set());
+    });
+
+    async function createProvider(config?: SourceConfig, token?: string) {
+        const { NotionDataProvider } = await import('../indexing/providers/notion.js');
+        return new NotionDataProvider(config ?? makeConfig(), { cloneDir: '/tmp', notionToken: token ?? 'test-token' });
+    }
+
+    // ── Constructor validation ──────────────────────────────────────────
+
+    it('throws if config.type is not notion', async () => {
+        const { NotionDataProvider } = await import('../indexing/providers/notion.js');
+        expect(() => new NotionDataProvider(
+            { type: 'markdown', name: 'x', chunk: { target_tokens: 500 }, path: '.', file_patterns: ['*.md'] } as SourceConfig,
+            { cloneDir: '/tmp', notionToken: 'tok' },
+        )).toThrow('NotionDataProvider requires a notion source config');
+    });
+
+    it('throws if notionToken is missing', async () => {
+        const { NotionDataProvider } = await import('../indexing/providers/notion.js');
+        expect(() => new NotionDataProvider(
+            makeConfig(),
+            { cloneDir: '/tmp' },
+        )).toThrow('notionToken');
+    });
+
+    // ── fullAcquire ─────────────────────────────────────────────────────
+
+    it('fullAcquire with search-all mode (no root_pages/databases)', async () => {
+        const pages = [
+            makePage('p1', 'Page One', '2025-01-01T00:00:00Z'),
+            makePage('p2', 'Page Two', '2025-01-02T00:00:00Z'),
+        ];
+        mockSearchPages.mockResolvedValue(pages);
+        mockGetPageContent.mockImplementation(async (id: string) =>
+            id === 'p1' ? '# Page One\nContent' : '# Page Two\nMore content',
+        );
+
+        const provider = await createProvider();
+        const result = await provider.fullAcquire();
+
+        expect(result.items).toHaveLength(2);
+        expect(result.items[0].id).toBe('p1');
+        expect(result.items[0].title).toBe('Page One');
+        expect(result.items[0].content).toBe('# Page One\nContent');
+        expect(result.items[0].sourceUrl).toBe('https://notion.so/p1');
+        expect(result.items[1].id).toBe('p2');
+        expect(result.removedIds).toEqual([]);
+        expect(result.stateToken).toBe('2025-01-02T00:00:00Z');
+    });
+
+    it('fullAcquire with databases (property header prepended)', async () => {
+        const pages = [
+            makePage('dp1', 'DB Page', '2025-03-01T00:00:00Z', 'database', {
+                title: 'DB Page',
+                Status: 'Done',
+                Priority: 'High',
+            }),
+        ];
+        mockQueryDatabase.mockResolvedValue(pages);
+        mockGetPageContent.mockResolvedValue('Some content');
+
+        const provider = await createProvider(makeConfig({ databases: ['db1'] }));
+        const result = await provider.fullAcquire();
+
+        expect(result.items).toHaveLength(1);
+        // Should have YAML frontmatter with Status and Priority, but not title
+        expect(result.items[0].content).toContain('---');
+        expect(result.items[0].content).toContain('Status: Done');
+        expect(result.items[0].content).toContain('Priority: High');
+        expect(result.items[0].content).not.toMatch(/^---\n.*title:/m);
+        expect(result.items[0].content).toContain('Some content');
+    });
+
+    it('fullAcquire with include_properties=false (no header)', async () => {
+        const pages = [
+            makePage('dp1', 'DB Page', '2025-03-01T00:00:00Z', 'database', {
+                title: 'DB Page',
+                Status: 'Done',
+            }),
+        ];
+        mockQueryDatabase.mockResolvedValue(pages);
+        mockGetPageContent.mockResolvedValue('Some content');
+
+        const provider = await createProvider(makeConfig({ databases: ['db1'], include_properties: false }));
+        const result = await provider.fullAcquire();
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].content).toBe('Some content');
+        expect(result.items[0].content).not.toContain('---');
+    });
+
+    it('fullAcquire with root_pages', async () => {
+        const page = makePage('rp1', 'Root Page', '2025-02-01T00:00:00Z');
+        mockGetPageMeta.mockResolvedValue(page);
+        mockGetPageContent.mockResolvedValue('Root content');
+
+        const provider = await createProvider(makeConfig({ root_pages: ['rp1'] }));
+        const result = await provider.fullAcquire();
+
+        expect(mockGetPageMeta).toHaveBeenCalledWith('rp1');
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('rp1');
+        expect(result.items[0].content).toBe('Root content');
+    });
+
+    it('fullAcquire deduplicates pages in both root_pages and database', async () => {
+        const page = makePage('dup1', 'Shared Page', '2025-04-01T00:00:00Z');
+        mockGetPageMeta.mockResolvedValue(page);
+        mockQueryDatabase.mockResolvedValue([page]);
+        mockGetPageContent.mockResolvedValue('Content');
+
+        const provider = await createProvider(makeConfig({ root_pages: ['dup1'], databases: ['db1'] }));
+        const result = await provider.fullAcquire();
+
+        // Should only appear once despite being in both root_pages and database
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('dup1');
+    });
+
+    // ── incrementalAcquire ──────────────────────────────────────────────
+
+    it('incrementalAcquire filters to recently edited pages', async () => {
+        const oldPage = makePage('old1', 'Old', '2025-01-01T00:00:00Z');
+        const newPage = makePage('new1', 'New', '2025-06-01T00:00:00Z');
+        // discoverAllPages returns both
+        mockSearchPages.mockResolvedValueOnce([oldPage, newPage]);
+        // discoverEditedPages returns only new
+        mockSearchPages.mockResolvedValueOnce([newPage]);
+        mockGetPageContent.mockResolvedValue('New content');
+
+        const provider = await createProvider();
+        const result = await provider.incrementalAcquire('2025-03-01T00:00:00Z');
+
+        // Only the new page should have content acquired
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('new1');
+    });
+
+    it('incrementalAcquire detects deleted pages via removedIds', async () => {
+        // Full discovery returns only p2 (p1 was deleted)
+        mockSearchPages.mockResolvedValueOnce([makePage('p2', 'Two', '2025-06-01T00:00:00Z')]);
+        // Edited pages returns p2
+        mockSearchPages.mockResolvedValueOnce([makePage('p2', 'Two', '2025-06-01T00:00:00Z')]);
+        mockGetPageContent.mockResolvedValue('Content');
+        // DB has both p1 and p2 indexed
+        mockGetIndexedItemIds.mockResolvedValue(new Set(['p1', 'p2']));
+
+        const provider = await createProvider();
+        const result = await provider.incrementalAcquire('2025-03-01T00:00:00Z');
+
+        expect(result.removedIds).toContain('p1');
+        expect(result.removedIds).not.toContain('p2');
+    });
+
+    it('incrementalAcquire returns early when no changes', async () => {
+        const page = makePage('p1', 'One', '2025-01-01T00:00:00Z');
+        // Full discover returns p1
+        mockSearchPages.mockResolvedValueOnce([page]);
+        // Edited pages returns empty (nothing changed)
+        mockSearchPages.mockResolvedValueOnce([]);
+        // DB has p1 indexed
+        mockGetIndexedItemIds.mockResolvedValue(new Set(['p1']));
+
+        const provider = await createProvider();
+        const result = await provider.incrementalAcquire('2025-03-01T00:00:00Z');
+
+        expect(result.items).toHaveLength(0);
+        expect(result.removedIds).toHaveLength(0);
+        expect(result.stateToken).toBe('2025-03-01T00:00:00Z');
+        // Should not have called getPageContent at all
+        expect(mockGetPageContent).not.toHaveBeenCalled();
+    });
+
+    // ── getCurrentStateToken ────────────────────────────────────────────
+
+    it('getCurrentStateToken returns latest timestamp', async () => {
+        mockSearchPages.mockResolvedValue([
+            makePage('p1', 'One', '2025-01-01T00:00:00Z'),
+            makePage('p2', 'Two', '2025-06-15T12:00:00Z'),
+            makePage('p3', 'Three', '2025-03-01T00:00:00Z'),
+        ]);
+
+        const provider = await createProvider();
+        const token = await provider.getCurrentStateToken();
+
+        expect(token).toBe('2025-06-15T12:00:00Z');
+    });
+
+    it('getCurrentStateToken returns null when empty', async () => {
+        mockSearchPages.mockResolvedValue([]);
+
+        const provider = await createProvider();
+        const token = await provider.getCurrentStateToken();
+
+        expect(token).toBeNull();
+    });
+
+    // ── Error handling ──────────────────────────────────────────────────
+
+    it('partial failure: continues when individual page fails', async () => {
+        mockSearchPages.mockResolvedValue([
+            makePage('p1', 'One', '2025-01-01T00:00:00Z'),
+            makePage('p2', 'Two', '2025-01-02T00:00:00Z'),
+        ]);
+        mockGetPageContent.mockImplementation(async (id: string) => {
+            if (id === 'p1') throw new Error('API error');
+            return 'Content for p2';
+        });
+
+        const provider = await createProvider();
+        const result = await provider.fullAcquire();
+
+        // p1 failed, p2 succeeded
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].id).toBe('p2');
+    });
+
+    it('all pages fail: throws', async () => {
+        mockSearchPages.mockResolvedValue([
+            makePage('p1', 'One', '2025-01-01T00:00:00Z'),
+            makePage('p2', 'Two', '2025-01-02T00:00:00Z'),
+        ]);
+        mockGetPageContent.mockRejectedValue(new Error('API error'));
+
+        const provider = await createProvider();
+        await expect(provider.fullAcquire()).rejects.toThrow('All 2 page(s) failed');
+    });
+
+    it('empty page: indexed with title-only content', async () => {
+        mockSearchPages.mockResolvedValue([
+            makePage('p1', 'Empty Page', '2025-01-01T00:00:00Z'),
+        ]);
+        mockGetPageContent.mockResolvedValue('');
+
+        const provider = await createProvider();
+        const result = await provider.fullAcquire();
+
+        expect(result.items).toHaveLength(1);
+        expect(result.items[0].content).toBe('# Empty Page');
+    });
+});

--- a/src/__tests__/raw-text-chunker.test.ts
+++ b/src/__tests__/raw-text-chunker.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect } from 'vitest';
+import { chunkRawText } from '../indexing/chunking/raw-text.js';
+import type { SourceConfig } from '../types.js';
+
+// Helper to build a minimal SourceConfig for raw-text chunking
+function mkConfig(overrides: { target_tokens?: number; overlap_tokens?: number } = {}): SourceConfig {
+    return {
+        name: 'test',
+        type: 'raw-text',
+        path: '/tmp',
+        file_patterns: ['*.txt'],
+        chunk: {
+            target_tokens: overrides.target_tokens,
+            overlap_tokens: overrides.overlap_tokens,
+        },
+    } as SourceConfig;
+}
+
+describe('chunkRawText', () => {
+    // ── Empty / whitespace input ────────────────────────────────────────
+
+    it('returns empty array for empty string', () => {
+        expect(chunkRawText('', 'test.txt', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array for whitespace-only string', () => {
+        expect(chunkRawText('   \n\n  ', 'test.txt', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array for null/undefined content', () => {
+        expect(chunkRawText(null as any, 'test.txt', mkConfig())).toEqual([]);
+        expect(chunkRawText(undefined as any, 'test.txt', mkConfig())).toEqual([]);
+    });
+
+    it('returns empty array for only newlines', () => {
+        expect(chunkRawText('\n\n\n\n', 'test.txt', mkConfig())).toEqual([]);
+    });
+
+    // ── Single chunk ────────────────────────────────────────────────────
+
+    it('returns a single chunk for small content', () => {
+        const content = 'Hello world.';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig());
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].content).toBe('Hello world.');
+        expect(chunks[0].chunkIndex).toBe(0);
+    });
+
+    it('returns a single chunk when content is under target size', () => {
+        const content = 'Paragraph one.\n\nParagraph two.';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 600 }));
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].content).toContain('Paragraph one');
+        expect(chunks[0].content).toContain('Paragraph two');
+    });
+
+    // ── Paragraph-based splitting ───────────────────────────────────────
+
+    it('splits on double newlines', () => {
+        const para = 'Word '.repeat(200);
+        const content = `${para}\n\n${para}\n\n${para}`;
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 100 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    it('merges small adjacent paragraphs', () => {
+        const content = 'Short one.\n\nShort two.\n\nShort three.';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 600 }));
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].content).toContain('Short one');
+        expect(chunks[0].content).toContain('Short two');
+        expect(chunks[0].content).toContain('Short three');
+    });
+
+    it('splits when merged paragraphs exceed target', () => {
+        const smallPara = 'Word '.repeat(80); // ~400 chars
+        const content = Array.from({ length: 10 }, () => smallPara).join('\n\n');
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 100 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    it('handles triple+ newlines as paragraph separators', () => {
+        const content = 'Para 1.\n\n\n\nPara 2.\n\n\n\n\nPara 3.';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig());
+        expect(chunks).toHaveLength(1);
+        expect(chunks[0].content).toContain('Para 1');
+        expect(chunks[0].content).toContain('Para 2');
+        expect(chunks[0].content).toContain('Para 3');
+    });
+
+    it('filters out whitespace-only paragraphs', () => {
+        const content = 'Real content.\n\n   \n\n\n\nMore real content.';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig());
+        expect(chunks).toHaveLength(1);
+        // Should not have empty/whitespace chunks
+        for (const chunk of chunks) {
+            expect(chunk.content.trim().length).toBeGreaterThan(0);
+        }
+    });
+
+    // ── chunkIndex numbering ────────────────────────────────────────────
+
+    it('sets chunkIndex sequentially', () => {
+        const para = 'Word '.repeat(200);
+        const content = Array.from({ length: 5 }, () => para).join('\n\n');
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 100 }));
+        for (let i = 0; i < chunks.length; i++) {
+            expect(chunks[i].chunkIndex).toBe(i);
+        }
+    });
+
+    // ── Overlap ─────────────────────────────────────────────────────────
+
+    it('applies overlap between chunks', () => {
+        const para = 'UniqueMarker ' + 'Word '.repeat(200);
+        const content = `${para}\n\n${para}\n\n${para}`;
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 100, overlap_tokens: 30 }));
+        if (chunks.length >= 2) {
+            // The second chunk should start with some text from the end of the first
+            // (overlap prepended)
+            expect(chunks[1].content.length).toBeGreaterThan(0);
+        }
+    });
+
+    it('does not apply overlap to the first chunk', () => {
+        const para = 'Word '.repeat(200);
+        const content = `${para}\n\n${para}`;
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 100, overlap_tokens: 30 }));
+        // First chunk should just be the first paragraph content
+        expect(chunks[0].content).not.toContain('\n\n\n');
+    });
+
+    it('finds clean break point in overlap at newline', () => {
+        // Build content where the overlap region contains newlines
+        const line = 'Word '.repeat(40);
+        const para = `${line}\n${line}\n${line}`;
+        const content = `${para}\n\n${para}\n\n${para}`;
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 80, overlap_tokens: 20 }));
+        // Just verify it doesn't crash and produces valid chunks
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+        for (const chunk of chunks) {
+            expect(chunk.content.trim().length).toBeGreaterThan(0);
+        }
+    });
+
+    it('does not apply overlap when overlap_tokens is 0', () => {
+        const para = 'Word '.repeat(200);
+        const content = `${para}\n\n${para}\n\n${para}`;
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 100, overlap_tokens: 0 }));
+        expect(chunks.length).toBeGreaterThan(1);
+    });
+
+    // ── Token-based sizing ──────────────────────────────────────────────
+
+    it('respects custom target_tokens for smaller chunks', () => {
+        const content = 'Word '.repeat(500);
+        const smallChunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 50 }));
+        const largeChunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 500 }));
+        expect(smallChunks.length).toBeGreaterThanOrEqual(largeChunks.length);
+    });
+
+    it('uses default target_tokens (600) when not specified', () => {
+        const content = 'Short text.';
+        const config = mkConfig();
+        delete (config as any).chunk.target_tokens;
+        const chunks = chunkRawText(content, 'test.txt', config);
+        expect(chunks).toHaveLength(1);
+    });
+
+    it('uses default overlap_tokens (50) when not specified', () => {
+        const para = 'Word '.repeat(200);
+        const content = `${para}\n\n${para}`;
+        const config = mkConfig({ target_tokens: 100 });
+        delete (config as any).chunk.overlap_tokens;
+        const chunks = chunkRawText(content, 'test.txt', config);
+        expect(chunks.length).toBeGreaterThanOrEqual(1);
+    });
+
+    // ── Special characters ──────────────────────────────────────────────
+
+    it('handles content with special characters', () => {
+        const content = 'Content with $pecial ch@rs: [brackets] {braces} (parens) & <angles>';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig());
+        expect(chunks[0].content).toContain('$pecial');
+    });
+
+    it('handles unicode content', () => {
+        const content = 'Unicode: \u{1F680}\u{1F30D} and CJK: \u4F60\u597D\u4E16\u754C';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig());
+        expect(chunks[0].content).toContain('\u{1F680}');
+        expect(chunks[0].content).toContain('\u4F60\u597D');
+    });
+
+    // ── Trimming ────────────────────────────────────────────────────────
+
+    it('trims chunk content', () => {
+        const content = '  \n  Hello world.  \n  ';
+        const chunks = chunkRawText(content, 'test.txt', mkConfig());
+        expect(chunks[0].content).toBe('Hello world.');
+    });
+
+    // ── Very long single paragraph ──────────────────────────────────────
+
+    it('handles a single very long paragraph without double newlines', () => {
+        const content = 'Word '.repeat(2000);
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 100 }));
+        // Without paragraph breaks, it stays as one chunk
+        expect(chunks).toHaveLength(1);
+    });
+
+    // ── filePath parameter is unused but accepted ───────────────────────
+
+    it('accepts any filePath without error', () => {
+        const chunks = chunkRawText('Some content.', '', mkConfig());
+        expect(chunks).toHaveLength(1);
+    });
+
+    // ── No metadata fields beyond content and chunkIndex ────────────────
+
+    it('only has content and chunkIndex in output', () => {
+        const chunks = chunkRawText('Hello.', 'test.txt', mkConfig());
+        expect(chunks[0]).toHaveProperty('content');
+        expect(chunks[0]).toHaveProperty('chunkIndex');
+        // Should not have markdown/code-specific fields
+        expect(chunks[0].title).toBeUndefined();
+        expect(chunks[0].language).toBeUndefined();
+        expect(chunks[0].startLine).toBeUndefined();
+    });
+
+    // ── Many small paragraphs ───────────────────────────────────────────
+
+    it('merges many small paragraphs into fewer chunks', () => {
+        const content = Array.from({ length: 50 }, (_, i) => `Para ${i}.`).join('\n\n');
+        const chunks = chunkRawText(content, 'test.txt', mkConfig({ target_tokens: 600 }));
+        // 50 tiny paragraphs should merge into far fewer chunks
+        expect(chunks.length).toBeLessThan(50);
+    });
+});

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from 'vitest';
+import { generateSchema, generateMigration, generatePostSchemaMigration } from '../db/schema.js';
+
+describe('generateSchema', () => {
+    it('returns SQL containing the vector extension', () => {
+        const ddl = generateSchema(1536);
+        expect(ddl).toContain('CREATE EXTENSION IF NOT EXISTS vector');
+    });
+
+    it('includes the correct vector dimension in the chunks table', () => {
+        const ddl = generateSchema(1536);
+        expect(ddl).toContain('vector(1536)');
+    });
+
+    it('parameterizes dimensions correctly for different values', () => {
+        const ddl768 = generateSchema(768);
+        expect(ddl768).toContain('vector(768)');
+        expect(ddl768).not.toContain('vector(1536)');
+
+        const ddl3072 = generateSchema(3072);
+        expect(ddl3072).toContain('vector(3072)');
+    });
+
+    // -- chunks table -----------------------------------------------------
+
+    describe('chunks table', () => {
+        it('creates the chunks table', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('CREATE TABLE IF NOT EXISTS chunks');
+        });
+
+        it('includes required columns', () => {
+            const ddl = generateSchema(1536);
+            const requiredColumns = [
+                'source_name',
+                'source_url',
+                'title',
+                'content',
+                'embedding',
+                'repo_url',
+                'file_path',
+                'start_line',
+                'end_line',
+                'language',
+                'chunk_index',
+                'metadata',
+                'indexed_at',
+                'commit_sha',
+                'version',
+            ];
+            for (const col of requiredColumns) {
+                expect(ddl).toContain(col);
+            }
+        });
+
+        it('has a unique constraint on source_name, file_path, chunk_index', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('chunks_source_file_chunk_uniq');
+            expect(ddl).toContain('UNIQUE (source_name, file_path, chunk_index)');
+        });
+
+        it('defines HNSW index on embedding column', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('CREATE INDEX IF NOT EXISTS idx_chunks_embedding');
+            expect(ddl).toContain('USING hnsw (embedding vector_cosine_ops)');
+        });
+
+        it('defines indexes on source_name and repo_url', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('CREATE INDEX IF NOT EXISTS idx_chunks_source_name');
+            expect(ddl).toContain('CREATE INDEX IF NOT EXISTS idx_chunks_repo_url');
+        });
+
+        it('has a serial primary key', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toMatch(/id\s+SERIAL PRIMARY KEY/);
+        });
+
+        it('defaults metadata to empty JSON object', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain("JSONB NOT NULL DEFAULT '{}'");
+        });
+
+        it('defaults indexed_at to NOW()', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('TIMESTAMPTZ NOT NULL DEFAULT NOW()');
+        });
+    });
+
+    // -- index_state table ------------------------------------------------
+
+    describe('index_state table', () => {
+        it('creates the index_state table', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('CREATE TABLE IF NOT EXISTS index_state');
+        });
+
+        it('includes required columns', () => {
+            const ddl = generateSchema(1536);
+            const cols = ['source_type', 'source_key', 'last_commit_sha', 'last_indexed_at', 'status', 'error_message'];
+            for (const col of cols) {
+                expect(ddl).toContain(col);
+            }
+        });
+
+        it('has a unique constraint on source_type, source_key', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('index_state_source_uniq');
+            expect(ddl).toContain('UNIQUE (source_type, source_key)');
+        });
+
+        it('defaults status to idle', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain("DEFAULT 'idle'");
+        });
+    });
+
+    // -- collected_data table ---------------------------------------------
+
+    describe('collected_data table', () => {
+        it('creates the collected_data table', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('CREATE TABLE IF NOT EXISTS collected_data');
+        });
+
+        it('includes required columns', () => {
+            const ddl = generateSchema(1536);
+            expect(ddl).toContain('tool_name');
+            expect(ddl).toContain('data');
+            expect(ddl).toContain('created_at');
+        });
+    });
+});
+
+describe('generateMigration', () => {
+    it('drops doc_chunks table', () => {
+        const sql = generateMigration();
+        expect(sql).toContain('DROP TABLE IF EXISTS doc_chunks CASCADE');
+    });
+
+    it('drops code_chunks table', () => {
+        const sql = generateMigration();
+        expect(sql).toContain('DROP TABLE IF EXISTS code_chunks CASCADE');
+    });
+});
+
+describe('generatePostSchemaMigration', () => {
+    it('adds version column to chunks', () => {
+        const sql = generatePostSchemaMigration();
+        expect(sql).toContain('ALTER TABLE chunks ADD COLUMN IF NOT EXISTS version TEXT');
+    });
+
+    it('creates index on version column', () => {
+        const sql = generatePostSchemaMigration();
+        expect(sql).toContain('CREATE INDEX IF NOT EXISTS idx_chunks_version ON chunks (version)');
+    });
+});

--- a/src/__tests__/search-tool.test.ts
+++ b/src/__tests__/search-tool.test.ts
@@ -1,0 +1,422 @@
+import { describe, it, expect, vi, beforeAll, beforeEach, afterAll } from 'vitest';
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
+import type { SearchToolConfig, ChunkResult } from '../types.js';
+
+vi.mock('../db/queries.js', () => ({
+    searchChunks: vi.fn(),
+}));
+
+import { registerSearchTool } from '../mcp/tools/search.js';
+import { searchChunks } from '../db/queries.js';
+
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockEmbed = vi.fn();
+
+function makeChunkResult(overrides: Partial<ChunkResult> = {}): ChunkResult {
+    return {
+        id: 1,
+        source_name: 'docs',
+        source_url: 'https://docs.example.com/getting-started',
+        title: 'Getting Started',
+        content: 'This is the getting started guide.',
+        repo_url: 'https://github.com/org/repo',
+        file_path: 'docs/getting-started.md',
+        start_line: null,
+        end_line: null,
+        language: null,
+        similarity: 0.95,
+        ...overrides,
+    };
+}
+
+const baseToolConfig: SearchToolConfig = {
+    name: 'search-docs',
+    type: 'search',
+    description: 'Search the documentation.',
+    source: 'docs',
+    default_limit: 5,
+    max_limit: 20,
+    result_format: 'docs',
+};
+
+// ── Full MCP protocol tests ────────────────────────────────────────────────
+
+describe('search tool via MCP protocol (docs format)', () => {
+    let client: Client;
+    let server: McpServer;
+
+    beforeAll(async () => {
+        server = new McpServer({ name: 'test', version: '1.0.0' });
+        const embeddingClient = { embed: mockEmbed };
+        registerSearchTool(server as never, embeddingClient as never, baseToolConfig);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        client = new Client({ name: 'test-client', version: '1.0.0' });
+        await client.connect(clientTransport);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    it('lists the search tool with correct name and description', async () => {
+        const { tools } = await client.listTools();
+        const tool = tools.find(t => t.name === 'search-docs');
+        expect(tool).toBeDefined();
+        expect(tool!.description).toBe('Search the documentation.');
+    });
+
+    it('returns formatted docs results for a valid query', async () => {
+        const embedding = [0.1, 0.2, 0.3];
+        mockEmbed.mockResolvedValueOnce(embedding);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({ title: 'Guide', content: 'Hello world', source_url: 'https://docs.example.com/guide' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'hello' },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('SNIPPET 1');
+        expect(text).toContain('TITLE: Guide');
+        expect(text).toContain('SOURCE: https://docs.example.com/guide');
+        expect(text).toContain('CONTENT:');
+        expect(text).toContain('Hello world');
+
+        expect(mockEmbed).toHaveBeenCalledWith('hello');
+        expect(mockSearchChunks).toHaveBeenCalledWith(embedding, 5, 'docs', undefined);
+    });
+
+    it('uses provided limit instead of default', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([]);
+
+        await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test', limit: 10 },
+        });
+
+        expect(mockSearchChunks).toHaveBeenCalledWith([0.1], 10, 'docs', undefined);
+    });
+
+    it('passes version filter when provided', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([]);
+
+        await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test', version: 'v2.0' },
+        });
+
+        expect(mockSearchChunks).toHaveBeenCalledWith([0.1], 5, 'docs', 'v2.0');
+    });
+
+    it('returns "No results found." when no results match', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([]);
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'nonexistent topic' },
+        });
+
+        expect(result.isError).toBeFalsy();
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toBe('No results found.');
+    });
+
+    it('filters results by min_score when provided', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({ similarity: 0.9, title: 'High' }),
+            makeChunkResult({ similarity: 0.3, title: 'Low' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test', min_score: 0.5 },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('High');
+        expect(text).not.toContain('Low');
+    });
+
+    it('returns error response on embedding failure', async () => {
+        mockEmbed.mockRejectedValueOnce(new Error('API rate limit'));
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test' },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toBe('Error: Search failed. Please try again later.');
+    });
+
+    it('returns error response on search failure', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockRejectedValueOnce(new Error('DB connection lost'));
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test' },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toBe('Error: Search failed. Please try again later.');
+    });
+
+    it('handles non-Error thrown values in catch', async () => {
+        mockEmbed.mockRejectedValueOnce('raw string error');
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test' },
+        });
+
+        expect(result.isError).toBe(true);
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toBe('Error: Search failed. Please try again later.');
+    });
+
+    it('formats multiple results with numbered snippets and separators', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({ title: 'First', content: 'First content' }),
+            makeChunkResult({ title: 'Second', content: 'Second content' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('SNIPPET 1');
+        expect(text).toContain('SNIPPET 2');
+        expect(text).toContain('---');
+    });
+
+    it('uses file_path as TITLE fallback when title is null', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({ title: null, file_path: 'docs/readme.md' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('TITLE: docs/readme.md');
+    });
+
+    it('uses file_path as SOURCE fallback when source_url is null', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({ source_url: null, file_path: 'docs/readme.md' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-docs',
+            arguments: { query: 'test' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('SOURCE: docs/readme.md');
+    });
+});
+
+// ── Code format tests ────────────────────────────────────────────────────────
+
+describe('search tool via MCP protocol (code format)', () => {
+    let client: Client;
+    let server: McpServer;
+
+    beforeAll(async () => {
+        server = new McpServer({ name: 'test-code', version: '1.0.0' });
+        const embeddingClient = { embed: mockEmbed };
+        const codeConfig: SearchToolConfig = {
+            ...baseToolConfig,
+            name: 'search-code',
+            result_format: 'code',
+            source: 'code',
+        };
+        registerSearchTool(server as never, embeddingClient as never, codeConfig);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        client = new Client({ name: 'test-client', version: '1.0.0' });
+        await client.connect(clientTransport);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    it('formats results with REPOSITORY and PATH fields', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({
+                repo_url: 'https://github.com/org/repo',
+                file_path: 'src/main.ts',
+                content: 'function hello() {}',
+            }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-code',
+            arguments: { query: 'hello function' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('REPOSITORY: https://github.com/org/repo');
+        expect(text).toContain('PATH: src/main.ts');
+        expect(text).toContain('function hello() {}');
+        // Code format should NOT have TITLE
+        expect(text).not.toContain('TITLE:');
+    });
+});
+
+// ── Raw format tests ─────────────────────────────────────────────────────────
+
+describe('search tool via MCP protocol (raw format)', () => {
+    let client: Client;
+    let server: McpServer;
+
+    beforeAll(async () => {
+        server = new McpServer({ name: 'test-raw', version: '1.0.0' });
+        const embeddingClient = { embed: mockEmbed };
+        const rawConfig: SearchToolConfig = {
+            ...baseToolConfig,
+            name: 'search-raw',
+            result_format: 'raw',
+            source: 'raw',
+        };
+        registerSearchTool(server as never, embeddingClient as never, rawConfig);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        client = new Client({ name: 'test-client', version: '1.0.0' });
+        await client.connect(clientTransport);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    it('formats results with SOURCE and CONTENT only', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({
+                source_url: 'https://example.com/page',
+                content: 'Raw content here',
+            }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-raw',
+            arguments: { query: 'raw' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('SOURCE: https://example.com/page');
+        expect(text).toContain('Raw content here');
+        // Raw format should NOT have TITLE or REPOSITORY
+        expect(text).not.toContain('TITLE:');
+        expect(text).not.toContain('REPOSITORY:');
+    });
+});
+
+// ── min_score from config tests ─────────────────────────────────────────────
+
+describe('search tool config-level min_score', () => {
+    let client: Client;
+    let server: McpServer;
+
+    beforeAll(async () => {
+        server = new McpServer({ name: 'test-minscore', version: '1.0.0' });
+        const embeddingClient = { embed: mockEmbed };
+        const configWithMinScore: SearchToolConfig = {
+            ...baseToolConfig,
+            name: 'search-filtered',
+            min_score: 0.6,
+        };
+        registerSearchTool(server as never, embeddingClient as never, configWithMinScore);
+
+        const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
+        await server.connect(serverTransport);
+        client = new Client({ name: 'test-client', version: '1.0.0' });
+        await client.connect(clientTransport);
+    });
+
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    afterAll(async () => {
+        await client.close();
+        await server.close();
+    });
+
+    it('applies config-level min_score when request min_score is not provided', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({ similarity: 0.9, title: 'High' }),
+            makeChunkResult({ similarity: 0.4, title: 'Low' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-filtered',
+            arguments: { query: 'test' },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('High');
+        expect(text).not.toContain('Low');
+    });
+
+    it('request min_score overrides config-level min_score', async () => {
+        mockEmbed.mockResolvedValueOnce([0.1]);
+        mockSearchChunks.mockResolvedValueOnce([
+            makeChunkResult({ similarity: 0.9, title: 'High' }),
+            makeChunkResult({ similarity: 0.4, title: 'Medium' }),
+            makeChunkResult({ similarity: 0.1, title: 'Low' }),
+        ]);
+
+        const result = await client.callTool({
+            name: 'search-filtered',
+            arguments: { query: 'test', min_score: 0.3 },
+        });
+
+        const text = (result.content as Array<{ type: string; text: string }>)[0].text;
+        expect(text).toContain('High');
+        expect(text).toContain('Medium');
+        expect(text).not.toContain('Low');
+    });
+});

--- a/src/__tests__/slack-config.test.ts
+++ b/src/__tests__/slack-config.test.ts
@@ -155,7 +155,7 @@ describe('SourceConfig discriminated union', () => {
             chunk: { target_tokens: 600, overlap_tokens: 50 },
         };
         const result = SourceConfigSchema.parse(config);
-        if (result.type !== 'slack' && result.type !== 'discord') {
+        if (result.type !== 'slack' && result.type !== 'discord' && result.type !== 'notion') {
             // TypeScript should know this is FileSourceConfig
             expect(result.path).toBe('docs/');
             expect(result.file_patterns).toEqual(['**/*.md']);

--- a/src/__tests__/url-derivation.test.ts
+++ b/src/__tests__/url-derivation.test.ts
@@ -1,0 +1,236 @@
+import { describe, it, expect } from 'vitest';
+import { deriveUrl } from '../indexing/url-derivation.js';
+import type { FileSourceConfig } from '../types.js';
+
+/** Helper to build a minimal FileSourceConfig with url_derivation options. */
+function makeConfig(
+    baseUrl: string,
+    derivation: FileSourceConfig['url_derivation'] = {},
+): FileSourceConfig {
+    return {
+        name: 'test',
+        type: 'markdown',
+        path: '.',
+        file_patterns: ['**/*.md'],
+        chunk: { target_tokens: 500 },
+        base_url: baseUrl,
+        url_derivation: derivation,
+    };
+}
+
+describe('deriveUrl', () => {
+    // ── Returns null when not configured ────────────────────────────────────
+
+    it('returns null when base_url is missing', () => {
+        const config: FileSourceConfig = {
+            name: 'test',
+            type: 'markdown',
+            path: '.',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 500 },
+            url_derivation: { strip_suffix: '.md' },
+        };
+        expect(deriveUrl('docs/page.md', config)).toBeNull();
+    });
+
+    it('returns null when url_derivation is missing', () => {
+        const config: FileSourceConfig = {
+            name: 'test',
+            type: 'markdown',
+            path: '.',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 500 },
+            base_url: 'https://example.com/docs/',
+        };
+        expect(deriveUrl('docs/page.md', config)).toBeNull();
+    });
+
+    it('returns null when both base_url and url_derivation are missing', () => {
+        const config: FileSourceConfig = {
+            name: 'test',
+            type: 'markdown',
+            path: '.',
+            file_patterns: ['**/*.md'],
+            chunk: { target_tokens: 500 },
+        };
+        expect(deriveUrl('docs/page.md', config)).toBeNull();
+    });
+
+    // ── No derivation options (empty object) ────────────────────────────────
+
+    it('returns base_url + full path when derivation options are empty', () => {
+        const config = makeConfig('https://example.com/docs/');
+        expect(deriveUrl('getting-started.md', config)).toBe(
+            'https://example.com/docs/getting-started.md',
+        );
+    });
+
+    // ── strip_prefix ────────────────────────────────────────────────────────
+
+    it('strips a matching prefix', () => {
+        const config = makeConfig('https://example.com/', { strip_prefix: 'docs/' });
+        expect(deriveUrl('docs/guide/intro.md', config)).toBe(
+            'https://example.com/guide/intro.md',
+        );
+    });
+
+    it('leaves path unchanged when prefix does not match', () => {
+        const config = makeConfig('https://example.com/', { strip_prefix: 'src/' });
+        expect(deriveUrl('docs/guide/intro.md', config)).toBe(
+            'https://example.com/docs/guide/intro.md',
+        );
+    });
+
+    it('strips prefix only from the start (not mid-path)', () => {
+        const config = makeConfig('https://example.com/', { strip_prefix: 'guide/' });
+        expect(deriveUrl('docs/guide/intro.md', config)).toBe(
+            'https://example.com/docs/guide/intro.md',
+        );
+    });
+
+    // ── strip_suffix ────────────────────────────────────────────────────────
+
+    it('strips a matching suffix', () => {
+        const config = makeConfig('https://example.com/', { strip_suffix: '.md' });
+        expect(deriveUrl('guide/intro.md', config)).toBe('https://example.com/guide/intro');
+    });
+
+    it('strips .mdx suffix', () => {
+        const config = makeConfig('https://example.com/', { strip_suffix: '.mdx' });
+        expect(deriveUrl('guide/intro.mdx', config)).toBe('https://example.com/guide/intro');
+    });
+
+    it('leaves path unchanged when suffix does not match', () => {
+        const config = makeConfig('https://example.com/', { strip_suffix: '.mdx' });
+        expect(deriveUrl('guide/intro.md', config)).toBe('https://example.com/guide/intro.md');
+    });
+
+    it('strips suffix only from the end (not mid-path)', () => {
+        const config = makeConfig('https://example.com/', { strip_suffix: '.md' });
+        expect(deriveUrl('.md/intro.txt', config)).toBe('https://example.com/.md/intro.txt');
+    });
+
+    it('handles suffix with regex-special characters', () => {
+        const config = makeConfig('https://example.com/', { strip_suffix: '.m+d' });
+        // The suffix ".m+d" should be treated literally, not as regex
+        expect(deriveUrl('guide/intro.m+d', config)).toBe('https://example.com/guide/intro');
+        // "." in the suffix should NOT match arbitrary characters
+        expect(deriveUrl('guide/introXm+d', config)).toBe(
+            'https://example.com/guide/introXm+d',
+        );
+    });
+
+    // ── strip_route_groups ──────────────────────────────────────────────────
+
+    it('strips Next.js-style route groups', () => {
+        const config = makeConfig('https://example.com/', { strip_route_groups: true });
+        expect(deriveUrl('(marketing)/about/page.md', config)).toBe(
+            'https://example.com/about/page.md',
+        );
+    });
+
+    it('strips multiple route groups', () => {
+        const config = makeConfig('https://example.com/', { strip_route_groups: true });
+        expect(deriveUrl('(app)/(dashboard)/settings/page.md', config)).toBe(
+            'https://example.com/settings/page.md',
+        );
+    });
+
+    it('does not strip route groups when disabled', () => {
+        const config = makeConfig('https://example.com/', { strip_route_groups: false });
+        expect(deriveUrl('(marketing)/about/page.md', config)).toBe(
+            'https://example.com/(marketing)/about/page.md',
+        );
+    });
+
+    it('leaves path unchanged when there are no route groups', () => {
+        const config = makeConfig('https://example.com/', { strip_route_groups: true });
+        expect(deriveUrl('about/page.md', config)).toBe('https://example.com/about/page.md');
+    });
+
+    // ── strip_index ─────────────────────────────────────────────────────────
+
+    it('strips trailing /index', () => {
+        const config = makeConfig('https://example.com/', { strip_index: true });
+        expect(deriveUrl('guide/index', config)).toBe('https://example.com/guide');
+    });
+
+    it('strips bare "index" (root index page)', () => {
+        const config = makeConfig('https://example.com/', { strip_index: true });
+        expect(deriveUrl('index', config)).toBe('https://example.com/');
+    });
+
+    it('does not strip "index" when it is part of a filename', () => {
+        const config = makeConfig('https://example.com/', { strip_index: true });
+        expect(deriveUrl('guide/indexing', config)).toBe('https://example.com/guide/indexing');
+    });
+
+    it('does not strip index when disabled', () => {
+        const config = makeConfig('https://example.com/', { strip_index: false });
+        expect(deriveUrl('guide/index', config)).toBe('https://example.com/guide/index');
+    });
+
+    // ── Combined options ────────────────────────────────────────────────────
+
+    it('applies all options together (prefix + suffix + route groups + index)', () => {
+        const config = makeConfig('https://docs.example.com/', {
+            strip_prefix: 'content/',
+            strip_suffix: '.mdx',
+            strip_route_groups: true,
+            strip_index: true,
+        });
+        // Order: strip_prefix -> strip_suffix -> strip_route_groups -> strip_index
+        // 'content/(guides)/getting-started/index.mdx'
+        //  -> strip_prefix 'content/': '(guides)/getting-started/index.mdx'
+        //  -> strip_suffix '.mdx':     '(guides)/getting-started/index'
+        //  -> strip_route_groups:      'getting-started/index'
+        //  -> strip_index:             'getting-started'
+        expect(deriveUrl('content/(guides)/getting-started/index.mdx', config)).toBe(
+            'https://docs.example.com/getting-started',
+        );
+        // Non-index path:
+        expect(deriveUrl('content/(guides)/getting-started/page.mdx', config)).toBe(
+            'https://docs.example.com/getting-started/page',
+        );
+    });
+
+    it('applies prefix + suffix together', () => {
+        const config = makeConfig('https://example.com/docs/', {
+            strip_prefix: 'pages/',
+            strip_suffix: '.md',
+        });
+        expect(deriveUrl('pages/api/reference.md', config)).toBe(
+            'https://example.com/docs/api/reference',
+        );
+    });
+
+    it('applies suffix + index together (suffix stripped before index check)', () => {
+        const config = makeConfig('https://example.com/', {
+            strip_suffix: '.md',
+            strip_index: true,
+        });
+        expect(deriveUrl('guide/index.md', config)).toBe('https://example.com/guide');
+    });
+
+    // ── Edge cases ──────────────────────────────────────────────────────────
+
+    it('handles empty path', () => {
+        const config = makeConfig('https://example.com/');
+        expect(deriveUrl('', config)).toBe('https://example.com/');
+    });
+
+    it('handles path that equals the prefix exactly', () => {
+        const config = makeConfig('https://example.com/', { strip_prefix: 'docs/' });
+        expect(deriveUrl('docs/', config)).toBe('https://example.com/');
+    });
+
+    it('handles deeply nested path', () => {
+        const config = makeConfig('https://example.com/', {
+            strip_prefix: 'content/',
+            strip_suffix: '.md',
+        });
+        expect(deriveUrl('content/a/b/c/d/e/page.md', config)).toBe(
+            'https://example.com/a/b/c/d/e/page',
+        );
+    });
+});

--- a/src/__tests__/validate.test.ts
+++ b/src/__tests__/validate.test.ts
@@ -58,6 +58,7 @@ vi.mock('../config.js', () => {
             nodeEnv: 'test',
             logLevel: 'info',
             cloneDir: '/tmp/test',
+            notionToken: '',
         }),
         getServerConfig: vi.fn().mockReturnValue({
             server: { name: 'test', version: '1.0' },
@@ -90,7 +91,7 @@ vi.mock('../indexing/providers/slack-api.js', () => {
     return { SlackApiClient: MockSlackApiClient };
 });
 
-import { validateConfig } from '../validate.js';
+import { validateConfig, formatValidationResult } from '../validate.js';
 import { existsSync } from 'node:fs';
 import { getConfig, getServerConfig } from '../config.js';
 
@@ -143,6 +144,7 @@ const defaultConfig = {
     nodeEnv: 'test',
     logLevel: 'info',
     cloneDir: '/tmp/test',
+    notionToken: '',
 };
 
 describe('validateConfig', () => {
@@ -169,6 +171,7 @@ describe('validateConfig', () => {
             discordPublicKey: '',
             slackBotToken: '',
             databaseUrl: '',
+            notionToken: '',
         });
 
         const result = await validateConfig();
@@ -220,5 +223,463 @@ describe('validateConfig', () => {
 
         const docsSource = result.sources.find(s => s.name === 'docs');
         expect(docsSource?.valid).toBe(false);
+    });
+
+    // ── Additional coverage tests ────────────────────────────────────────────
+
+    it('sets PATHFINDER_CONFIG when configPath is provided', async () => {
+        const result = await validateConfig('/custom/path.yaml');
+        // The function should set the env var (even though getServerConfig is mocked)
+        expect(process.env.PATHFINDER_CONFIG).toBe('/custom/path.yaml');
+        expect(result.configValid).toBe(true);
+    });
+
+    it('handles non-Error exceptions during config load', async () => {
+        (getServerConfig as ReturnType<typeof vi.fn>).mockImplementation(() => {
+            throw 'string error';
+        });
+
+        const result = await validateConfig();
+        expect(result.configValid).toBe(false);
+        expect(result.errors[0]).toContain('string error');
+    });
+
+    it('reports all missing required env vars', async () => {
+        (getConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            openaiApiKey: '',
+            discordBotToken: '',
+            discordPublicKey: '',
+            slackBotToken: '',
+            databaseUrl: '',
+            notionToken: '',
+        });
+
+        const result = await validateConfig();
+        // Should report DATABASE_URL, OPENAI_API_KEY, DISCORD_BOT_TOKEN, DISCORD_PUBLIC_KEY
+        expect(result.errors.filter(e => e.includes('Missing required environment variable'))).toHaveLength(4);
+    });
+
+    it('marks env vars as not required when no relevant sources/tools', async () => {
+        (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            server: { name: 'test', version: '1.0' },
+            sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+            tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+        });
+        (getConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            openaiApiKey: '',
+            slackBotToken: '',
+            discordBotToken: '',
+            discordPublicKey: '',
+            databaseUrl: '',
+            notionToken: '',
+        });
+
+        const result = await validateConfig();
+        // No errors because collect tools don't require these env vars in validate
+        const requiredEnvs = result.envVars.filter(e => e.required);
+        expect(requiredEnvs).toHaveLength(0);
+    });
+
+    it('marks NOTION_TOKEN as required when notion source exists', async () => {
+        (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            server: { name: 'test', version: '1.0' },
+            sources: [{ name: 'notion-docs', type: 'notion', chunk: {} }],
+            tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+        });
+        (getConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            ...defaultConfig,
+            notionToken: '',
+        });
+
+        const result = await validateConfig();
+        const notionEnv = result.envVars.find(e => e.name === 'NOTION_TOKEN');
+        expect(notionEnv?.required).toBe(true);
+        expect(notionEnv?.present).toBe(false);
+        expect(result.errors.some(e => e.includes('NOTION_TOKEN'))).toBe(true);
+    });
+
+    it('marks SLACK_BOT_TOKEN as required when slack source exists', async () => {
+        (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            server: { name: 'test', version: '1.0' },
+            sources: [{ name: 'slack-src', type: 'slack', channels: ['C123'], chunk: {} }],
+            tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+        });
+        (getConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            ...defaultConfig,
+            slackBotToken: '',
+        });
+
+        const result = await validateConfig();
+        const slackEnv = result.envVars.find(e => e.name === 'SLACK_BOT_TOKEN');
+        expect(slackEnv?.required).toBe(true);
+        expect(slackEnv?.present).toBe(false);
+    });
+
+    it('marks OPENAI_API_KEY as required for discord text channels', async () => {
+        (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            server: { name: 'test', version: '1.0' },
+            sources: [{
+                name: 'disc',
+                type: 'discord',
+                guild_id: '123',
+                channels: [{ id: '1', type: 'text' }],
+                chunk: {},
+            }],
+            tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+        });
+        (getConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+            ...defaultConfig,
+            openaiApiKey: '',
+            discordBotToken: 'token',
+            discordPublicKey: 'key',
+        });
+
+        const result = await validateConfig();
+        const openaiEnv = result.envVars.find(e => e.name === 'OPENAI_API_KEY');
+        expect(openaiEnv?.required).toBe(true);
+    });
+
+    // ── Source validation ────────────────────────────────────────────────────
+
+    describe('source validation', () => {
+        it('validates file source with existing local path', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            });
+            (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(true);
+
+            const result = await validateConfig();
+            const src = result.sources.find(s => s.name === 'docs');
+            expect(src?.valid).toBe(true);
+            expect(src?.details).toContain('exists');
+        });
+
+        it('validates file source with missing local path', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './nonexistent', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            });
+            (existsSync as ReturnType<typeof vi.fn>).mockReturnValue(false);
+
+            const result = await validateConfig();
+            const src = result.sources.find(s => s.name === 'docs');
+            expect(src?.valid).toBe(false);
+            expect(src?.details).toContain('not found');
+            expect(result.errors.some(e => e.includes('docs'))).toBe(true);
+        });
+
+        it('validates file source with remote repo (skips local path check)', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                server: { name: 'test', version: '1.0' },
+                sources: [{
+                    name: 'remote-docs',
+                    type: 'markdown',
+                    path: './docs',
+                    file_patterns: ['**/*.md'],
+                    repo: 'https://github.com/org/repo',
+                    chunk: {},
+                }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            });
+
+            const result = await validateConfig();
+            const src = result.sources.find(s => s.name === 'remote-docs');
+            expect(src?.valid).toBe(true);
+            expect(src?.details).toContain('Remote repo');
+        });
+
+        it('validates slack source (offline mode)', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'slack-src', type: 'slack', channels: ['C123'], chunk: {} }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            });
+
+            const result = await validateConfig();
+            const src = result.sources.find(s => s.name === 'slack-src');
+            expect(src?.valid).toBe(true);
+            expect(src?.details).toContain('Slack validation requires live API probe');
+        });
+
+        it('validates discord source (offline mode)', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                server: { name: 'test', version: '1.0' },
+                sources: [{
+                    name: 'disc',
+                    type: 'discord',
+                    guild_id: '123',
+                    channels: [{ id: '1', type: 'forum' }],
+                    chunk: {},
+                }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            });
+
+            const result = await validateConfig();
+            const src = result.sources.find(s => s.name === 'disc');
+            expect(src?.valid).toBe(true);
+            expect(src?.details).toContain('Discord validation requires live API probe');
+        });
+
+        it('validates notion source (offline mode)', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'notion-src', type: 'notion', chunk: {} }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            });
+
+            const result = await validateConfig();
+            const src = result.sources.find(s => s.name === 'notion-src');
+            expect(src?.valid).toBe(true);
+            expect(src?.details).toContain('Notion validation requires live API probe');
+        });
+
+        it('handles source validation exceptions gracefully', async () => {
+            // Make existsSync throw for file source validation
+            (existsSync as ReturnType<typeof vi.fn>).mockImplementation(() => {
+                throw new Error('Permission denied');
+            });
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                server: { name: 'test', version: '1.0' },
+                sources: [{ name: 'docs', type: 'markdown', path: './docs', file_patterns: ['**/*.md'], chunk: {} }],
+                tools: [{ name: 'c', type: 'collect', description: 'collect', response: 'Collected', schema: { field1: { type: 'string' } } }],
+            });
+
+            const result = await validateConfig();
+            const src = result.sources.find(s => s.name === 'docs');
+            expect(src?.valid).toBe(false);
+            expect(src?.details).toContain('Validation error');
+            expect(result.errors.some(e => e.includes('Permission denied'))).toBe(true);
+        });
+    });
+
+    // ── Tool cross-validation ────────────────────────────────────────────────
+
+    describe('tool cross-validation', () => {
+        it('validates search tool with valid source reference', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                ...defaultServerConfig,
+                tools: [{ name: 'search-docs', type: 'search', source: 'docs', description: 'Search', default_limit: 10, max_limit: 50, result_format: 'docs' }],
+            });
+
+            const result = await validateConfig();
+            const tool = result.tools.find(t => t.name === 'search-docs');
+            expect(tool?.valid).toBe(true);
+            expect(tool?.detail).toContain('docs');
+        });
+
+        it('detects knowledge tool with missing source references', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                ...defaultServerConfig,
+                tools: [{ name: 'faq', type: 'knowledge', sources: ['docs', 'nonexistent'], description: 'FAQ', min_confidence: 0.5, default_limit: 10, max_limit: 50 }],
+            });
+
+            const result = await validateConfig();
+            const tool = result.tools.find(t => t.name === 'faq');
+            expect(tool?.valid).toBe(false);
+            expect(result.errors.some(e => e.includes('nonexistent'))).toBe(true);
+        });
+
+        it('validates bash tool with valid source references', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                ...defaultServerConfig,
+                tools: [{ name: 'bash-tool', type: 'bash', sources: ['docs'], description: 'Bash' }],
+            });
+
+            const result = await validateConfig();
+            const tool = result.tools.find(t => t.name === 'bash-tool');
+            expect(tool?.valid).toBe(true);
+        });
+
+        it('detects bash tool with missing source references', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                ...defaultServerConfig,
+                tools: [{ name: 'bash-tool', type: 'bash', sources: ['docs', 'ghost'], description: 'Bash' }],
+            });
+
+            const result = await validateConfig();
+            const tool = result.tools.find(t => t.name === 'bash-tool');
+            expect(tool?.valid).toBe(false);
+            expect(result.errors.some(e => e.includes('ghost'))).toBe(true);
+        });
+
+        it('accepts collect tool (always valid)', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                ...defaultServerConfig,
+                tools: [{ name: 'collect-tool', type: 'collect', description: 'Collect' }],
+            });
+
+            const result = await validateConfig();
+            const tool = result.tools.find(t => t.name === 'collect-tool');
+            expect(tool?.valid).toBe(true);
+            expect(tool?.detail).toContain('type: collect');
+        });
+
+        it('validates knowledge tool with all valid source references', async () => {
+            (getServerConfig as ReturnType<typeof vi.fn>).mockReturnValue({
+                ...defaultServerConfig,
+                tools: [{ name: 'faq', type: 'knowledge', sources: ['docs', 'discord-support'], description: 'FAQ', min_confidence: 0.5, default_limit: 10, max_limit: 50 }],
+            });
+
+            const result = await validateConfig();
+            const tool = result.tools.find(t => t.name === 'faq');
+            expect(tool?.valid).toBe(true);
+            expect(tool?.detail).toContain('docs');
+            expect(tool?.detail).toContain('discord-support');
+        });
+    });
+});
+
+// ── formatValidationResult ───────────────────────────────────────────────────
+
+describe('formatValidationResult', () => {
+    it('formats a fully valid result', () => {
+        const result: ValidationResult = {
+            configValid: true,
+            envVars: [
+                { name: 'DATABASE_URL', present: true, required: true },
+                { name: 'OPENAI_API_KEY', present: true, required: true },
+            ],
+            sources: [
+                { name: 'docs', type: 'markdown', valid: true, details: 'Path: /docs -- exists' },
+            ],
+            tools: [
+                { name: 'search-docs', valid: true, detail: '-> docs' },
+            ],
+            errors: [],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('Config: valid');
+        expect(output).toContain('DATABASE_URL OK');
+        expect(output).toContain('OPENAI_API_KEY OK');
+        expect(output).toContain('docs (markdown) OK');
+        expect(output).toContain('search-docs OK');
+        expect(output).toContain('All validations passed');
+    });
+
+    it('formats an invalid config result', () => {
+        const result: ValidationResult = {
+            configValid: false,
+            envVars: [],
+            sources: [],
+            tools: [],
+            errors: ['Config validation failed: missing server field'],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('Config: INVALID');
+        expect(output).toContain('1 error(s) found');
+        expect(output).toContain('missing server field');
+    });
+
+    it('formats missing env vars as MISSING', () => {
+        const result: ValidationResult = {
+            configValid: true,
+            envVars: [
+                { name: 'DATABASE_URL', present: false, required: true },
+                { name: 'SLACK_BOT_TOKEN', present: false, required: false },
+            ],
+            sources: [],
+            tools: [],
+            errors: ['Missing required environment variable: DATABASE_URL'],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('DATABASE_URL MISSING');
+        // Non-required env vars should NOT appear in the output
+        expect(output).not.toContain('SLACK_BOT_TOKEN');
+    });
+
+    it('formats failed sources', () => {
+        const result: ValidationResult = {
+            configValid: true,
+            envVars: [],
+            sources: [
+                { name: 'docs', type: 'markdown', valid: false, details: 'Path: /docs -- not found' },
+            ],
+            tools: [],
+            errors: ['Source "docs" validation failed'],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('docs (markdown) FAILED');
+        expect(output).toContain('not found');
+    });
+
+    it('formats source with channels', () => {
+        const result: ValidationResult = {
+            configValid: true,
+            envVars: [],
+            sources: [
+                {
+                    name: 'discord',
+                    type: 'discord',
+                    valid: true,
+                    details: 'Discord guild accessible',
+                    channels: [
+                        { id: '111', name: 'general', valid: true, detail: 'accessible' },
+                        { id: '222', valid: false, detail: 'not found' },
+                    ],
+                },
+            ],
+            tools: [],
+            errors: [],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('111 OK accessible');
+        expect(output).toContain('222 FAILED not found');
+    });
+
+    it('formats failed tools', () => {
+        const result: ValidationResult = {
+            configValid: true,
+            envVars: [],
+            sources: [],
+            tools: [
+                { name: 'bad-tool', valid: false, detail: 'Source "missing" not found' },
+            ],
+            errors: ['Tool "bad-tool" references missing source'],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('bad-tool FAILED');
+        expect(output).toContain('Source "missing" not found');
+    });
+
+    it('formats multiple errors', () => {
+        const result: ValidationResult = {
+            configValid: true,
+            envVars: [],
+            sources: [],
+            tools: [],
+            errors: ['Error one', 'Error two', 'Error three'],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('3 error(s) found');
+        expect(output).toContain('- Error one');
+        expect(output).toContain('- Error two');
+        expect(output).toContain('- Error three');
+    });
+
+    it('includes section headers', () => {
+        const result: ValidationResult = {
+            configValid: true,
+            envVars: [],
+            sources: [],
+            tools: [],
+            errors: [],
+        };
+
+        const output = formatValidationResult(result);
+        expect(output).toContain('Pathfinder Config Validation');
+        expect(output).toContain('============================');
+        expect(output).toContain('Environment Variables:');
+        expect(output).toContain('Sources:');
+        expect(output).toContain('Tools:');
     });
 });

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { ServerConfigSchema, type ServerConfig, isDiscordSourceConfig, isNotionSourceConfig, isFileSourceConfig } from './types.js';
+import { ServerConfigSchema, type ServerConfig, isDiscordSourceConfig, isFileSourceConfig } from './types.js';
 
 // ── Environment variable config (secrets and runtime settings) ────────────────
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -4,7 +4,7 @@ import 'dotenv/config';
 import { readFileSync, existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { parse as parseYaml } from 'yaml';
-import { ServerConfigSchema, type ServerConfig, isDiscordSourceConfig } from './types.js';
+import { ServerConfigSchema, type ServerConfig, isDiscordSourceConfig, isNotionSourceConfig, isFileSourceConfig } from './types.js';
 
 // ── Environment variable config (secrets and runtime settings) ────────────────
 
@@ -21,6 +21,7 @@ export interface Config {
     slackSigningSecret: string;
     discordBotToken: string;
     discordPublicKey: string;
+    notionToken: string;
 }
 
 /**
@@ -96,6 +97,11 @@ function parseConfig(): Config {
     if (hasDiscordSource && !discordPublicKey) missing.push('DISCORD_PUBLIC_KEY');
     if (hasDiscordTextChannels && !openaiApiKey) missing.push('OPENAI_API_KEY (required for Discord text channel distillation)');
 
+    // Notion credentials — required when any notion source is configured
+    const hasNotionSource = getServerConfig().sources.some(s => s.type === 'notion');
+    const notionToken = process.env.NOTION_TOKEN ?? '';
+    if (hasNotionSource && !notionToken) missing.push('NOTION_TOKEN');
+
     if (missing.length > 0) {
         throw new Error(
             `Missing required environment variables: ${missing.join(', ')}. ` +
@@ -121,6 +127,7 @@ function parseConfig(): Config {
         slackSigningSecret,
         discordBotToken,
         discordPublicKey,
+        notionToken,
     };
 }
 
@@ -273,7 +280,7 @@ function loadServerConfig(): ServerConfig {
 
     // Validate local source paths exist (file-based sources only)
     for (const source of result.data.sources) {
-        if (source.type === 'slack' || source.type === 'discord') continue;
+        if (!isFileSourceConfig(source)) continue;
         if (!source.repo) {
             const resolved = resolve(source.path);
             if (!existsSync(resolved)) {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -202,6 +202,19 @@ export async function deleteChunksBySource(sourceName: string): Promise<void> {
     await pool.query("DELETE FROM chunks WHERE source_name = $1", [sourceName]);
 }
 
+/**
+ * Get all unique item IDs (stored as file_path) for a given source.
+ * Used by providers that support deleted-item detection during incremental acquire.
+ */
+export async function getIndexedItemIds(sourceName: string): Promise<Set<string>> {
+    const pool = getPool();
+    const { rows } = await pool.query(
+        "SELECT DISTINCT file_path FROM chunks WHERE source_name = $1",
+        [sourceName],
+    );
+    return new Set(rows.map((r: Record<string, unknown>) => r.file_path as string));
+}
+
 // ---------------------------------------------------------------------------
 // Index state
 // ---------------------------------------------------------------------------

--- a/src/indexing/chunking/index.ts
+++ b/src/indexing/chunking/index.ts
@@ -31,3 +31,4 @@ import { chunkQa } from './qa.js';
 
 registerChunker('slack', chunkQa);
 registerChunker('discord', chunkQa);
+registerChunker('notion', chunkMarkdown);

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -180,6 +180,7 @@ export class IndexingOrchestrator {
             githubToken: config.githubToken,
             slackBotToken: config.slackBotToken,
             discordBotToken: config.discordBotToken,
+            notionToken: config.notionToken,
         };
         const provider = getProvider(source.type)(source, providerOptions);
         return provider.getCurrentStateToken();
@@ -419,7 +420,7 @@ export class IndexingOrchestrator {
     ): Promise<void> {
         const lockKey = `${sourceConfig.type}:${sourceConfig.name}`;
         await this.withSourceLock(lockKey, async () => {
-            const providerOptions: ProviderOptions = { cloneDir, githubToken, slackBotToken: getConfig().slackBotToken, discordBotToken: getConfig().discordBotToken };
+            const providerOptions: ProviderOptions = { cloneDir, githubToken, slackBotToken: getConfig().slackBotToken, discordBotToken: getConfig().discordBotToken, notionToken: getConfig().notionToken };
             const provider = getProvider(sourceConfig.type)(sourceConfig, providerOptions);
             const pipeline = new IndexingPipeline(embeddingClient, sourceConfig);
 

--- a/src/indexing/providers/index.ts
+++ b/src/indexing/providers/index.ts
@@ -32,3 +32,5 @@ registerProvider('slack', (config, options) => new SlackDataProvider(config, opt
 import { DiscordDataProvider } from './discord.js';
 
 registerProvider('discord', (config, options) => new DiscordDataProvider(config, options));
+
+// Notion provider registered after implementation (see notion.ts)

--- a/src/indexing/providers/index.ts
+++ b/src/indexing/providers/index.ts
@@ -33,4 +33,6 @@ import { DiscordDataProvider } from './discord.js';
 
 registerProvider('discord', (config, options) => new DiscordDataProvider(config, options));
 
-// Notion provider registered after implementation (see notion.ts)
+import { NotionDataProvider } from './notion.js';
+
+registerProvider('notion', (config, options) => new NotionDataProvider(config, options));

--- a/src/indexing/providers/notion-api.ts
+++ b/src/indexing/providers/notion-api.ts
@@ -25,6 +25,8 @@ export interface NotionDatabaseMeta {
 export interface NotionApiClientOptions {
     /** Minimum ms between API requests (default: 340 for Notion's 3 req/s limit) */
     minRequestInterval?: number;
+    /** Maximum block recursion depth (default: 10) */
+    maxDepth?: number;
 }
 
 // ── Rate limit helpers ───────────────────────────────────────────────────────
@@ -43,12 +45,14 @@ export class NotionApiClient {
     private client: Client;
     private userCache = new Map<string, string>();
     private minRequestInterval: number;
+    private maxDepth: number;
     private lastRequestTime = 0;
     private logPrefix = '[notion-api]';
 
     constructor(token: string, options?: NotionApiClientOptions) {
         this.client = new Client({ auth: token });
         this.minRequestInterval = options?.minRequestInterval ?? DEFAULT_MIN_REQUEST_INTERVAL;
+        this.maxDepth = options?.maxDepth ?? MAX_RECURSION_DEPTH;
     }
 
     // ── Public methods ──────────────────────────────────────────────────────
@@ -208,7 +212,7 @@ export class NotionApiClient {
      * Fetch all blocks for a parent and convert to markdown lines.
      */
     private async fetchBlocks(parentId: string, depth: number, indent: string = ''): Promise<string[]> {
-        if (depth >= MAX_RECURSION_DEPTH) return [];
+        if (depth >= this.maxDepth) return [];
 
         const blocks = await this.paginateBlockChildren(parentId);
         const lines: string[] = [];
@@ -469,6 +473,11 @@ export class NotionApiClient {
         // Extract title from properties
         const title = this.extractTitle(page.properties);
 
+        // Serialize database entry properties for YAML frontmatter
+        const properties = parentType === 'database'
+            ? this.serializeProperties(page.properties)
+            : undefined;
+
         return {
             id: page.id,
             title,
@@ -476,6 +485,7 @@ export class NotionApiClient {
             url: page.url ?? '',
             parentType,
             parentId,
+            properties,
         };
     }
 

--- a/src/indexing/providers/notion-api.ts
+++ b/src/indexing/providers/notion-api.ts
@@ -1,0 +1,511 @@
+// Notion API client wrapper — handles pagination, rate limiting, block-to-markdown conversion.
+// Uses @notionhq/client for type-safe API access.
+
+import { Client } from '@notionhq/client';
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+export interface NotionPageMeta {
+    id: string;
+    title: string;
+    lastEditedTime: string;  // ISO 8601
+    url: string;
+    parentType: 'workspace' | 'page' | 'database';
+    parentId: string | null;
+    properties?: Record<string, string>;  // for database entries
+}
+
+export interface NotionDatabaseMeta {
+    id: string;
+    title: string;
+    url: string;
+    propertyNames: string[];
+}
+
+export interface NotionApiClientOptions {
+    /** Minimum ms between API requests (default: 340 for Notion's 3 req/s limit) */
+    minRequestInterval?: number;
+}
+
+// ── Rate limit helpers ───────────────────────────────────────────────────────
+
+function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+// ── Client ───────────────────────────────────────────────────────────────────
+
+const MAX_PAGES = 100;
+const MAX_RECURSION_DEPTH = 10;
+const DEFAULT_MIN_REQUEST_INTERVAL = 340;
+
+export class NotionApiClient {
+    private client: Client;
+    private userCache = new Map<string, string>();
+    private minRequestInterval: number;
+    private lastRequestTime = 0;
+    private logPrefix = '[notion-api]';
+
+    constructor(token: string, options?: NotionApiClientOptions) {
+        this.client = new Client({ auth: token });
+        this.minRequestInterval = options?.minRequestInterval ?? DEFAULT_MIN_REQUEST_INTERVAL;
+    }
+
+    // ── Public methods ──────────────────────────────────────────────────────
+
+    /**
+     * Search for pages in the workspace. Optionally filter to pages edited after a timestamp.
+     */
+    async searchPages(editedAfter?: string): Promise<NotionPageMeta[]> {
+        const pages: NotionPageMeta[] = [];
+        let startCursor: string | undefined;
+        let pageCount = 0;
+        const cutoff = editedAfter ? new Date(editedAfter).getTime() : 0;
+
+        do {
+            pageCount++;
+            const response = await this.throttledCall(() =>
+                this.client.search({
+                    filter: { property: 'object', value: 'page' },
+                    start_cursor: startCursor,
+                    page_size: 100,
+                }),
+            );
+
+            for (const result of response.results) {
+                if (result.object !== 'page') continue;
+                const page = result as any;
+                if (cutoff && new Date(page.last_edited_time).getTime() <= cutoff) continue;
+                pages.push(this.extractPageMeta(page));
+            }
+
+            startCursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+
+            if (pageCount >= MAX_PAGES) {
+                console.warn(`${this.logPrefix} searchPages hit max pages (${MAX_PAGES})`);
+                break;
+            }
+        } while (startCursor);
+
+        return pages;
+    }
+
+    /**
+     * Get full markdown content of a page by converting its blocks recursively.
+     */
+    async getPageContent(pageId: string): Promise<string> {
+        const lines = await this.fetchBlocks(pageId, 0);
+        return lines.join('\n');
+    }
+
+    /**
+     * Get metadata for a single page.
+     */
+    async getPageMeta(pageId: string): Promise<NotionPageMeta> {
+        const page = await this.throttledCall(() =>
+            this.client.pages.retrieve({ page_id: pageId }),
+        );
+        return this.extractPageMeta(page as any);
+    }
+
+    /**
+     * Get metadata for a database.
+     */
+    async getDatabaseMeta(databaseId: string): Promise<NotionDatabaseMeta> {
+        const db = await this.throttledCall(() =>
+            this.client.databases.retrieve({ database_id: databaseId }),
+        ) as any;
+
+        const titleParts = db.title ?? [];
+        const title = titleParts.map((t: any) => t.plain_text).join('');
+        const propertyNames = Object.keys(db.properties ?? {});
+
+        return {
+            id: db.id,
+            title,
+            url: db.url ?? '',
+            propertyNames,
+        };
+    }
+
+    /**
+     * Query a database for pages. Optionally filter to pages edited after a timestamp.
+     */
+    async queryDatabase(databaseId: string, editedAfter?: string): Promise<NotionPageMeta[]> {
+        const pages: NotionPageMeta[] = [];
+        let startCursor: string | undefined;
+        let pageCount = 0;
+        const cutoff = editedAfter ? new Date(editedAfter).getTime() : 0;
+
+        do {
+            pageCount++;
+            const response: any = await this.throttledCall(() =>
+                (this.client.databases as any).query({
+                    database_id: databaseId,
+                    start_cursor: startCursor,
+                    page_size: 100,
+                }),
+            );
+
+            for (const result of response.results) {
+                const page = result as any;
+                if (cutoff && new Date(page.last_edited_time).getTime() <= cutoff) continue;
+                pages.push(this.extractPageMeta(page));
+            }
+
+            startCursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+
+            if (pageCount >= MAX_PAGES) {
+                console.warn(`${this.logPrefix} queryDatabase hit max pages (${MAX_PAGES})`);
+                break;
+            }
+        } while (startCursor);
+
+        return pages;
+    }
+
+    /**
+     * Resolve a Notion user ID to a display name. Caches results.
+     */
+    async resolveUser(userId: string): Promise<string> {
+        const cached = this.userCache.get(userId);
+        if (cached) return cached;
+
+        try {
+            const user = await this.throttledCall(() =>
+                this.client.users.retrieve({ user_id: userId }),
+            ) as any;
+            const name = user.name ?? 'Unknown User';
+            this.userCache.set(userId, name);
+            return name;
+        } catch {
+            const fallback = 'Unknown User';
+            this.userCache.set(userId, fallback);
+            return fallback;
+        }
+    }
+
+    /**
+     * Serialize a Notion properties object to a Record<string, string>.
+     * Unsupported property types are omitted.
+     */
+    serializeProperties(properties: any): Record<string, string> {
+        const result: Record<string, string> = {};
+
+        for (const [key, prop] of Object.entries(properties)) {
+            const value = this.serializeProperty(prop as any);
+            if (value !== null) {
+                result[key] = value;
+            }
+        }
+
+        return result;
+    }
+
+    // ── Private: block fetching & conversion ────────────────────────────────
+
+    /**
+     * Fetch all blocks for a parent and convert to markdown lines.
+     */
+    private async fetchBlocks(parentId: string, depth: number, indent: string = ''): Promise<string[]> {
+        if (depth >= MAX_RECURSION_DEPTH) return [];
+
+        const blocks = await this.paginateBlockChildren(parentId);
+        const lines: string[] = [];
+
+        for (const blk of blocks) {
+            const converted = this.convertBlock(blk, indent);
+            if (converted !== null) {
+                lines.push(converted);
+            }
+
+            // Recurse into children if the block has them
+            if (blk.has_children) {
+                const childIndent = this.getChildIndent(blk.type, indent);
+                const childLines = await this.fetchBlocks(blk.id, depth + 1, childIndent);
+
+                // Special handling for table blocks — render as markdown table
+                if (blk.type === 'table') {
+                    const tableLines = this.renderTable(blk, childLines, blocks);
+                    lines.push(...tableLines);
+                } else {
+                    lines.push(...childLines);
+                }
+            }
+        }
+
+        return lines;
+    }
+
+    /**
+     * Paginate through all children of a block.
+     */
+    private async paginateBlockChildren(blockId: string): Promise<any[]> {
+        const blocks: any[] = [];
+        let startCursor: string | undefined;
+        let pageCount = 0;
+
+        do {
+            pageCount++;
+            const response = await this.throttledCall(() =>
+                this.client.blocks.children.list({
+                    block_id: blockId,
+                    start_cursor: startCursor,
+                    page_size: 100,
+                }),
+            );
+
+            blocks.push(...response.results);
+            startCursor = response.has_more ? (response.next_cursor ?? undefined) : undefined;
+
+            if (pageCount >= MAX_PAGES) {
+                console.warn(`${this.logPrefix} paginateBlockChildren hit max pages (${MAX_PAGES})`);
+                break;
+            }
+        } while (startCursor);
+
+        return blocks;
+    }
+
+    /**
+     * Convert a single block to a markdown string. Returns null for unsupported types.
+     */
+    private convertBlock(blk: any, indent: string): string | null {
+        const type = blk.type;
+        const data = blk[type];
+
+        switch (type) {
+            case 'paragraph':
+                return `${indent}${this.renderRichText(data.rich_text)}`;
+
+            case 'heading_1':
+                return `# ${this.renderRichText(data.rich_text)}`;
+            case 'heading_2':
+                return `## ${this.renderRichText(data.rich_text)}`;
+            case 'heading_3':
+                return `### ${this.renderRichText(data.rich_text)}`;
+
+            case 'bulleted_list_item':
+                return `${indent}- ${this.renderRichText(data.rich_text)}`;
+            case 'numbered_list_item':
+                return `${indent}1. ${this.renderRichText(data.rich_text)}`;
+
+            case 'to_do':
+                return `${indent}- [${data.checked ? 'x' : ' '}] ${this.renderRichText(data.rich_text)}`;
+
+            case 'toggle':
+                return `${indent}**${this.renderRichText(data.rich_text)}**`;
+
+            case 'quote':
+                return `${indent}> ${this.renderRichText(data.rich_text)}`;
+
+            case 'callout': {
+                const icon = data.icon?.emoji ?? data.icon?.external?.url ?? '';
+                return `${indent}> **${icon}** ${this.renderRichText(data.rich_text)}`;
+            }
+
+            case 'code':
+                return `${indent}\`\`\`${data.language ?? ''}\n${this.renderRichText(data.rich_text)}\n\`\`\``;
+
+            case 'divider':
+                return `${indent}---`;
+
+            case 'image': {
+                const imgUrl = data.type === 'external' ? data.external?.url : data.file?.url;
+                const caption = data.caption ? this.renderRichText(data.caption) : '';
+                return `${indent}![${caption}](${imgUrl ?? ''})`;
+            }
+
+            case 'bookmark': {
+                const bmCaption = data.caption ? this.renderRichText(data.caption) : data.url;
+                return `${indent}[${bmCaption}](${data.url})`;
+            }
+
+            case 'equation':
+                return `${indent}$$${data.expression}$$`;
+
+            case 'child_page':
+                return `${indent}[Page: ${data.title}]`;
+
+            case 'child_database':
+                return `${indent}[Database: ${data.title}]`;
+
+            // Table is handled specially — its text comes from child rows
+            case 'table':
+                return null;
+
+            // Table rows are rendered by the table handler
+            case 'table_row': {
+                const cells = (data.cells ?? []).map((cell: any[]) => this.renderRichText(cell));
+                return `| ${cells.join(' | ')} |`;
+            }
+
+            // Transparent containers — just recurse children (handled by fetchBlocks)
+            case 'synced_block':
+            case 'column_list':
+            case 'column':
+                return null;
+
+            default:
+                // Silently skip unsupported block types
+                return null;
+        }
+    }
+
+    /**
+     * Render a Notion table from its child table_row lines.
+     */
+    private renderTable(tableBlock: any, childLines: string[], _allBlocks: any[]): string[] {
+        const lines: string[] = [];
+        const hasHeader = tableBlock.table?.has_column_header ?? false;
+
+        for (let i = 0; i < childLines.length; i++) {
+            lines.push(childLines[i]);
+            // Insert separator after header row
+            if (i === 0 && hasHeader) {
+                const colCount = tableBlock.table?.table_width ?? 2;
+                const separator = `| ${Array(colCount).fill('---').join(' | ')} |`;
+                lines.push(separator);
+            }
+        }
+
+        return lines;
+    }
+
+    /**
+     * Determine child indentation based on block type.
+     */
+    private getChildIndent(blockType: string, currentIndent: string): string {
+        if (blockType === 'bulleted_list_item' || blockType === 'numbered_list_item') {
+            return currentIndent + '  ';
+        }
+        return currentIndent;
+    }
+
+    // ── Private: rich text rendering ────────────────────────────────────────
+
+    /**
+     * Concatenate rich text segments, wrapping linked segments as [text](url).
+     */
+    private renderRichText(richText: any[]): string {
+        if (!richText || !Array.isArray(richText)) return '';
+        return richText.map(segment => {
+            const text = segment.plain_text ?? '';
+            if (segment.href) {
+                return `[${text}](${segment.href})`;
+            }
+            return text;
+        }).join('');
+    }
+
+    // ── Private: property serialization ─────────────────────────────────────
+
+    /**
+     * Serialize a single Notion property to a string. Returns null for unsupported types.
+     */
+    private serializeProperty(prop: any): string | null {
+        switch (prop.type) {
+            case 'title':
+                return this.renderRichText(prop.title);
+            case 'rich_text':
+                return this.renderRichText(prop.rich_text);
+            case 'number':
+                return prop.number != null ? String(prop.number) : null;
+            case 'select':
+                return prop.select?.name ?? null;
+            case 'multi_select':
+                return (prop.multi_select ?? []).map((s: any) => s.name).join(', ') || null;
+            case 'date': {
+                if (!prop.date) return null;
+                const { start, end } = prop.date;
+                return end ? `${start} → ${end}` : start;
+            }
+            case 'checkbox':
+                return String(prop.checkbox);
+            case 'url':
+                return prop.url ?? null;
+            case 'email':
+                return prop.email ?? null;
+            case 'phone_number':
+                return prop.phone_number ?? null;
+            case 'status':
+                return prop.status?.name ?? null;
+            case 'people':
+                return (prop.people ?? []).map((p: any) => p.name).join(', ') || null;
+            case 'created_time':
+                return prop.created_time ?? null;
+            case 'last_edited_time':
+                return prop.last_edited_time ?? null;
+            case 'files':
+                return (prop.files ?? []).map((f: any) => {
+                    if (f.type === 'external') return f.external?.url;
+                    if (f.type === 'file') return f.file?.url;
+                    return null;
+                }).filter(Boolean).join(', ') || null;
+            default:
+                // formula, rollup, relation, created_by, last_edited_by, etc.
+                return null;
+        }
+    }
+
+    // ── Private: page metadata extraction ───────────────────────────────────
+
+    /**
+     * Extract NotionPageMeta from a Notion page object.
+     */
+    private extractPageMeta(page: any): NotionPageMeta {
+        const parentRaw = page.parent ?? {};
+        let parentType: NotionPageMeta['parentType'] = 'workspace';
+        let parentId: string | null = null;
+
+        if (parentRaw.type === 'page_id') {
+            parentType = 'page';
+            parentId = parentRaw.page_id;
+        } else if (parentRaw.type === 'database_id') {
+            parentType = 'database';
+            parentId = parentRaw.database_id;
+        }
+
+        // Extract title from properties
+        const title = this.extractTitle(page.properties);
+
+        return {
+            id: page.id,
+            title,
+            lastEditedTime: page.last_edited_time,
+            url: page.url ?? '',
+            parentType,
+            parentId,
+        };
+    }
+
+    /**
+     * Extract the title string from a Notion page's properties object.
+     * Looks for any property of type "title".
+     */
+    private extractTitle(properties: any): string {
+        if (!properties) return '';
+        for (const prop of Object.values(properties)) {
+            const p = prop as any;
+            if (p.type === 'title' && Array.isArray(p.title)) {
+                return this.renderRichText(p.title);
+            }
+        }
+        return '';
+    }
+
+    // ── Private: throttled API calls ────────────────────────────────────────
+
+    /**
+     * Execute an API call with self-throttling to respect Notion's rate limit.
+     */
+    private async throttledCall<T>(fn: () => Promise<T>): Promise<T> {
+        const now = Date.now();
+        const elapsed = now - this.lastRequestTime;
+        if (elapsed < this.minRequestInterval) {
+            await sleep(this.minRequestInterval - elapsed);
+        }
+        this.lastRequestTime = Date.now();
+        return fn();
+    }
+}

--- a/src/indexing/providers/notion.ts
+++ b/src/indexing/providers/notion.ts
@@ -21,7 +21,9 @@ export class NotionDataProvider implements DataProvider {
         if (!token) {
             throw new Error('NotionDataProvider requires a notionToken in provider options');
         }
-        this.apiClient = new NotionApiClient(token);
+        this.apiClient = new NotionApiClient(token, {
+            maxDepth: this.config.max_depth,
+        });
         this.logPrefix = `[notion-provider:${config.name}]`;
     }
 

--- a/src/indexing/providers/notion.ts
+++ b/src/indexing/providers/notion.ts
@@ -1,0 +1,271 @@
+// NotionDataProvider — Notion page acquisition via API client.
+// Implements DataProvider: discovers pages from root_pages, databases, or workspace search,
+// fetches markdown content, and detects deletions during incremental acquire.
+
+import { NotionApiClient, type NotionPageMeta } from './notion-api.js';
+import { getIndexedItemIds } from '../../db/queries.js';
+import type { SourceConfig, NotionSourceConfig } from '../../types.js';
+import type { DataProvider, AcquisitionResult, ContentItem, ProviderOptions } from './types.js';
+
+export class NotionDataProvider implements DataProvider {
+    private config: NotionSourceConfig;
+    private apiClient: NotionApiClient;
+    private logPrefix: string;
+
+    constructor(config: SourceConfig, options: ProviderOptions) {
+        if (config.type !== 'notion') {
+            throw new Error('NotionDataProvider requires a notion source config');
+        }
+        this.config = config;
+        const token = options.notionToken;
+        if (!token) {
+            throw new Error('NotionDataProvider requires a notionToken in provider options');
+        }
+        this.apiClient = new NotionApiClient(token);
+        this.logPrefix = `[notion-provider:${config.name}]`;
+    }
+
+    async fullAcquire(): Promise<AcquisitionResult> {
+        console.log(`${this.logPrefix} Starting full acquire`);
+
+        const pages = await this.discoverAllPages();
+        console.log(`${this.logPrefix} Discovered ${pages.size} page(s)`);
+
+        const { items, maxTime, failedCount } = await this.acquireContent(pages);
+
+        if (failedCount === pages.size && pages.size > 0) {
+            throw new Error(`All ${failedCount} page(s) failed during acquire`);
+        }
+
+        console.log(`${this.logPrefix} Full acquire complete: ${items.length} item(s)`);
+
+        return {
+            items,
+            removedIds: [],
+            stateToken: maxTime || new Date().toISOString(),
+        };
+    }
+
+    async incrementalAcquire(lastStateToken: string): Promise<AcquisitionResult> {
+        console.log(`${this.logPrefix} Starting incremental acquire since ${lastStateToken}`);
+
+        // Discover full page set for deletion detection
+        const allPages = await this.discoverAllPages();
+        const allPageIds = new Set(allPages.keys());
+
+        // Discover recently edited pages
+        const editedPages = await this.discoverEditedPages(lastStateToken);
+
+        // Detect deletions
+        const indexedIds = await getIndexedItemIds(this.config.name);
+        const removedIds: string[] = [];
+        for (const id of indexedIds) {
+            if (!allPageIds.has(id)) {
+                removedIds.push(id);
+            }
+        }
+
+        // Early return if no changes
+        if (editedPages.size === 0 && removedIds.length === 0) {
+            console.log(`${this.logPrefix} No changes detected`);
+            return { items: [], removedIds: [], stateToken: lastStateToken };
+        }
+
+        // Acquire content only for edited pages
+        const { items, maxTime, failedCount } = await this.acquireContent(editedPages);
+
+        if (failedCount === editedPages.size && editedPages.size > 0) {
+            throw new Error(`All ${failedCount} page(s) failed during acquire`);
+        }
+
+        console.log(`${this.logPrefix} Incremental acquire complete: ${items.length} item(s), ${removedIds.length} removal(s)`);
+
+        return {
+            items,
+            removedIds,
+            stateToken: maxTime || lastStateToken,
+        };
+    }
+
+    async getCurrentStateToken(): Promise<string | null> {
+        const pages = await this.apiClient.searchPages();
+        if (pages.length === 0) return null;
+
+        let maxTime = '';
+        for (const page of pages) {
+            if (page.lastEditedTime > maxTime) {
+                maxTime = page.lastEditedTime;
+            }
+        }
+
+        return maxTime || null;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private: discovery
+    // -----------------------------------------------------------------------
+
+    /**
+     * Discover all pages — full page set for indexing or deletion detection.
+     */
+    private async discoverAllPages(): Promise<Map<string, NotionPageMeta>> {
+        const pages = new Map<string, NotionPageMeta>();
+        const hasRootPages = this.config.root_pages.length > 0;
+        const hasDatabases = this.config.databases.length > 0;
+
+        if (!hasRootPages && !hasDatabases) {
+            // Search-all mode
+            const results = await this.apiClient.searchPages();
+            for (const page of results) {
+                pages.set(page.id, page);
+            }
+            return pages;
+        }
+
+        // Fetch root pages
+        for (const pageId of this.config.root_pages) {
+            try {
+                const page = await this.apiClient.getPageMeta(pageId);
+                pages.set(page.id, page);
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to fetch root page ${pageId}: ${msg}`);
+            }
+        }
+
+        // Query databases
+        for (const dbId of this.config.databases) {
+            try {
+                const entries = await this.apiClient.queryDatabase(dbId);
+                for (const entry of entries) {
+                    pages.set(entry.id, entry);
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to query database ${dbId}: ${msg}`);
+            }
+        }
+
+        return pages;
+    }
+
+    /**
+     * Discover recently edited pages — only pages edited after the given timestamp.
+     */
+    private async discoverEditedPages(editedAfter: string): Promise<Map<string, NotionPageMeta>> {
+        const pages = new Map<string, NotionPageMeta>();
+        const hasRootPages = this.config.root_pages.length > 0;
+        const hasDatabases = this.config.databases.length > 0;
+
+        if (!hasRootPages && !hasDatabases) {
+            const results = await this.apiClient.searchPages(editedAfter);
+            for (const page of results) {
+                pages.set(page.id, page);
+            }
+            return pages;
+        }
+
+        // Fetch root pages and filter by time
+        const cutoff = new Date(editedAfter).getTime();
+        for (const pageId of this.config.root_pages) {
+            try {
+                const page = await this.apiClient.getPageMeta(pageId);
+                if (new Date(page.lastEditedTime).getTime() > cutoff) {
+                    pages.set(page.id, page);
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to fetch root page ${pageId}: ${msg}`);
+            }
+        }
+
+        // Query databases with time filter
+        for (const dbId of this.config.databases) {
+            try {
+                const entries = await this.apiClient.queryDatabase(dbId, editedAfter);
+                for (const entry of entries) {
+                    pages.set(entry.id, entry);
+                }
+            } catch (err) {
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to query database ${dbId}: ${msg}`);
+            }
+        }
+
+        return pages;
+    }
+
+    // -----------------------------------------------------------------------
+    // Private: content acquisition
+    // -----------------------------------------------------------------------
+
+    /**
+     * Acquire content for a set of pages. Returns items, max edit time, and failure count.
+     */
+    private async acquireContent(
+        pages: Map<string, NotionPageMeta>,
+    ): Promise<{ items: ContentItem[]; maxTime: string; failedCount: number }> {
+        const items: ContentItem[] = [];
+        let maxTime = '';
+        let failedCount = 0;
+
+        for (const [id, page] of pages) {
+            try {
+                let content = await this.apiClient.getPageContent(id);
+
+                // Prepend YAML frontmatter if page has properties and include_properties is enabled
+                if (page.properties && this.config.include_properties) {
+                    const frontmatter = this.buildFrontmatter(page.properties);
+                    if (frontmatter) {
+                        content = `${frontmatter}\n\n${content}`;
+                    }
+                }
+
+                // Empty pages get title-only content
+                if (!content.trim()) {
+                    content = `# ${page.title}`;
+                }
+
+                items.push({
+                    id: page.id,
+                    content,
+                    title: page.title,
+                    sourceUrl: page.url,
+                    metadata: {
+                        parentType: page.parentType,
+                        parentId: page.parentId,
+                    },
+                });
+
+                if (page.lastEditedTime > maxTime) {
+                    maxTime = page.lastEditedTime;
+                }
+            } catch (err) {
+                failedCount++;
+                const msg = err instanceof Error ? err.message : String(err);
+                console.warn(`${this.logPrefix} Failed to acquire content for page ${id}: ${msg}`);
+            }
+        }
+
+        return { items, maxTime, failedCount };
+    }
+
+    /**
+     * Build YAML frontmatter from page properties.
+     * Skips the "title" key (redundant with page title) and null/empty values.
+     */
+    private buildFrontmatter(properties: Record<string, string>): string | null {
+        const lines: string[] = [];
+
+        for (const [key, value] of Object.entries(properties)) {
+            // Skip title property — it's already the page title
+            if (key.toLowerCase() === 'title') continue;
+            // Skip null/empty values
+            if (!value) continue;
+            lines.push(`${key}: ${value}`);
+        }
+
+        if (lines.length === 0) return null;
+        return `---\n${lines.join('\n')}\n---`;
+    }
+}

--- a/src/indexing/providers/types.ts
+++ b/src/indexing/providers/types.ts
@@ -58,6 +58,7 @@ export interface ProviderOptions {
     githubToken?: string;
     slackBotToken?: string;
     discordBotToken?: string;
+    notionToken?: string;
 }
 
 /** Factory function that creates a DataProvider for a given source config. */

--- a/src/types.ts
+++ b/src/types.ts
@@ -74,11 +74,21 @@ export const DiscordSourceConfigSchema = z.object({
     distiller_model: z.string().optional(),
 });
 
+export const NotionSourceConfigSchema = z.object({
+    ...BaseSourceFields,
+    type: z.literal('notion'),
+    root_pages: z.array(z.string().min(1)).optional().default([]),
+    databases: z.array(z.string().min(1)).optional().default([]),
+    max_depth: z.number().int().min(1).max(20).optional().default(5),
+    include_properties: z.boolean().optional().default(true),
+});
+
 // Union: TypeScript infers the right shape based on `type`
 export const SourceConfigSchema = z.discriminatedUnion('type', [
     FileSourceConfigSchema,
     SlackSourceConfigSchema,
     DiscordSourceConfigSchema,
+    NotionSourceConfigSchema,
 ]);
 
 // ── Tool configuration schemas ────────────────────────────────────────────────
@@ -271,6 +281,7 @@ export type FileSourceConfig = z.infer<typeof FileSourceConfigSchema>;
 export type SlackSourceConfig = z.infer<typeof SlackSourceConfigSchema>;
 export type DiscordChannelConfig = z.infer<typeof DiscordChannelConfigSchema>;
 export type DiscordSourceConfig = z.infer<typeof DiscordSourceConfigSchema>;
+export type NotionSourceConfig = z.infer<typeof NotionSourceConfigSchema>;
 export type SearchToolConfig = z.infer<typeof SearchToolConfigSchema>;
 export type BashToolConfig = z.infer<typeof BashToolConfigSchema>;
 export type CollectToolConfig = z.infer<typeof CollectToolConfigSchema>;
@@ -295,6 +306,10 @@ export function isSlackSourceConfig(config: SourceConfig): config is SlackSource
 
 export function isDiscordSourceConfig(config: SourceConfig): config is DiscordSourceConfig {
     return config.type === 'discord';
+}
+
+export function isNotionSourceConfig(config: SourceConfig): config is NotionSourceConfig {
+    return config.type === 'notion';
 }
 
 // ── Data types: unified chunk ─────────────────────────────────────────────────

--- a/src/validate.ts
+++ b/src/validate.ts
@@ -3,7 +3,7 @@
 import { existsSync } from 'node:fs';
 import { resolve } from 'node:path';
 import { getConfig, getServerConfig } from './config.js';
-import { isFileSourceConfig, isSlackSourceConfig, isDiscordSourceConfig } from './types.js';
+import { isFileSourceConfig, isSlackSourceConfig, isDiscordSourceConfig, isNotionSourceConfig } from './types.js';
 import type { SourceConfig } from './types.js';
 
 // ── Types ────────────────────────────────────────────────────────────────────
@@ -55,6 +55,7 @@ export async function validateConfig(configPath?: string): Promise<ValidationRes
     const hasDiscordTextChannels = serverCfg.sources.some(
         s => isDiscordSourceConfig(s) && s.channels.some(c => c.type === 'text')
     );
+    const hasNotionSource = serverCfg.sources.some(s => s.type === 'notion');
     const needsRag = serverCfg.tools.some(t => t.type === 'search' || t.type === 'knowledge');
 
     const envChecks = [
@@ -63,6 +64,7 @@ export async function validateConfig(configPath?: string): Promise<ValidationRes
         { name: 'SLACK_BOT_TOKEN', present: !!cfg.slackBotToken, required: hasSlackSource },
         { name: 'DISCORD_BOT_TOKEN', present: !!cfg.discordBotToken, required: hasDiscordSource },
         { name: 'DISCORD_PUBLIC_KEY', present: !!cfg.discordPublicKey, required: hasDiscordSource },
+        { name: 'NOTION_TOKEN', present: !!cfg.notionToken, required: hasNotionSource },
     ];
     result.envVars = envChecks;
 
@@ -145,6 +147,9 @@ async function validateSource(source: SourceConfig): Promise<ValidationResult['s
     }
     if (isDiscordSourceConfig(source)) {
         return { name: source.name, type: 'discord', valid: true, details: 'Discord validation requires live API probe — skipped in offline mode' };
+    }
+    if (isNotionSourceConfig(source)) {
+        return { name: source.name, type: 'notion', valid: true, details: 'Notion validation requires live API probe — skipped in offline mode' };
     }
     // Exhaustive fallback — should not be reachable with current discriminated union
     const s = source as SourceConfig;


### PR DESCRIPTION
## Summary

- Adds a Notion data provider that indexes Notion pages and database entries as searchable markdown documents
- Converts Notion blocks to markdown via recursive block tree fetching with configurable depth
- Self-throttled API client (340ms between requests) to stay within Notion's 3 req/s rate limit
- Two-pass incremental acquire: full discovery for deletion detection, incremental for content
- Database entry properties serialized as YAML frontmatter headers
- Reuses existing markdown chunker — no new chunker needed
- No webhook handler (Notion has no push API)

## New files
- `src/indexing/providers/notion-api.ts` — API client wrapper (block-to-markdown, throttling, pagination)
- `src/indexing/providers/notion.ts` — DataProvider implementation
- `src/__tests__/notion-api.test.ts` — 55 tests
- `src/__tests__/notion-provider.test.ts` — 16 tests
- `src/__tests__/notion-config.test.ts` — 9 tests

## Config
```yaml
sources:
  - name: notion-wiki
    type: notion
    root_pages: ["page-id"]
    databases: ["db-id"]
    max_depth: 5
    include_properties: true
    chunk:
      target_tokens: 600
      overlap_tokens: 50
```

Env var: `NOTION_TOKEN` (internal integration token)

## Test plan
- [x] 1014 tests pass (80 new Notion tests)
- [x] Clean build
- [x] CR loop clean (MSAL: 2 module agents, 1 critical + 1 important found and fixed)
- [ ] E2E: configure with real Notion workspace, run `pathfinder validate`, seed-index, search

🤖 Generated with [Claude Code](https://claude.com/claude-code)