### PR TITLE
Switch license to Elastic License 2.0

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,106 @@
-MIT License
+Copyright 2024-2026 CopilotKit, Inc.
 
-Copyright (c) 2026 CopilotKit, Inc.
+Licensor:             CopilotKit, Inc.
+Licensed Work:        Pathfinder
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Licensed under the Elastic License 2.0 (the "License"); you may not use this
+software except in compliance with the License. You may obtain a copy of the
+License at
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+    https://www.elastic.co/licensing/elastic-license
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+
+Elastic License 2.0
+
+URL: https://www.elastic.co/licensing/elastic-license
+
+
+## Acceptance
+
+By using the software, you agree to all of the terms and conditions below.
+
+## Copyright License
+
+The licensor grants you a non-exclusive, royalty-free, worldwide,
+non-sublicensable, non-transferable license to use, copy, distribute, make
+available, and prepare derivative works of the software, in each case subject to
+the limitations and conditions below.
+
+## Limitations
+
+You may not provide the software to third parties as a hosted or managed
+service, where the service provides users with access to any substantial set of
+the features or functionality of the software.
+
+You may not move, change, disable, or circumvent the license key functionality
+in the software, and you may not remove or obscure any functionality in the
+software that is protected by the license key.
+
+You may not alter, remove, or obscure any licensing, copyright, or other notices
+of the licensor in the software. Any use of the licensor's trademarks is subject
+to applicable law.
+
+## Patents
+
+The licensor grants you a license, under any patent claims the licensor can
+license, or becomes able to license, to make, have made, use, sell, offer for
+sale, import and have imported the software, in each case subject to the
+limitations and conditions in this license. This license does not cover any
+patent claims that you cause to be infringed by modifications or additions to
+the software. If you or your company make any written claim that the software
+infringes or contributes to infringement of any patent, your patent license for
+the software granted under these terms ends immediately. If your company makes
+such a claim, your patent license ends immediately for work on behalf of your
+company.
+
+## Notices
+
+You must ensure that anyone who gets a copy of any part of the software from you
+also gets a copy of these terms.
+
+If you modify the software, you must include in any modified copies of the
+software prominent notices stating that you have modified the software.
+
+## No Other Rights
+
+These terms do not imply any licenses other than those expressly granted in
+these terms.
+
+## Termination
+
+If you use the software in violation of these terms, such use is not licensed,
+and your licenses will automatically terminate. If the licensor provides you
+with a notice of your violation, and you cease all violation of this license no
+later than 30 days after you receive that notice, your licenses will be
+reinstated retroactively. However, if you violate these terms after such
+reinstatement, any additional violation of these terms will cause your licenses
+to terminate automatically and permanently.
+
+## No Liability
+
+*As far as the law allows, the software comes as is, without any warranty or
+condition, and the licensor will not be liable to you for any damages arising
+out of these terms or the use or nature of the software, under any kind of
+legal claim.*
+
+## Definitions
+
+The **licensor** is the entity offering these terms, and the **software** is the
+software the licensor makes available under these terms, including any portion
+of it.
+
+**you** refers to the individual or entity agreeing to these terms.
+
+**your company** is any legal entity, sole proprietorship, or other kind of
+organization that you work for, plus all organizations that have control over,
+are under the control of, or are under common control with that
+organization. **control** means ownership of substantially all the assets of an
+entity, or the power to direct its management and policies by vote, contract, or
+otherwise. Control can be direct or indirect.
+
+**your licenses** are all the licenses granted to you for the software under
+these terms.
+
+**use** means anything you do with the software requiring one of your licenses.
+
+**trademark** means trademarks, service marks, and similar rights.

--- a/README.md
+++ b/README.md
@@ -98,4 +98,10 @@ Step-by-step migration guide: **[Migrate from Mintlify](https://pathfinder.copil
 
 ## License
 
-MIT
+Pathfinder is source-available under the [Elastic License 2.0 (ELv2)](LICENSE).
+
+**You can:** use it, modify it, self-host it, embed it in your product, run it for your company, contribute to it — all free.
+
+**One restriction:** you can't take Pathfinder and sell it as a hosted service. That's it.
+
+If you're using Pathfinder to power your own docs, your own product, or your own internal tools — you're good. The license only kicks in if you're reselling Pathfinder itself as a managed service to third parties.

--- a/docs/clients.html
+++ b/docs/clients.html
@@ -332,7 +332,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
 <footer>
   <div class="container">
-    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; MIT License</div>
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
     <ul class="footer-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>

--- a/docs/config.html
+++ b/docs/config.html
@@ -722,7 +722,7 @@ https://docs.example.com/getting-started</div>
 
 <footer>
   <div class="container">
-    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; MIT License</div>
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
     <ul class="footer-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>

--- a/docs/deploy.html
+++ b/docs/deploy.html
@@ -400,7 +400,7 @@ server {
 
 <footer>
   <div class="container">
-    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; MIT License</div>
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
     <ul class="footer-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>

--- a/docs/index.html
+++ b/docs/index.html
@@ -5,17 +5,17 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Pathfinder — Knowledge Retrieval for AI Agents</title>
 <link rel="icon" type="image/svg+xml" href="favicon.svg">
-<meta name="description" content="Self-hosted MCP server with semantic search + filesystem exploration for AI agents. Open source, MIT licensed.">
+<meta name="description" content="Self-hosted MCP server with semantic search + filesystem exploration for AI agents. Source-available, self-hosted, free to use.">
 <meta property="og:type" content="website">
 <meta property="og:url" content="https://pathfinder.copilotkit.dev/">
 <meta property="og:title" content="Pathfinder — Knowledge retrieval for AI agents">
-<meta property="og:description" content="Docs, code, and conversations — one knowledge server for AI agents. Open source, self-hosted, MIT licensed.">
+<meta property="og:description" content="Docs, code, and conversations — one knowledge server for AI agents. Source-available, self-hosted, free to use.">
 <meta property="og:image" content="https://pathfinder.copilotkit.dev/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Pathfinder — Knowledge retrieval for AI agents">
-<meta name="twitter:description" content="Docs, code, and conversations — one knowledge server for AI agents. Open source, self-hosted, MIT licensed.">
+<meta name="twitter:description" content="Docs, code, and conversations — one knowledge server for AI agents. Source-available, self-hosted, free to use.">
 <meta name="twitter:image" content="https://pathfinder.copilotkit.dev/og-image.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
@@ -217,7 +217,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
 <section class="hero">
     <div class="badge"><span class="dot"></span> pathfinder — knowledge retrieval for AI agents</div>
-    <h1>The <span class="accent">agentic knowledge server</span> for AI agents</h1>
+    <h1>The <span class="accent">knowledge server</span> for <span class="accent">AI agents</span></h1>
     <p class="subtitle">Index your documentation, codebase, and conversations — from Slack threads to Discord forums. Pathfinder turns everything your team knows into searchable, agent-accessible knowledge. Self-hosted, open source, zero lock-in.</p>
 
     <div class="install-box">
@@ -331,7 +331,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
             <tr><td>Multi-source</td><td class="highlight-col"><span class="check">&#10003;</span> Config-driven</td><td><span class="cross">&#10007;</span> Single collection</td></tr>
             <tr><td>Feedback collection</td><td class="highlight-col"><span class="check">&#10003;</span> Collect tools</td><td><span class="cross">&#10007;</span></td></tr>
             <tr><td>Zero-infra mode</td><td class="highlight-col"><span class="check">&#10003;</span> Bash-only</td><td><span class="cross">&#10007;</span> Needs Chroma+Redis</td></tr>
-            <tr><td>Open source</td><td class="highlight-col"><span class="check">&#10003;</span> MIT</td><td><span class="cross">&#10007;</span> Proprietary</td></tr>
+            <tr><td>Source-available</td><td class="highlight-col"><span class="check">&#10003;</span> ELv2 (free to use &amp; self-host)</td><td><span class="cross">&#10007;</span> Proprietary</td></tr>
             <tr><td>Auto-refresh on webhook</td><td class="highlight-col"><span class="check">&#10003;</span></td><td><span class="partial">~</span> Manual reingestion</td></tr>
         </tbody>
     </table>
@@ -345,7 +345,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
 <footer>
   <div class="container">
-    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; MIT License</div>
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
     <ul class="footer-links">
         <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>
         <li><a href="https://www.npmjs.com/package/@copilotkit/pathfinder" target="_blank" rel="noopener">npm</a></li>

--- a/docs/migrate-from-mintlify.html
+++ b/docs/migrate-from-mintlify.html
@@ -447,7 +447,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
 <footer>
   <div class="container">
-    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; MIT License</div>
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
     <ul class="footer-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>

--- a/docs/search.html
+++ b/docs/search.html
@@ -348,7 +348,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
 <footer>
   <div class="container">
-    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; MIT License</div>
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
     <ul class="footer-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>

--- a/docs/usage.html
+++ b/docs/usage.html
@@ -330,7 +330,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
 <footer>
   <div class="container">
-    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; MIT License</div>
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
     <ul class="footer-links">
         <li><a href="index.html">Home</a></li>
         <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
         "embeddings",
         "copilotkit"
     ],
-    "license": "MIT",
+    "license": "Elastic-2.0",
     "main": "dist/index.js",
     "bin": {
         "pathfinder": "dist/cli.js"


### PR DESCRIPTION
## Summary

- Switches from MIT to Elastic License 2.0 (ELv2)
- Updates LICENSE file with full ELv2 text (Licensor: CopilotKit, Inc., Licensed Work: Pathfinder)
- Updates package.json license field
- Updates README with plain-English explanation: use it, modify it, self-host it — just don't resell it as a hosted service
- Updates all docs page footers (7 HTML files) with linked ELv2 reference
- Updates meta tags and comparison table to say "source-available" instead of "open source, MIT"

## What ELv2 means for users

**You can:** use, modify, self-host, embed in products, run for your company, contribute — all free.

**One restriction:** you can't offer Pathfinder as a managed/hosted service to third parties.

## Test plan
- [x] Build clean
- [x] 1698 tests pass
- [x] Grep confirms no stale MIT references in our code (only in dependency licenses and historical CHANGELOG)