### PR TITLE
Competitive landscape: comparison matrix, migration guides, CI automation

### DIFF
--- a/.github/workflows/deploy-health-check.yml
+++ b/.github/workflows/deploy-health-check.yml
@@ -1,0 +1,36 @@
+name: Production Health Check
+on:
+  push:
+    branches: [main]
+jobs:
+  health-check:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Wait for deploy
+        run: sleep 120
+      - name: Check copilotkit-docs
+        run: |
+          STATUS=$(curl -sf https://mcp.copilotkit.ai/health | jq -r '.status')
+          echo "copilotkit-docs: $STATUS"
+          [ "$STATUS" = "ok" ] || exit 1
+      - name: Check pathfinder-docs
+        run: |
+          STATUS=$(curl -sf https://mcp.pathfinder.copilotkit.dev/health | jq -r '.status')
+          echo "pathfinder-docs: $STATUS"
+          [ "$STATUS" = "ok" ] || exit 1
+      - name: Notify Slack — success
+        if: success()
+        run: |
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d '{"text":"Pathfinder production deploy healthy — both services OK"}'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Notify Slack — failure
+        if: failure()
+        run: |
+          curl -s -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"Pathfinder production health check FAILED after deploy\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -25,3 +25,10 @@ jobs:
           path: docs
       - id: deploy
         uses: actions/deploy-pages@v4
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\"❌ *Pathfinder GitHub Pages deploy failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -1,0 +1,16 @@
+name: PR Notification
+on:
+  pull_request_target:
+    types: [opened]
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Slack
+        if: github.actor != 'github-actions[bot]'
+        run: |
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"New PR on pathfinder: *${{ github.event.pull_request.title }}* by ${{ github.actor }}\n<${{ github.event.pull_request.html_url }}|View PR #${{ github.event.pull_request.number }}>\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -26,3 +26,19 @@ jobs:
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+      - name: Notify Slack — success
+        if: success()
+        run: |
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"Docker image published: ghcr.io/copilotkit/pathfinder:${{ github.ref_name }}\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Notify Slack — failure
+        if: failure()
+        run: |
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"Docker publish failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -61,3 +61,18 @@ jobs:
           gh release create "${TAG}" --generate-notes --title "${TAG}" --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Notify Slack on success
+        if: steps.check.outputs.published == 'false'
+        run: |
+          VERSION="v${{ steps.check.outputs.version }}"
+          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\"📦 *@copilotkit/pathfinder ${VERSION} published*\nnpm: https://www.npmjs.com/package/@copilotkit/pathfinder/v/${{ steps.check.outputs.version }}\nRelease: https://github.com/${{ github.repository }}/releases/tag/${VERSION}\"}"
+
+      - name: Notify Slack on failure
+        if: failure()
+        run: |
+          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H "Content-Type: application/json" \
+            -d "{\"text\":\"❌ *Pathfinder release failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"

--- a/.github/workflows/static-quality.yml
+++ b/.github/workflows/static-quality.yml
@@ -1,0 +1,33 @@
+name: Static Quality
+on:
+  pull_request:
+    branches: [main, master]
+  push:
+    branches: [main, master]
+jobs:
+  prettier:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: npm ci
+      - run: npx prettier --check "src/**/*.ts"
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: npm ci
+      - run: npm run build
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with: { node-version: 22 }
+      - run: npm ci
+      - run: npm test

--- a/.github/workflows/unreleased-check.yml
+++ b/.github/workflows/unreleased-check.yml
@@ -2,21 +2,35 @@ name: Unreleased Changes Check
 on:
   push:
     branches: [main, master]
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-      - name: Check for unreleased changes
+        with: { fetch-depth: 0 }
+
+      - name: Check for unreleased source changes
         run: |
-          LATEST_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "")
-          if [ -z "$LATEST_TAG" ]; then
-            echo "No tags found, skipping"
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          TAG="v${PKG_VERSION}"
+
+          # If the tag doesn't exist yet, this is the release commit itself — skip
+          if ! git rev-parse "${TAG}" >/dev/null 2>&1; then
+            echo "Tag ${TAG} not found — this push likely IS the release. Skipping."
             exit 0
           fi
-          COMMITS=$(git rev-list "$LATEST_TAG"..HEAD -- src/ | wc -l | tr -d ' ')
-          if [ "$COMMITS" -gt "0" ]; then
-            echo "::warning::$COMMITS source commits since $LATEST_TAG — consider releasing"
+
+          # Count source-file commits since the last release tag
+          UNRELEASED=$(git log "${TAG}..HEAD" --oneline -- 'src/' | wc -l | tr -d ' ')
+
+          if [ "$UNRELEASED" -gt 0 ]; then
+            echo "::warning::${UNRELEASED} source commits on main since ${TAG} — version has not been bumped."
+            echo ""
+            echo "Unreleased commits:"
+            git log "${TAG}..HEAD" --oneline -- 'src/'
+            echo ""
+            echo "Run: bump package.json version, update CHANGELOG.md, push to trigger publish."
+          else
+            echo "No unreleased source changes since ${TAG}."
           fi

--- a/.github/workflows/unreleased-check.yml
+++ b/.github/workflows/unreleased-check.yml
@@ -11,6 +11,7 @@ jobs:
         with: { fetch-depth: 0 }
 
       - name: Check for unreleased source changes
+        id: unreleased
         run: |
           PKG_VERSION=$(node -p "require('./package.json').version")
           TAG="v${PKG_VERSION}"
@@ -31,6 +32,17 @@ jobs:
             git log "${TAG}..HEAD" --oneline -- 'src/'
             echo ""
             echo "Run: bump package.json version, update CHANGELOG.md, push to trigger publish."
+            echo "count=$UNRELEASED" >> $GITHUB_OUTPUT
+            echo "tag=$TAG" >> $GITHUB_OUTPUT
           else
             echo "No unreleased source changes since ${TAG}."
           fi
+
+      - name: Notify Slack — unreleased changes
+        if: steps.unreleased.outputs.count
+        run: |
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"Unreleased changes on main — ${{ steps.unreleased.outputs.count }} commits since ${{ steps.unreleased.outputs.tag }}\n<https://github.com/${{ github.repository }}/compare/${{ steps.unreleased.outputs.tag }}...main|View compare>\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -22,6 +22,7 @@ jobs:
           fi
       - name: Create PR
         if: steps.changes.outputs.changed == 'true'
+        id: pr
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
@@ -29,4 +30,21 @@ jobs:
           git add -A
           git commit -m "Update competitive matrix from weekly scan"
           git push -u origin auto/competitive-matrix-update
-          gh pr create --title "Update competitive matrix" --body "$(cat /tmp/matrix-summary.md)" --base main
+          PR_URL=$(gh pr create --title "Update competitive matrix" --body "$(cat /tmp/matrix-summary.md)" --base main)
+          echo "url=$PR_URL" >> $GITHUB_OUTPUT
+      - name: Notify Slack — changes detected
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"Competitive matrix updated — PR created\n<${{ steps.pr.outputs.url }}|View PR>\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Notify Slack — failure
+        if: failure()
+        run: |
+          curl -sf -X POST "$SLACK_WEBHOOK" \
+            -H 'Content-Type: application/json' \
+            -d "{\"text\":\"Competitive matrix scan failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -1,0 +1,32 @@
+name: Update Competitive Matrix
+on:
+  schedule:
+    - cron: '0 9 * * 1'  # Monday 9am UTC
+  workflow_dispatch:
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+      - run: npm ci
+      - run: npx tsx scripts/update-competitive-matrix.ts --summary /tmp/matrix-summary.md
+      - name: Check for changes
+        id: changes
+        run: |
+          if [ -n "$(git diff --name-only)" ]; then
+            echo "changed=true" >> $GITHUB_OUTPUT
+          fi
+      - name: Create PR
+        if: steps.changes.outputs.changed == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          git checkout -b auto/competitive-matrix-update
+          git add -A
+          git commit -m "Update competitive matrix from weekly scan"
+          git push -u origin auto/competitive-matrix-update
+          gh pr create --title "Update competitive matrix" --body "$(cat /tmp/matrix-summary.md)" --base main

--- a/docs/index.html
+++ b/docs/index.html
@@ -109,18 +109,24 @@ nav .container { display:flex; align-items:center; justify-content:space-between
 .feature-card h3 { font-size: 16px; margin-bottom: 8px; }
 .feature-card p { font-size: 14px; color: var(--text-secondary); line-height: 1.5; }
 
-/* Comparison */
-.comparison { padding: 4rem 2rem; max-width: 1120px; margin: 0 auto; }
-.comparison h2 { font-size: clamp(1.8rem, 4vw, 2.8rem); margin-bottom: 0.5rem; letter-spacing: -0.02em; text-align: center; }
-.comparison .section-sub { color: var(--text-secondary); margin-bottom: 2rem; font-size: 16px; text-align: center; }
-.comp-table { width: 100%; border-collapse: collapse; font-size: 14px; }
-.comp-table th { padding: 12px 16px; text-align: left; border-bottom: 2px solid var(--border); color: var(--text-secondary); font-weight: 500; }
-.comp-table th.highlight-col { color: var(--accent); border-bottom-color: var(--accent); }
-.comp-table td { padding: 10px 16px; border-bottom: 1px solid var(--border); }
-.comp-table td.highlight-col { background: var(--accent-glow); }
-.comp-table .check { color: var(--accent); }
-.comp-table .cross { color: var(--text-dim); }
-.comp-table .partial { color: var(--warning); }
+/* Comparison matrix */
+.section-comparison { padding: 4rem 2rem; max-width: 1120px; margin: 0 auto; }
+.section-comparison h2 { font-size: clamp(1.8rem, 4vw, 2.8rem); margin-bottom: 0.5rem; letter-spacing: -0.02em; text-align: center; }
+.section-comparison .section-sub { color: var(--text-secondary); margin-bottom: 2rem; font-size: 16px; text-align: center; }
+.comparison-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; margin: 0 -2rem; padding: 0 2rem; }
+.comp-matrix { width: 100%; border-collapse: collapse; font-size: 14px; min-width: 640px; }
+.comp-matrix thead { position: sticky; top: 0; z-index: 2; }
+.comp-matrix th { padding: 12px 16px; text-align: center; border-bottom: 2px solid var(--border); color: var(--text-secondary); font-weight: 500; background: var(--bg-deep); white-space: nowrap; }
+.comp-matrix th:first-child { text-align: left; }
+.comp-matrix th.col-pathfinder { color: var(--accent); border-bottom-color: var(--accent); background: rgba(0,204,255,0.06); }
+.comp-matrix td { padding: 10px 16px; border-bottom: 1px solid var(--border); text-align: center; }
+.comp-matrix td:first-child { text-align: left; color: var(--text-secondary); font-weight: 500; }
+.comp-matrix td.col-pathfinder { background: rgba(0,204,255,0.06); border-left: 2px solid var(--accent); border-right: 2px solid var(--accent); }
+.comp-matrix tr:last-child td.col-pathfinder { border-bottom: 2px solid var(--accent); }
+.comp-matrix thead th.col-pathfinder { border-top: 2px solid var(--accent); }
+.comp-matrix .yes { color: #22cc88; font-weight: 600; }
+.comp-matrix .no { color: var(--text-dim); }
+.comp-matrix .partial { color: var(--warning); font-weight: 500; }
 
 /* Migration CTA */
 .migration { padding: 4rem 2rem; max-width: 1120px; margin: 0 auto; text-align: center; }
@@ -144,11 +150,11 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     .demo-grid { grid-template-columns: 1fr; }
     .feature-grid { grid-template-columns: 1fr 1fr; }
     .install-box { flex-wrap: wrap; justify-content: center; font-size: 12px; }
-    .comp-table { font-size: 12px; }
-    .comp-table th, .comp-table td { padding: 8px 10px; }
+    .comp-matrix { font-size: 12px; }
+    .comp-matrix th, .comp-matrix td { padding: 8px 10px; }
     .nav-links { gap: 1rem; }
     .hero { padding: 100px 16px 2rem; }
-    .hero, .features, .comparison, .migration { padding-left: 1rem; padding-right: 1rem; }
+    .hero, .features, .section-comparison, .migration { padding-left: 1rem; padding-right: 1rem; }
 }
 
 /* Responsive: Mobile */
@@ -159,7 +165,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     .install-box { padding: 10px 14px; font-size: 11px; }
     .install-box .cmd { word-break: break-all; }
     .demo-body { font-size: 11px; min-height: 360px; }
-    .migration h2, .features h2, .comparison h2 { font-size: 1.75rem; }
+    .migration h2, .features h2, .section-comparison h2 { font-size: 1.75rem; }
 }
 
 /* Hamburger menu */
@@ -309,34 +315,130 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     </div>
 </section>
 
-<section class="comparison" id="comparison">
-    <h2>Pathfinder vs ChromaFS</h2>
-    <p class="section-sub">Mintlify hides RAG behind a filesystem. We give agents both directly.</p>
+<section class="section-comparison" id="comparison">
+    <h2>How Pathfinder compares</h2>
+    <p class="section-sub">See how Pathfinder stacks up against other knowledge tools for AI agents.</p>
 
-    <table class="comp-table">
+    <div class="comparison-wrap">
+    <table class="comp-matrix">
         <thead>
             <tr>
-                <th>Capability</th>
-                <th class="highlight-col">Pathfinder</th>
-                <th>ChromaFS</th>
+                <th></th>
+                <th class="col-pathfinder">Pathfinder</th>
+                <th>Mintlify</th>
+                <th>GitBook</th>
+                <th>mcp-ragdocs</th>
+                <th>mcp-local-rag</th>
             </tr>
         </thead>
         <tbody>
-            <tr><td>Semantic search</td><td class="highlight-col"><span class="check">&#10003;</span> pgvector RAG</td><td><span class="check">&#10003;</span> Via Chroma</td></tr>
-            <tr><td>File exploration</td><td class="highlight-col"><span class="check">&#10003;</span> find/grep/cat/ls</td><td><span class="check">&#10003;</span> find/grep/cat/ls</td></tr>
-            <tr><td>Both paradigms composable</td><td class="highlight-col"><span class="check">&#10003;</span></td><td><span class="cross">&#10007;</span> FS-only</td></tr>
-            <tr><td>Session state (persistent CWD)</td><td class="highlight-col"><span class="check">&#10003;</span></td><td><span class="cross">&#10007;</span></td></tr>
-            <tr><td>Vector-backed grep</td><td class="highlight-col"><span class="check">&#10003;</span> Configurable</td><td><span class="check">&#10003;</span> Chroma-backed</td></tr>
-            <tr><td>Conversational sources</td><td class="highlight-col"><span class="check">&#10003;</span></td><td><span class="cross">&#10007;</span></td></tr>
-            <tr><td>FAQ endpoint</td><td class="highlight-col"><span class="check">&#10003;</span></td><td><span class="cross">&#10007;</span></td></tr>
-            <tr><td>Writable workspace</td><td class="highlight-col"><span class="check">&#10003;</span></td><td><span class="cross">&#10007;</span> EROFS</td></tr>
-            <tr><td>Multi-source</td><td class="highlight-col"><span class="check">&#10003;</span> Config-driven</td><td><span class="cross">&#10007;</span> Single collection</td></tr>
-            <tr><td>Feedback collection</td><td class="highlight-col"><span class="check">&#10003;</span> Collect tools</td><td><span class="cross">&#10007;</span></td></tr>
-            <tr><td>Zero-infra mode</td><td class="highlight-col"><span class="check">&#10003;</span> Bash-only</td><td><span class="cross">&#10007;</span> Needs Chroma+Redis</td></tr>
-            <tr><td>Source-available</td><td class="highlight-col"><span class="check">&#10003;</span> ELv2 (free to use &amp; self-host)</td><td><span class="cross">&#10007;</span> Proprietary</td></tr>
-            <tr><td>Auto-refresh on webhook</td><td class="highlight-col"><span class="check">&#10003;</span></td><td><span class="partial">~</span> Manual reingestion</td></tr>
+            <tr>
+                <td>Semantic search</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+            </tr>
+            <tr>
+                <td>Filesystem exploration</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="partial">Internal only</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Multi-source (docs + code)</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Slack indexing</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="partial">Via Assistant</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Discord indexing</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="partial">Via Assistant</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Notion indexing</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Config-driven (one YAML)</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Webhook auto-reindex</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="partial">Auto</span></td>
+                <td><span class="partial">Git Sync</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Self-hosted</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+            </tr>
+            <tr>
+                <td>Knowledge / FAQ tool</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Zero-infra mode</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+            </tr>
+            <tr>
+                <td>llms.txt / faq.txt endpoints</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>Hosted option</td>
+                <td class="col-pathfinder"><span class="no">&#10007;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
         </tbody>
     </table>
+    </div>
 </section>
 
 <section class="migration" id="migration">

--- a/docs/index.html
+++ b/docs/index.html
@@ -442,9 +442,14 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 </section>
 
 <section class="migration" id="migration">
-    <h2>Switching from Mintlify?</h2>
-    <p class="section-sub">Your docs are already structured for it. Our migration guide takes less than 15 minutes.</p>
-    <a href="/migrate-from-mintlify" class="cta-btn">Migration Guide &#8594;</a>
+    <h2>Switch to Pathfinder</h2>
+    <p class="section-sub">Migration guides for every platform. Most take less than 15 minutes.</p>
+    <div style="display:flex; flex-wrap:wrap; gap:12px; justify-content:center;">
+        <a href="/migrate-from-mintlify" class="cta-btn">From Mintlify &#8594;</a>
+        <a href="/migrate-from-gitbook" class="cta-btn">From GitBook &#8594;</a>
+        <a href="/migrate-from-ragdocs" class="cta-btn">From mcp-ragdocs &#8594;</a>
+        <a href="/migrate-from-local-rag" class="cta-btn">From mcp-local-rag &#8594;</a>
+    </div>
 </section>
 
 <footer>

--- a/docs/migrate-from-gitbook/index.html
+++ b/docs/migrate-from-gitbook/index.html
@@ -1,0 +1,481 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Migrate from GitBook to Pathfinder</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="description" content="Step-by-step guide to switching from GitBook to Pathfinder for agentic docs retrieval.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://pathfinder.copilotkit.dev/migrate-from-gitbook">
+<meta property="og:title" content="Switching from GitBook to Pathfinder">
+<meta property="og:description" content="Index more than just docs. This guide takes 15 minutes.">
+<meta property="og:image" content="https://pathfinder.copilotkit.dev/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Switching from GitBook to Pathfinder">
+<meta name="twitter:description" content="Step-by-step guide: GitBook to Pathfinder in 15 minutes.">
+<meta name="twitter:image" content="https://pathfinder.copilotkit.dev/og-image.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+    --bg-deep: #0a0a0f;
+    --bg-surface: #111118;
+    --bg-card: #16161f;
+    --border: #222233;
+    --text-primary: #e8e8f0;
+    --text-secondary: #8888a0;
+    --text-dim: #555570;
+    --accent: #00ccff;
+    --accent-dim: #00aadd;
+    --accent-glow: rgba(0,204,255,0.15);
+    --blue: #4488ff;
+    --purple: #aa66ff;
+    --warning: #ffaa00;
+    --mono: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
+    --sans: "Instrument Sans", -apple-system, system-ui, sans-serif;
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-size: 16px; }
+body { background: var(--bg-deep); color: var(--text-primary); font-family: var(--sans); line-height: 1.6; overflow-x:hidden; }
+code, pre, kbd, .demo-body, .install-command { font-feature-settings: "liga" 0, "calt" 0; }
+
+/* Noise overlay */
+body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100%; pointer-events:none; z-index:9999;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+}
+
+/* Container */
+.container { max-width: 1120px; margin: 0 auto; padding: 0 2rem; }
+
+/* Nav */
+nav { position:fixed; top:0; left:0; right:0; z-index:100; padding: 1rem 0;
+    background: rgba(10,10,15,0.85); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border-bottom: 1px solid var(--border); }
+nav .container { display:flex; align-items:center; justify-content:space-between; }
+.nav-brand { font-family: var(--mono); font-weight: 600; font-size: 1rem; color: var(--text-primary); text-decoration: none; }
+.nav-brand span { color: var(--accent); }
+.nav-links { display:flex; gap: 2rem; align-items:center; list-style:none; }
+.nav-links a { color: var(--text-secondary); text-decoration:none; font-size: 0.875rem; font-weight: 500; transition: color 0.2s; }
+.nav-links a:hover { color: var(--text-primary); }
+.nav-links a.active { color: var(--accent); }
+.nav-links .gh-btn { display:inline-flex; align-items:center; gap:0.5rem; padding: 0.4rem 1rem; border: 1px solid var(--border); border-radius: 6px; transition: border-color 0.2s, background 0.2s; }
+.nav-links .gh-btn:hover { border-color: var(--text-dim); background: var(--bg-card); }
+
+/* Sidebar */
+:root { --sb-width: 220px; }
+#page-sidebar {
+    position: fixed !important;
+    top: 60px;
+    right: 0;
+    width: var(--sb-width);
+    height: calc(100vh - 60px);
+    overflow-y: auto;
+    padding: 2rem 1.5rem 2rem 1.5rem;
+    border-left: 1px solid var(--border);
+    background: var(--bg-deep);
+    z-index: 50;
+}
+#page-sidebar .sb-title {
+    font-family: var(--mono);
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-dim);
+    margin-bottom: 0.75rem;
+}
+#page-sidebar a {
+    display: block;
+    padding: 0.25rem 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color 0.15s;
+    line-height: 1.4;
+}
+#page-sidebar a:hover { color: var(--text-primary); }
+#page-sidebar a.active { color: var(--accent); }
+#page-sidebar a.sb-indent { padding-left: 0.75rem; font-size: 0.75rem; }
+
+/* Article layout */
+.article {
+    max-width: 860px;
+    padding: 100px 2rem 80px;
+    margin-right: calc(var(--sb-width) + max(0px, (100vw - var(--sb-width) - 860px) / 2));
+    margin-left: max(2rem, calc((100vw - var(--sb-width) - 860px) / 2));
+}
+@media (max-width: 1200px) {
+    #page-sidebar { display: none; }
+    .article { max-width: 1120px; margin: 0 auto; }
+}
+.article h1 { font-size: 42px; font-weight: 700; line-height: 1.15; margin-bottom: 16px; letter-spacing: -0.02em; }
+.article h1 .accent { color: var(--accent); }
+.article .lead { font-size: 18px; color: var(--text-secondary); margin-bottom: 48px; }
+.article h2 { font-size: 28px; font-weight: 600; margin: 48px 0 16px; padding-top: 16px; border-top: 1px solid var(--border); scroll-margin-top: 80px; }
+.article h2:first-of-type { border-top: none; }
+.article h3 { font-size: 20px; font-weight: 600; margin: 32px 0 12px; scroll-margin-top: 80px; }
+.article p { color: var(--text-secondary); margin-bottom: 16px; font-size: 1rem; line-height: 1.7; }
+.article ul, .article ol { color: var(--text-secondary); margin-bottom: 1rem; padding-left: 1.5rem; font-size: 1rem; line-height: 1.7; }
+.article li { margin-bottom: 0.35rem; line-height: 1.6; }
+.article li strong { color: var(--text-primary); }
+.article a { color: var(--accent); text-decoration: none; }
+.article a:hover { text-decoration: underline; }
+
+/* Code blocks */
+.code-block { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 20px; font-family: var(--mono); font-size: 13px; line-height: 1.7; overflow-x: auto; margin-bottom: 16px; color: var(--text-primary); white-space: pre; }
+.code-block .comment { color: var(--text-dim); }
+.code-block .key { color: var(--warning); }
+.code-block .value { color: var(--blue); }
+.code-block .cmd { color: var(--accent); }
+
+/* Inline code */
+.article code { background: var(--bg-card); border: 1px solid var(--border); border-radius: 4px; padding: 0.15rem 0.4rem; font-family: var(--mono); font-size: 0.85em; }
+
+/* Concept mapping table */
+.concept-table { width: 100%; border-collapse: collapse; font-size: 14px; margin-bottom: 24px; }
+.concept-table th { padding: 12px 16px; text-align: left; border-bottom: 2px solid var(--border); color: var(--text-secondary); font-weight: 500; }
+.concept-table th.highlight-col { color: var(--accent); border-bottom-color: var(--accent); }
+.concept-table td { padding: 10px 16px; border-bottom: 1px solid var(--border); color: var(--text-secondary); }
+.concept-table td.highlight-col { background: var(--accent-glow); color: var(--text-primary); }
+
+/* Callout cards */
+.callout-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
+.callout-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }
+.callout-card .icon { font-size: 24px; margin-bottom: 8px; }
+.callout-card h4 { font-size: 15px; margin-bottom: 6px; color: var(--text-primary); }
+.callout-card p { font-size: 13px; color: var(--text-secondary); margin-bottom: 0; }
+
+/* Gaps section */
+.gap-card { background: var(--bg-surface); border: 1px solid var(--border); border-left: 3px solid var(--warning); border-radius: 0 10px 10px 0; padding: 16px 20px; margin-bottom: 12px; }
+.gap-card h4 { font-size: 14px; margin-bottom: 4px; color: var(--warning); }
+.gap-card p { font-size: 13px; color: var(--text-secondary); margin-bottom: 0; }
+
+/* Step numbers */
+.step { display: flex; gap: 16px; margin-bottom: 24px; }
+.step-num { flex-shrink: 0; width: 32px; height: 32px; border-radius: 50%; background: var(--accent); color: var(--bg-deep); font-weight: 700; font-size: 14px; display: flex; align-items: center; justify-content: center; margin-top: 2px; }
+.step-content { flex: 1; }
+.step-content h3 { margin-top: 0; }
+
+/* Back link */
+.back-link { display: inline-flex; align-items: center; gap: 8px; color: var(--accent); text-decoration: none; font-size: 14px; margin-top: 32px; }
+.back-link:hover { text-decoration: underline; }
+
+/* Footer */
+footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center; }
+.footer-brand { font-family: var(--mono); font-size: 0.85rem; color: var(--text-dim); margin-bottom: 1rem; }
+.footer-brand .prompt { color: var(--accent); }
+.footer-links { display:flex; gap: 2rem; justify-content:center; list-style:none; }
+.footer-links a { color: var(--text-secondary); font-size: 0.85rem; font-weight: 500; text-decoration:none; transition: color 0.2s; }
+.footer-links a:hover { color: var(--text-primary); }
+
+/* Responsive: Tablet */
+@media (max-width: 768px) {
+    .article h1 { font-size: 32px; }
+    .article { padding: 90px 16px 60px; }
+    .callout-grid { grid-template-columns: 1fr; }
+    .concept-table { font-size: 12px; }
+    .concept-table th, .concept-table td { padding: 8px 10px; }
+    .nav-links { gap: 1rem; }
+}
+
+/* Responsive: Mobile */
+@media (max-width: 480px) {
+    .article h1 { font-size: 26px; }
+    .article .lead { font-size: 15px; }
+    .article h2 { font-size: 22px; }
+    .code-block { font-size: 11px; padding: 12px 14px; }
+    .step { flex-direction: column; gap: 8px; }
+}
+
+/* Hamburger menu */
+.hamburger { display:none; background:none; border:none; cursor:pointer; padding:0.5rem; z-index:101; }
+.hamburger span { display:block; width:22px; height:2px; background:var(--text-primary); margin:5px 0; transition: transform 0.3s, opacity 0.3s; border-radius:1px; }
+.hamburger.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.hamburger.open span:nth-child(2) { opacity:0; }
+.hamburger.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+.mobile-menu { display:none; position:fixed; top:57px; left:0; right:0; background:var(--bg-surface); border-bottom:1px solid var(--border); padding:1rem 2rem 1.5rem; z-index:99; flex-direction:column; gap:0.25rem; }
+.mobile-menu.open { display:flex; }
+@media (min-width: 769px) { .mobile-menu { display:none !important; } }
+.mobile-menu a { color:var(--text-secondary); text-decoration:none; font-size:1rem; font-weight:500; padding:0.6rem 0; border-bottom:1px solid var(--border); transition:color 0.2s; }
+.mobile-menu a:last-child { border-bottom:none; }
+.mobile-menu a:hover { color:var(--text-primary); }
+.mobile-menu a.active { color:var(--accent); }
+.mobile-menu .gh-btn { display:inline-flex; align-items:center; gap:0.5rem; margin-top:0.5rem; padding:0.5rem 1rem; border:1px solid var(--border); border-radius:6px; width:fit-content; }
+.mobile-menu .gh-btn:hover { border-color:var(--text-dim); background:var(--bg-card); }
+@media (max-width: 768px) {
+    .hamburger { display:block; }
+    .nav-links { display:none !important; }
+}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="container">
+    <a href="/" class="nav-brand"><span>$</span> pathfinder</a>
+    <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/usage">Usage</a>
+        <a href="/config">Config</a>
+        <a href="/deploy">Deploy</a>
+        <a href="/clients">Clients</a>
+        <a href="/search">Search</a>
+        <a href="/migrate-from-gitbook" class="active">Switch</a>
+        <a href="https://github.com/CopilotKit/pathfinder" class="gh-btn">GitHub</a>
+    </div>
+    <button class="hamburger" aria-label="Menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+  </div>
+</nav>
+
+<div class="mobile-menu">
+    <a href="/">Home</a>
+    <a href="/usage">Usage</a>
+    <a href="/config">Config</a>
+    <a href="/deploy">Deploy</a>
+    <a href="/clients">Clients</a>
+    <a href="/search">Search</a>
+    <a href="/migrate-from-gitbook" class="active">Switch</a>
+    <a href="https://github.com/CopilotKit/pathfinder" class="gh-btn">GitHub</a>
+</div>
+
+<article class="article">
+    <h1>Switching from <span class="accent">GitBook</span> to Pathfinder</h1>
+    <p class="lead">GitBook is a great docs platform with solid AI search features. Pathfinder is something different: a self-hosted knowledge server that indexes more than just published pages. This guide walks you through the switch in about 15 minutes.</p>
+
+    <h2>Why Migrate</h2>
+    <ul>
+        <li><strong>Index more than docs.</strong> GitBook indexes your published documentation. Pathfinder indexes docs, Slack threads, Discord forums, Notion pages, and code &mdash; your agents search everything your team knows, not just what's published.</li>
+        <li><strong>Self-hosted &mdash; your data stays yours.</strong> No vendor lock-in, no per-seat pricing, no surprise deprecations. Your content lives in your repo, your search runs on your Postgres.</li>
+        <li><strong>Both retrieval paradigms.</strong> GitBook offers AI search. Pathfinder composes both RAG search and filesystem exploration &mdash; agents pick the right tool for each sub-task.</li>
+        <li><strong>Config-driven.</strong> One YAML file defines your sources, tools, and indexing behavior. No SaaS dashboard to click through.</li>
+        <li><strong>Zero-infra option.</strong> Start with bash-only tools (no database, no API keys) and add RAG when you're ready. GitBook always requires their hosted platform.</li>
+    </ul>
+
+    <h2>Concept Mapping</h2>
+    <p>How GitBook concepts translate to Pathfinder:</p>
+
+    <table class="concept-table">
+        <thead>
+            <tr>
+                <th>GitBook</th>
+                <th class="highlight-col">Pathfinder</th>
+                <th>Notes</th>
+            </tr>
+        </thead>
+        <tbody>
+            <tr><td>Space</td><td class="highlight-col">Source (type: markdown/html)</td><td>One source per content collection</td></tr>
+            <tr><td>AI Search</td><td class="highlight-col">Search tool (type: search)</td><td>pgvector instead of GitBook's built-in</td></tr>
+            <tr><td>GitBook Assistant</td><td class="highlight-col">Knowledge tool + Search tool</td><td>Compose multiple tools for richer retrieval</td></tr>
+            <tr><td>Git Sync</td><td class="highlight-col">Webhook auto-reindex</td><td>GitHub push triggers targeted reindex</td></tr>
+            <tr><td>Connections (Slack/Discord)</td><td class="highlight-col">Slack/Discord data providers</td><td>Native indexing, not just surface connections</td></tr>
+            <tr><td>Adaptive Content</td><td class="highlight-col">Not available</td><td>Pathfinder serves raw knowledge, not rendered pages</td></tr>
+            <tr><td>Hosted platform</td><td class="highlight-col">Self-hosted (Docker/Railway)</td><td>You own the infrastructure</td></tr>
+        </tbody>
+    </table>
+
+    <h2>Migration Walkthrough</h2>
+
+    <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+            <h3>Install Pathfinder</h3>
+            <div class="code-block"><span class="cmd">$</span> npx @copilotkit/pathfinder init</div>
+            <p>This scaffolds a <code>pathfinder.yaml</code> config file and a <code>.env</code> template in your project.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+            <h3>Export your GitBook content</h3>
+            <p>If you have Git Sync enabled, your content is already in a repo. Clone it:</p>
+            <div class="code-block"><span class="cmd">$</span> git clone https://github.com/your-org/your-gitbook-repo.git gitbook-docs</div>
+            <p>If you don't use Git Sync, enable it in your GitBook space settings and sync to a GitHub repo. GitBook exports your pages as Markdown files.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+            <h3>Configure sources</h3>
+            <p>Point Pathfinder at your exported content in <code>pathfinder.yaml</code>:</p>
+            <div class="code-block"><span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">docs</span>
+    <span class="key">type:</span> <span class="value">markdown</span>
+    <span class="key">repo:</span> <span class="value">https://github.com/your-org/your-gitbook-repo.git</span>
+    <span class="key">path:</span> <span class="value">./</span>
+    <span class="key">file_patterns:</span> [<span class="value">"**/*.md"</span>]
+    <span class="key">chunk:</span>
+      <span class="key">target_tokens:</span> <span class="value">600</span>
+      <span class="key">overlap_tokens:</span> <span class="value">50</span></div>
+            <p>Adjust <code>path</code> if your docs live in a subdirectory.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+            <h3>Add tools</h3>
+            <p>Define how agents access your knowledge:</p>
+            <div class="code-block"><span class="key">tools:</span>
+  <span class="comment"># Semantic search &mdash; replaces GitBook AI Search</span>
+  - <span class="key">name:</span> <span class="value">search-docs</span>
+    <span class="key">type:</span> <span class="value">search</span>
+    <span class="key">source:</span> <span class="value">docs</span>
+    <span class="key">default_limit:</span> <span class="value">5</span>
+
+  <span class="comment"># Filesystem exploration &mdash; browse docs like a directory</span>
+  - <span class="key">name:</span> <span class="value">explore-docs</span>
+    <span class="key">type:</span> <span class="value">bash</span>
+    <span class="key">sources:</span> [<span class="value">docs</span>]
+    <span class="key">bash:</span>
+      <span class="key">session_state:</span> <span class="value">true</span>
+      <span class="key">grep_strategy:</span> <span class="value">hybrid</span></div>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">5</div>
+        <div class="step-content">
+            <h3>Start serving</h3>
+            <div class="code-block"><span class="cmd">$</span> npx @copilotkit/pathfinder serve</div>
+            <p>The first boot indexes your sources automatically. If you're using RAG search tools, make sure <code>OPENAI_API_KEY</code> and <code>DATABASE_URL</code> are set in your <code>.env</code>.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">6</div>
+        <div class="step-content">
+            <h3>Connect your agent</h3>
+            <p>Point your agent's MCP config at Pathfinder:</p>
+            <div class="code-block">{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"docs"</span>: { <span class="key">"url"</span>: <span class="value">"http://localhost:3001/mcp"</span> }
+  }
+}</div>
+            <p>Your agent now has access to both search and filesystem tools.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">7</div>
+        <div class="step-content">
+            <h3>Add Slack, Discord, or Notion sources (optional)</h3>
+            <p>Unlike GitBook's Connections feature, Pathfinder natively indexes these sources &mdash; not just links to them:</p>
+            <div class="code-block"><span class="key">sources:</span>
+  <span class="comment"># ... your docs source above ...</span>
+
+  - <span class="key">name:</span> <span class="value">community</span>
+    <span class="key">type:</span> <span class="value">discord</span>
+    <span class="key">guild_id:</span> <span class="value">"123456789"</span>
+    <span class="key">channels:</span>
+      - <span class="key">id:</span> <span class="value">"111111111"</span>
+        <span class="key">type:</span> <span class="value">forum</span>
+
+  - <span class="key">name:</span> <span class="value">team-knowledge</span>
+    <span class="key">type:</span> <span class="value">slack</span>
+    <span class="key">channels:</span> [<span class="value">"help-desk"</span>, <span class="value">"engineering"</span>]
+
+  - <span class="key">name:</span> <span class="value">wiki</span>
+    <span class="key">type:</span> <span class="value">notion</span>
+    <span class="key">root_page_id:</span> <span class="value">"abc123..."</span></div>
+            <p>Your agents can then search across docs, community discussions, team Slack threads, and Notion pages &mdash; all from one server.</p>
+        </div>
+    </div>
+
+    <h2>What You Gain</h2>
+    <div class="callout-grid">
+        <div class="callout-card">
+            <div class="icon">&#x1F50D;</div>
+            <h4>Beyond Just Docs</h4>
+            <p>GitBook indexes your docs. Pathfinder indexes your docs, Notion wikis, Slack threads, and Discord forums &mdash; all in one server. Your agents search everything your team knows.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#x1F9ED;</div>
+            <h4>Session State</h4>
+            <p>Agents <code>cd</code> into directories and stay there across commands. No more repeating full paths every tool call.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#x26A1;</div>
+            <h4>Vector Grep</h4>
+            <p>When <code>grep</code> misses, Pathfinder suggests <code>qmd</code> &mdash; a semantic search command that finds docs by meaning, not just text matches.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#x1F4DD;</div>
+            <h4>Writable Workspace</h4>
+            <p>Agents save notes, grep results, and intermediate files to <code>/workspace/</code> during a session.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#x1F517;</div>
+            <h4>Cross-Source Related</h4>
+            <p>Run <code>related /docs/auth.md</code> to discover semantically similar files across all sources.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#x1F680;</div>
+            <h4>Zero-Infra Start</h4>
+            <p>Bash-only mode needs no database or API keys. Add RAG later with a config change &mdash; no code edits.</p>
+        </div>
+    </div>
+
+    <h2>What's Different</h2>
+    <p>Pathfinder is not a drop-in replacement for GitBook's full platform. Here's what it doesn't do:</p>
+
+    <div class="gap-card">
+        <h4>No hosted docs site</h4>
+        <p>Pathfinder is an MCP server, not a documentation hosting platform. Your rendered docs site stays wherever it is &mdash; GitBook, Docusaurus, Mintlify, etc.</p>
+    </div>
+    <div class="gap-card">
+        <h4>No adaptive content or personalization</h4>
+        <p>GitBook can tailor content per visitor segment. Pathfinder serves raw knowledge to agents &mdash; it doesn't render or personalize pages.</p>
+    </div>
+    <div class="gap-card">
+        <h4>No WYSIWYG editor</h4>
+        <p>GitBook's browser-based editor is a key feature. Pathfinder reads your existing Markdown/HTML files &mdash; you edit them however you already do (VS Code, Obsidian, vim, etc.).</p>
+    </div>
+    <div class="gap-card">
+        <h4>No built-in analytics</h4>
+        <p>Telemetry data (file access patterns, search queries) goes to the database but there's no built-in visualization yet. Query it directly or build your own dashboard.</p>
+    </div>
+
+    <a href="/" class="back-link">&larr; Back to Pathfinder</a>
+</article>
+
+<aside id="page-sidebar"></aside>
+<script src="/sidebar.js"></script>
+
+<footer>
+  <div class="container">
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
+    <ul class="footer-links">
+        <li><a href="/">Home</a></li>
+        <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@copilotkit/pathfinder" target="_blank" rel="noopener">npm</a></li>
+        <li><a href="https://copilotkit.ai" target="_blank" rel="noopener">CopilotKit</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var btn=document.querySelector(".hamburger");
+  var menu=document.querySelector(".mobile-menu");
+  if(!btn||!menu)return;
+  btn.addEventListener("click",function(){
+    btn.classList.toggle("open");
+    menu.classList.toggle("open");
+  });
+  menu.addEventListener("click",function(e){
+    if(e.target.tagName==="A"){
+      btn.classList.remove("open");
+      menu.classList.remove("open");
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/migrate-from-local-rag/index.html
+++ b/docs/migrate-from-local-rag/index.html
@@ -1,0 +1,457 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Switching from mcp-local-rag to Pathfinder</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="description" content="Honest comparison and migration guide: when to switch from mcp-local-rag to Pathfinder, and when to stay.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://pathfinder.copilotkit.dev/migrate-from-local-rag">
+<meta property="og:title" content="Switching from mcp-local-rag to Pathfinder">
+<meta property="og:description" content="Shared server, multi-source indexing, and team-wide agent access — or stay with local-rag if single-user is all you need.">
+<meta property="og:image" content="https://pathfinder.copilotkit.dev/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Switching from mcp-local-rag to Pathfinder">
+<meta name="twitter:description" content="Honest comparison and migration guide: when to switch, and when to stay.">
+<meta name="twitter:image" content="https://pathfinder.copilotkit.dev/og-image.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+    --bg-deep: #0a0a0f;
+    --bg-surface: #111118;
+    --bg-card: #16161f;
+    --border: #222233;
+    --text-primary: #e8e8f0;
+    --text-secondary: #8888a0;
+    --text-dim: #555570;
+    --accent: #00ccff;
+    --accent-dim: #00aadd;
+    --accent-glow: rgba(0,204,255,0.15);
+    --blue: #4488ff;
+    --purple: #aa66ff;
+    --warning: #ffaa00;
+    --green: #22cc88;
+    --mono: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
+    --sans: "Instrument Sans", -apple-system, system-ui, sans-serif;
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-size: 16px; }
+body { background: var(--bg-deep); color: var(--text-primary); font-family: var(--sans); line-height: 1.6; overflow-x:hidden; }
+code, pre, kbd, .demo-body, .install-command { font-feature-settings: "liga" 0, "calt" 0; }
+
+/* Noise overlay */
+body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100%; pointer-events:none; z-index:9999;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+}
+
+/* Container */
+.container { max-width: 1120px; margin: 0 auto; padding: 0 2rem; }
+
+/* Nav */
+nav { position:fixed; top:0; left:0; right:0; z-index:100; padding: 1rem 0;
+    background: rgba(10,10,15,0.85); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border-bottom: 1px solid var(--border); }
+nav .container { display:flex; align-items:center; justify-content:space-between; }
+.nav-brand { font-family: var(--mono); font-weight: 600; font-size: 1rem; color: var(--text-primary); text-decoration: none; }
+.nav-brand span { color: var(--accent); }
+.nav-links { display:flex; gap: 2rem; align-items:center; list-style:none; }
+.nav-links a { color: var(--text-secondary); text-decoration:none; font-size: 0.875rem; font-weight: 500; transition: color 0.2s; }
+.nav-links a:hover { color: var(--text-primary); }
+.nav-links a.active { color: var(--accent); }
+.nav-links .gh-btn { display:inline-flex; align-items:center; gap:0.5rem; padding: 0.4rem 1rem; border: 1px solid var(--border); border-radius: 6px; transition: border-color 0.2s, background 0.2s; }
+.nav-links .gh-btn:hover { border-color: var(--text-dim); background: var(--bg-card); }
+
+/* Sidebar */
+:root { --sb-width: 220px; }
+#page-sidebar {
+    position: fixed !important;
+    top: 60px;
+    right: 0;
+    width: var(--sb-width);
+    height: calc(100vh - 60px);
+    overflow-y: auto;
+    padding: 2rem 1.5rem 2rem 1.5rem;
+    border-left: 1px solid var(--border);
+    background: var(--bg-deep);
+    z-index: 50;
+}
+#page-sidebar .sb-title {
+    font-family: var(--mono);
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-dim);
+    margin-bottom: 0.75rem;
+}
+#page-sidebar a {
+    display: block;
+    padding: 0.25rem 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color 0.15s;
+    line-height: 1.4;
+}
+#page-sidebar a:hover { color: var(--text-primary); }
+#page-sidebar a.active { color: var(--accent); }
+#page-sidebar a.sb-indent { padding-left: 0.75rem; font-size: 0.75rem; }
+
+/* Article layout */
+.article {
+    max-width: 860px;
+    padding: 100px 2rem 80px;
+    margin-right: calc(var(--sb-width) + max(0px, (100vw - var(--sb-width) - 860px) / 2));
+    margin-left: max(2rem, calc((100vw - var(--sb-width) - 860px) / 2));
+}
+@media (max-width: 1200px) {
+    #page-sidebar { display: none; }
+    .article { max-width: 1120px; margin: 0 auto; }
+}
+.article h1 { font-size: 42px; font-weight: 700; line-height: 1.15; margin-bottom: 16px; letter-spacing: -0.02em; }
+.article h1 .accent { color: var(--accent); }
+.article .lead { font-size: 18px; color: var(--text-secondary); margin-bottom: 48px; }
+.article h2 { font-size: 28px; font-weight: 600; margin: 48px 0 16px; padding-top: 16px; border-top: 1px solid var(--border); scroll-margin-top: 80px; }
+.article h2:first-of-type { border-top: none; }
+.article h3 { font-size: 20px; font-weight: 600; margin: 32px 0 12px; scroll-margin-top: 80px; }
+.article p { color: var(--text-secondary); margin-bottom: 16px; font-size: 1rem; line-height: 1.7; }
+.article ul, .article ol { color: var(--text-secondary); margin-bottom: 1rem; padding-left: 1.5rem; font-size: 1rem; line-height: 1.7; }
+.article li { margin-bottom: 0.35rem; line-height: 1.6; }
+.article li strong { color: var(--text-primary); }
+.article a { color: var(--accent); text-decoration: none; }
+.article a:hover { text-decoration: underline; }
+
+/* Code blocks */
+.code-block { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 20px; font-family: var(--mono); font-size: 13px; line-height: 1.7; overflow-x: auto; margin-bottom: 16px; color: var(--text-primary); white-space: pre; }
+.code-block .comment { color: var(--text-dim); }
+.code-block .key { color: var(--warning); }
+.code-block .value { color: var(--blue); }
+.code-block .cmd { color: var(--accent); }
+
+/* Inline code */
+.article code { background: var(--bg-card); border: 1px solid var(--border); border-radius: 4px; padding: 0.15rem 0.4rem; font-family: var(--mono); font-size: 0.85em; }
+
+/* Callout cards */
+.callout-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
+.callout-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }
+.callout-card .icon { font-size: 24px; margin-bottom: 8px; }
+.callout-card h4 { font-size: 15px; margin-bottom: 6px; color: var(--text-primary); }
+.callout-card p { font-size: 13px; color: var(--text-secondary); margin-bottom: 0; }
+
+/* Gaps section */
+.gap-card { background: var(--bg-surface); border: 1px solid var(--border); border-left: 3px solid var(--warning); border-radius: 0 10px 10px 0; padding: 16px 20px; margin-bottom: 12px; }
+.gap-card h4 { font-size: 14px; margin-bottom: 4px; color: var(--warning); }
+.gap-card p { font-size: 13px; color: var(--text-secondary); margin-bottom: 0; }
+
+/* Stay card (green left border) */
+.stay-card { background: var(--bg-surface); border: 1px solid var(--border); border-left: 3px solid var(--green); border-radius: 0 10px 10px 0; padding: 16px 20px; margin-bottom: 12px; }
+.stay-card h4 { font-size: 14px; margin-bottom: 4px; color: var(--green); }
+.stay-card p { font-size: 13px; color: var(--text-secondary); margin-bottom: 0; }
+
+/* Step numbers */
+.step { display: flex; gap: 16px; margin-bottom: 24px; }
+.step-num { flex-shrink: 0; width: 32px; height: 32px; border-radius: 50%; background: var(--accent); color: var(--bg-deep); font-weight: 700; font-size: 14px; display: flex; align-items: center; justify-content: center; margin-top: 2px; }
+.step-content { flex: 1; }
+.step-content h3 { margin-top: 0; }
+
+/* Back link */
+.back-link { display: inline-flex; align-items: center; gap: 8px; color: var(--accent); text-decoration: none; font-size: 14px; margin-top: 32px; }
+.back-link:hover { text-decoration: underline; }
+
+/* Footer */
+footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center; }
+.footer-brand { font-family: var(--mono); font-size: 0.85rem; color: var(--text-dim); margin-bottom: 1rem; }
+.footer-brand .prompt { color: var(--accent); }
+.footer-links { display:flex; gap: 2rem; justify-content:center; list-style:none; }
+.footer-links a { color: var(--text-secondary); font-size: 0.85rem; font-weight: 500; text-decoration:none; transition: color 0.2s; }
+.footer-links a:hover { color: var(--text-primary); }
+
+/* Responsive: Tablet */
+@media (max-width: 768px) {
+    .article h1 { font-size: 32px; }
+    .article { padding: 90px 16px 60px; }
+    .callout-grid { grid-template-columns: 1fr; }
+    .nav-links { gap: 1rem; }
+}
+
+/* Responsive: Mobile */
+@media (max-width: 480px) {
+    .article h1 { font-size: 26px; }
+    .article .lead { font-size: 15px; }
+    .article h2 { font-size: 22px; }
+    .code-block { font-size: 11px; padding: 12px 14px; }
+    .step { flex-direction: column; gap: 8px; }
+}
+
+/* Hamburger menu */
+.hamburger { display:none; background:none; border:none; cursor:pointer; padding:0.5rem; z-index:101; }
+.hamburger span { display:block; width:22px; height:2px; background:var(--text-primary); margin:5px 0; transition: transform 0.3s, opacity 0.3s; border-radius:1px; }
+.hamburger.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.hamburger.open span:nth-child(2) { opacity:0; }
+.hamburger.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+.mobile-menu { display:none; position:fixed; top:57px; left:0; right:0; background:var(--bg-surface); border-bottom:1px solid var(--border); padding:1rem 2rem 1.5rem; z-index:99; flex-direction:column; gap:0.25rem; }
+.mobile-menu.open { display:flex; }
+@media (min-width: 769px) { .mobile-menu { display:none !important; } }
+.mobile-menu a { color:var(--text-secondary); text-decoration:none; font-size:1rem; font-weight:500; padding:0.6rem 0; border-bottom:1px solid var(--border); transition:color 0.2s; }
+.mobile-menu a:last-child { border-bottom:none; }
+.mobile-menu a:hover { color:var(--text-primary); }
+.mobile-menu a.active { color:var(--accent); }
+.mobile-menu .gh-btn { display:inline-flex; align-items:center; gap:0.5rem; margin-top:0.5rem; padding:0.5rem 1rem; border:1px solid var(--border); border-radius:6px; width:fit-content; }
+.mobile-menu .gh-btn:hover { border-color:var(--text-dim); background:var(--bg-card); }
+@media (max-width: 768px) {
+    .hamburger { display:block; }
+    .nav-links { display:none !important; }
+}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="container">
+    <a href="/" class="nav-brand"><span>$</span> pathfinder</a>
+    <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/usage" class="active">Usage</a>
+        <a href="/config">Config</a>
+        <a href="/deploy">Deploy</a>
+        <a href="/clients">Clients</a>
+        <a href="/search">Search</a>
+        <a href="/migrate-from-mintlify">Switch</a>
+        <a href="https://github.com/CopilotKit/pathfinder" class="gh-btn">GitHub</a>
+    </div>
+    <button class="hamburger" aria-label="Menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+  </div>
+</nav>
+
+<div class="mobile-menu">
+    <a href="/">Home</a>
+    <a href="/usage" class="active">Usage</a>
+    <a href="/config">Config</a>
+    <a href="/deploy">Deploy</a>
+    <a href="/clients">Clients</a>
+    <a href="/search">Search</a>
+    <a href="/migrate-from-mintlify">Switch</a>
+    <a href="https://github.com/CopilotKit/pathfinder" class="gh-btn">GitHub</a>
+</div>
+
+<article class="article">
+    <h1>Switching from <span class="accent">mcp-local-rag</span> to Pathfinder</h1>
+    <p class="lead">mcp-local-rag is excellent for local, private, single-user doc search with zero setup. Pathfinder is for when you need a shared server, multi-source indexing, and team-wide agent access.</p>
+
+    <h2 id="why-switch">Why Switch</h2>
+    <ul>
+        <li><strong>Shared server.</strong> Deploy once, and every agent on your team connects. No per-developer setup, no duplicated indexes.</li>
+        <li><strong>Multi-source indexing.</strong> Go beyond local files — index docs, code, Slack threads, Discord forums, and Notion pages in one server.</li>
+        <li><strong>Filesystem exploration.</strong> Bash tools alongside semantic search — agents can <code>grep</code>, <code>cat</code>, and <code>find</code> your indexed content, not just vector-search it.</li>
+        <li><strong>Webhook auto-reindex.</strong> Stays current on every git push. No manual re-ingestion, no stale results.</li>
+        <li><strong>Knowledge and FAQ.</strong> Distill Slack threads and Discord forums into searchable Q&amp;A pairs automatically. Agents get answers, not raw chat logs.</li>
+        <li><strong>Production deployment.</strong> Docker, Railway, persistent PostgreSQL. Built to run as infrastructure, not a local process.</li>
+    </ul>
+
+    <h2 id="when-to-stay">When to Stay with mcp-local-rag</h2>
+    <p>mcp-local-rag is a great tool. Here's when it's the better choice:</p>
+
+    <div class="stay-card">
+        <h4>Personal / single-user search</h4>
+        <p>If you're the only one searching your docs and don't need to share a server, local-rag's simplicity is hard to beat.</p>
+    </div>
+    <div class="stay-card">
+        <h4>Fully offline operation</h4>
+        <p>mcp-local-rag uses local embedding models — no API keys, no network calls. Pathfinder requires an OpenAI API key for embeddings (local embedding support is on the roadmap).</p>
+    </div>
+    <div class="stay-card">
+        <h4>Zero dependencies</h4>
+        <p><code>npx mcp-local-rag</code> and you're done. No Docker, no PostgreSQL, no config files. Pathfinder's zero-infra mode (PGlite + bash-only) is similar but still needs a running server process.</p>
+    </div>
+
+    <h2 id="migration-walkthrough">Migration Walkthrough</h2>
+
+    <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+            <h3>Install Pathfinder</h3>
+            <p><strong>CLI:</strong></p>
+            <div class="code-block"><span class="cmd">$</span> npx @copilotkit/pathfinder init
+<span class="cmd">$</span> npx @copilotkit/pathfinder serve</div>
+            <p><strong>Docker:</strong></p>
+            <div class="code-block"><span class="cmd">$</span> docker pull ghcr.io/copilotkit/pathfinder</div>
+            <p>See <a href="/usage">full setup guide</a> for detailed instructions.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+            <h3>Point at the same docs local-rag was indexing</h3>
+            <p>Open <code>pathfinder.yaml</code> and add your docs directory as a source. If local-rag was indexing <code>~/projects/my-app/docs</code>:</p>
+            <div class="code-block"><span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">docs</span>
+    <span class="key">type:</span> <span class="value">markdown</span>
+    <span class="key">path:</span> <span class="value">~/projects/my-app/docs</span>
+    <span class="key">file_patterns:</span> [<span class="value">"**/*.md"</span>, <span class="value">"**/*.mdx"</span>]</div>
+            <p>Or point at a git repo instead of a local path:</p>
+            <div class="code-block"><span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">docs</span>
+    <span class="key">type:</span> <span class="value">markdown</span>
+    <span class="key">repo:</span> <span class="value">https://github.com/your-org/your-repo.git</span>
+    <span class="key">path:</span> <span class="value">docs/</span></div>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+            <h3>Start serving</h3>
+            <div class="code-block"><span class="cmd">$</span> npx @copilotkit/pathfinder serve</div>
+            <p>First boot indexes your sources automatically. Subsequent starts are instant.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+            <h3>Update your MCP client config</h3>
+            <p>Replace the mcp-local-rag entry in your MCP client config:</p>
+            <p><strong>Before (mcp-local-rag):</strong></p>
+            <div class="code-block">{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"local-rag"</span>: {
+      <span class="key">"command"</span>: <span class="value">"npx"</span>,
+      <span class="key">"args"</span>: [<span class="value">"mcp-local-rag"</span>, <span class="value">"~/projects/my-app/docs"</span>]
+    }
+  }
+}</div>
+            <p><strong>After (Pathfinder):</strong></p>
+            <div class="code-block">{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"docs"</span>: { <span class="key">"url"</span>: <span class="value">"http://localhost:3001/mcp"</span> }
+  }
+}</div>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">5</div>
+        <div class="step-content">
+            <h3>Add sources local-rag couldn't do</h3>
+            <p>Now that you're on Pathfinder, add the sources that weren't possible before:</p>
+            <div class="code-block"><span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">docs</span>
+    <span class="key">type:</span> <span class="value">markdown</span>
+    <span class="key">path:</span> <span class="value">~/projects/my-app/docs</span>
+
+  <span class="comment"># Slack threads from your help channel</span>
+  - <span class="key">name:</span> <span class="value">slack-help</span>
+    <span class="key">type:</span> <span class="value">slack</span>
+    <span class="key">channels:</span>
+      - <span class="key">id:</span> <span class="value">"C0123456789"</span>
+        <span class="key">type:</span> <span class="value">threaded</span>
+
+  <span class="comment"># Discord community forums</span>
+  - <span class="key">name:</span> <span class="value">community</span>
+    <span class="key">type:</span> <span class="value">discord</span>
+    <span class="key">guild_id:</span> <span class="value">"123456789"</span>
+    <span class="key">channels:</span>
+      - <span class="key">id:</span> <span class="value">"111111111"</span>
+        <span class="key">type:</span> <span class="value">forum</span>
+
+  <span class="comment"># Notion wiki pages</span>
+  - <span class="key">name:</span> <span class="value">wiki</span>
+    <span class="key">type:</span> <span class="value">notion</span>
+    <span class="key">root_page_id:</span> <span class="value">"abc123..."</span></div>
+        </div>
+    </div>
+
+    <h2 id="what-you-gain">What You Gain</h2>
+    <div class="callout-grid">
+        <div class="callout-card">
+            <div class="icon">🌐</div>
+            <h4>Team-Wide Access</h4>
+            <p>One server, every agent. No per-developer index setup. Deploy to Docker or Railway and your whole team's agents connect instantly.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">📚</div>
+            <h4>Multi-Source Search</h4>
+            <p>Docs, Slack threads, Discord forums, Notion pages — all searchable from one MCP server. local-rag only indexes local files.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">🔍</div>
+            <h4>Filesystem + Semantic</h4>
+            <p>Agents choose the right tool: <code>grep</code> for precise matches, <code>qmd</code> for meaning-based search. Both paradigms, composable.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">🔄</div>
+            <h4>Webhook Auto-Reindex</h4>
+            <p>Push to git, docs reindex automatically. No manual re-ingestion, no stale search results.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">💬</div>
+            <h4>Knowledge / FAQ</h4>
+            <p>Slack threads and Discord forums are distilled into Q&amp;A pairs. Agents get direct answers, not raw conversation logs.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">🚀</div>
+            <h4>Production-Ready</h4>
+            <p>Docker, Railway, persistent PostgreSQL, health checks, telemetry. Built to run as team infrastructure, not a local process.</p>
+        </div>
+    </div>
+
+    <h2 id="whats-different">What's Different</h2>
+    <p>Pathfinder is more capable, but it's also more involved. Here's what changes:</p>
+
+    <div class="gap-card">
+        <h4>Requires an OpenAI API key for embeddings</h4>
+        <p>mcp-local-rag uses local embedding models with zero API dependencies. Pathfinder uses OpenAI embeddings by default. Local embedding support is on the roadmap. If you only use bash tools (no semantic search), you can skip the API key entirely.</p>
+    </div>
+    <div class="gap-card">
+        <h4>Server process stays running</h4>
+        <p>mcp-local-rag starts on-demand when your MCP client invokes it. Pathfinder runs as a persistent server process — via <code>npx serve</code>, Docker, or a cloud deployment.</p>
+    </div>
+    <div class="gap-card">
+        <h4>More setup than <code>npx mcp-local-rag</code></h4>
+        <p>There's a config file (<code>pathfinder.yaml</code>), environment variables, and optionally PostgreSQL. The tradeoff is significantly more capability — multi-source, shared access, auto-reindex, and production deployment.</p>
+    </div>
+
+    <a href="/" class="back-link">&larr; Back to Pathfinder</a>
+</article>
+
+<aside id="page-sidebar"></aside>
+<script src="/sidebar.js"></script>
+
+<footer>
+  <div class="container">
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
+    <ul class="footer-links">
+        <li><a href="/">Home</a></li>
+        <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@copilotkit/pathfinder" target="_blank" rel="noopener">npm</a></li>
+        <li><a href="https://copilotkit.ai" target="_blank" rel="noopener">CopilotKit</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var btn=document.querySelector(".hamburger");
+  var menu=document.querySelector(".mobile-menu");
+  if(!btn||!menu)return;
+  btn.addEventListener("click",function(){
+    btn.classList.toggle("open");
+    menu.classList.toggle("open");
+  });
+  menu.addEventListener("click",function(e){
+    if(e.target.tagName==="A"){
+      btn.classList.remove("open");
+      menu.classList.remove("open");
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/docs/migrate-from-ragdocs/index.html
+++ b/docs/migrate-from-ragdocs/index.html
@@ -1,0 +1,508 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>Switching from mcp-ragdocs to Pathfinder</title>
+<link rel="icon" type="image/svg+xml" href="/favicon.svg">
+<meta name="description" content="Step-by-step guide to switching from mcp-ragdocs to Pathfinder for agentic docs retrieval.">
+<meta property="og:type" content="article">
+<meta property="og:url" content="https://pathfinder.copilotkit.dev/migrate-from-ragdocs">
+<meta property="og:title" content="Switching from mcp-ragdocs to Pathfinder">
+<meta property="og:description" content="mcp-ragdocs is solid. Pathfinder adds filesystem exploration, multi-source indexing, and config-driven setup.">
+<meta property="og:image" content="https://pathfinder.copilotkit.dev/og-image.png">
+<meta name="twitter:card" content="summary_large_image">
+<meta name="twitter:title" content="Switching from mcp-ragdocs to Pathfinder">
+<meta name="twitter:description" content="mcp-ragdocs is solid. Pathfinder adds filesystem exploration, multi-source indexing, and config-driven setup.">
+<meta name="twitter:image" content="https://pathfinder.copilotkit.dev/og-image.png">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">
+<style>
+:root {
+    --bg-deep: #0a0a0f;
+    --bg-surface: #111118;
+    --bg-card: #16161f;
+    --border: #222233;
+    --text-primary: #e8e8f0;
+    --text-secondary: #8888a0;
+    --text-dim: #555570;
+    --accent: #00ccff;
+    --accent-dim: #00aadd;
+    --accent-glow: rgba(0,204,255,0.15);
+    --blue: #4488ff;
+    --purple: #aa66ff;
+    --warning: #ffaa00;
+    --mono: "JetBrains Mono", "SF Mono", "Fira Code", monospace;
+    --sans: "Instrument Sans", -apple-system, system-ui, sans-serif;
+}
+* { margin:0; padding:0; box-sizing:border-box; }
+html { -webkit-font-smoothing: antialiased; -moz-osx-font-smoothing: grayscale; font-size: 16px; }
+body { background: var(--bg-deep); color: var(--text-primary); font-family: var(--sans); line-height: 1.6; overflow-x:hidden; }
+code, pre, kbd, .demo-body, .install-command { font-feature-settings: "liga" 0, "calt" 0; }
+
+/* Noise overlay */
+body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100%; pointer-events:none; z-index:9999;
+    background: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.85' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.03'/%3E%3C/svg%3E");
+}
+
+/* Container */
+.container { max-width: 1120px; margin: 0 auto; padding: 0 2rem; }
+
+/* Nav */
+nav { position:fixed; top:0; left:0; right:0; z-index:100; padding: 1rem 0;
+    background: rgba(10,10,15,0.85); backdrop-filter: blur(20px) saturate(1.4); -webkit-backdrop-filter: blur(20px) saturate(1.4); border-bottom: 1px solid var(--border); }
+nav .container { display:flex; align-items:center; justify-content:space-between; }
+.nav-brand { font-family: var(--mono); font-weight: 600; font-size: 1rem; color: var(--text-primary); text-decoration: none; }
+.nav-brand span { color: var(--accent); }
+.nav-links { display:flex; gap: 2rem; align-items:center; list-style:none; }
+.nav-links a { color: var(--text-secondary); text-decoration:none; font-size: 0.875rem; font-weight: 500; transition: color 0.2s; }
+.nav-links a:hover { color: var(--text-primary); }
+.nav-links a.active { color: var(--accent); }
+.nav-links .gh-btn { display:inline-flex; align-items:center; gap:0.5rem; padding: 0.4rem 1rem; border: 1px solid var(--border); border-radius: 6px; transition: border-color 0.2s, background 0.2s; }
+.nav-links .gh-btn:hover { border-color: var(--text-dim); background: var(--bg-card); }
+
+/* Sidebar */
+:root { --sb-width: 220px; }
+#page-sidebar {
+    position: fixed !important;
+    top: 60px;
+    right: 0;
+    width: var(--sb-width);
+    height: calc(100vh - 60px);
+    overflow-y: auto;
+    padding: 2rem 1.5rem 2rem 1.5rem;
+    border-left: 1px solid var(--border);
+    background: var(--bg-deep);
+    z-index: 50;
+}
+#page-sidebar .sb-title {
+    font-family: var(--mono);
+    font-size: 0.65rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.12em;
+    color: var(--text-dim);
+    margin-bottom: 0.75rem;
+}
+#page-sidebar a {
+    display: block;
+    padding: 0.25rem 0;
+    font-size: 0.8rem;
+    color: var(--text-secondary);
+    text-decoration: none;
+    transition: color 0.15s;
+    line-height: 1.4;
+}
+#page-sidebar a:hover { color: var(--text-primary); }
+#page-sidebar a.active { color: var(--accent); }
+#page-sidebar a.sb-indent { padding-left: 0.75rem; font-size: 0.75rem; }
+
+/* Article layout */
+.article {
+    max-width: 860px;
+    padding: 100px 2rem 80px;
+    margin-right: calc(var(--sb-width) + max(0px, (100vw - var(--sb-width) - 860px) / 2));
+    margin-left: max(2rem, calc((100vw - var(--sb-width) - 860px) / 2));
+}
+@media (max-width: 1200px) {
+    #page-sidebar { display: none; }
+    .article { max-width: 1120px; margin: 0 auto; }
+}
+.article h1 { font-size: 42px; font-weight: 700; line-height: 1.15; margin-bottom: 16px; letter-spacing: -0.02em; }
+.article h1 .accent { color: var(--accent); }
+.article .lead { font-size: 18px; color: var(--text-secondary); margin-bottom: 48px; }
+.article h2 { font-size: 28px; font-weight: 600; margin: 48px 0 16px; padding-top: 16px; border-top: 1px solid var(--border); scroll-margin-top: 80px; }
+.article h2:first-of-type { border-top: none; }
+.article h3 { font-size: 20px; font-weight: 600; margin: 32px 0 12px; scroll-margin-top: 80px; }
+.article p { color: var(--text-secondary); margin-bottom: 16px; font-size: 1rem; line-height: 1.7; }
+.article ul, .article ol { color: var(--text-secondary); margin-bottom: 1rem; padding-left: 1.5rem; font-size: 1rem; line-height: 1.7; }
+.article li { margin-bottom: 0.35rem; line-height: 1.6; }
+.article li strong { color: var(--text-primary); }
+.article a { color: var(--accent); text-decoration: none; }
+.article a:hover { text-decoration: underline; }
+
+/* Code blocks */
+.code-block { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 8px; padding: 16px 20px; font-family: var(--mono); font-size: 13px; line-height: 1.7; overflow-x: auto; margin-bottom: 16px; color: var(--text-primary); white-space: pre; }
+.code-block .comment { color: var(--text-dim); }
+.code-block .key { color: var(--warning); }
+.code-block .value { color: var(--blue); }
+.code-block .cmd { color: var(--accent); }
+
+/* Inline code */
+.article code { background: var(--bg-card); border: 1px solid var(--border); border-radius: 4px; padding: 0.15rem 0.4rem; font-family: var(--mono); font-size: 0.85em; }
+
+/* Config comparison */
+.config-compare { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
+.config-compare .config-panel { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; overflow: hidden; }
+.config-compare .config-header { padding: 10px 16px; background: var(--bg-card); border-bottom: 1px solid var(--border); font-family: var(--mono); font-size: 12px; color: var(--text-dim); font-weight: 600; }
+.config-compare .config-header.highlight { color: var(--accent); }
+.config-compare .config-body { padding: 16px; font-family: var(--mono); font-size: 13px; line-height: 1.7; white-space: pre; overflow-x: auto; }
+
+/* Callout cards */
+.callout-grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; margin-bottom: 24px; }
+.callout-card { background: var(--bg-surface); border: 1px solid var(--border); border-radius: 10px; padding: 20px; }
+.callout-card .icon { font-size: 24px; margin-bottom: 8px; }
+.callout-card h4 { font-size: 15px; margin-bottom: 6px; color: var(--text-primary); }
+.callout-card p { font-size: 13px; color: var(--text-secondary); margin-bottom: 0; }
+
+/* Gaps section */
+.gap-card { background: var(--bg-surface); border: 1px solid var(--border); border-left: 3px solid var(--warning); border-radius: 0 10px 10px 0; padding: 16px 20px; margin-bottom: 12px; }
+.gap-card h4 { font-size: 14px; margin-bottom: 4px; color: var(--warning); }
+.gap-card p { font-size: 13px; color: var(--text-secondary); margin-bottom: 0; }
+
+/* Step numbers */
+.step { display: flex; gap: 16px; margin-bottom: 24px; }
+.step-num { flex-shrink: 0; width: 32px; height: 32px; border-radius: 50%; background: var(--accent); color: var(--bg-deep); font-weight: 700; font-size: 14px; display: flex; align-items: center; justify-content: center; margin-top: 2px; }
+.step-content { flex: 1; }
+.step-content h3 { margin-top: 0; }
+
+/* Back link */
+.back-link { display: inline-flex; align-items: center; gap: 8px; color: var(--accent); text-decoration: none; font-size: 14px; margin-top: 32px; }
+.back-link:hover { text-decoration: underline; }
+
+/* Footer */
+footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center; }
+.footer-brand { font-family: var(--mono); font-size: 0.85rem; color: var(--text-dim); margin-bottom: 1rem; }
+.footer-brand .prompt { color: var(--accent); }
+.footer-links { display:flex; gap: 2rem; justify-content:center; list-style:none; }
+.footer-links a { color: var(--text-secondary); font-size: 0.85rem; font-weight: 500; text-decoration:none; transition: color 0.2s; }
+.footer-links a:hover { color: var(--text-primary); }
+
+/* Responsive: Tablet */
+@media (max-width: 768px) {
+    .article h1 { font-size: 32px; }
+    .article { padding: 90px 16px 60px; }
+    .callout-grid { grid-template-columns: 1fr; }
+    .config-compare { grid-template-columns: 1fr; }
+    .nav-links { gap: 1rem; }
+}
+
+/* Responsive: Mobile */
+@media (max-width: 480px) {
+    .article h1 { font-size: 26px; }
+    .article .lead { font-size: 15px; }
+    .article h2 { font-size: 22px; }
+    .code-block { font-size: 11px; padding: 12px 14px; }
+    .step { flex-direction: column; gap: 8px; }
+}
+
+/* Hamburger menu */
+.hamburger { display:none; background:none; border:none; cursor:pointer; padding:0.5rem; z-index:101; }
+.hamburger span { display:block; width:22px; height:2px; background:var(--text-primary); margin:5px 0; transition: transform 0.3s, opacity 0.3s; border-radius:1px; }
+.hamburger.open span:nth-child(1) { transform: translateY(7px) rotate(45deg); }
+.hamburger.open span:nth-child(2) { opacity:0; }
+.hamburger.open span:nth-child(3) { transform: translateY(-7px) rotate(-45deg); }
+.mobile-menu { display:none; position:fixed; top:57px; left:0; right:0; background:var(--bg-surface); border-bottom:1px solid var(--border); padding:1rem 2rem 1.5rem; z-index:99; flex-direction:column; gap:0.25rem; }
+.mobile-menu.open { display:flex; }
+@media (min-width: 769px) { .mobile-menu { display:none !important; } }
+.mobile-menu a { color:var(--text-secondary); text-decoration:none; font-size:1rem; font-weight:500; padding:0.6rem 0; border-bottom:1px solid var(--border); transition:color 0.2s; }
+.mobile-menu a:last-child { border-bottom:none; }
+.mobile-menu a:hover { color:var(--text-primary); }
+.mobile-menu a.active { color:var(--accent); }
+.mobile-menu .gh-btn { display:inline-flex; align-items:center; gap:0.5rem; margin-top:0.5rem; padding:0.5rem 1rem; border:1px solid var(--border); border-radius:6px; width:fit-content; }
+.mobile-menu .gh-btn:hover { border-color:var(--text-dim); background:var(--bg-card); }
+@media (max-width: 768px) {
+    .hamburger { display:block; }
+    .nav-links { display:none !important; }
+}
+</style>
+</head>
+<body>
+
+<nav>
+  <div class="container">
+    <a href="/" class="nav-brand"><span>$</span> pathfinder</a>
+    <div class="nav-links">
+        <a href="/">Home</a>
+        <a href="/usage" class="active">Usage</a>
+        <a href="/config">Config</a>
+        <a href="/deploy">Deploy</a>
+        <a href="/clients">Clients</a>
+        <a href="/search">Search</a>
+        <a href="/migrate-from-mintlify">Switch</a>
+        <a href="https://github.com/CopilotKit/pathfinder" class="gh-btn">GitHub</a>
+    </div>
+    <button class="hamburger" aria-label="Menu">
+      <span></span>
+      <span></span>
+      <span></span>
+    </button>
+  </div>
+</nav>
+
+<div class="mobile-menu">
+    <a href="/">Home</a>
+    <a href="/usage" class="active">Usage</a>
+    <a href="/config">Config</a>
+    <a href="/deploy">Deploy</a>
+    <a href="/clients">Clients</a>
+    <a href="/search">Search</a>
+    <a href="/migrate-from-mintlify">Switch</a>
+    <a href="https://github.com/CopilotKit/pathfinder" class="gh-btn">GitHub</a>
+</div>
+
+<article class="article">
+    <h1>Switching from <span class="accent">mcp-ragdocs</span> to Pathfinder</h1>
+    <p class="lead">mcp-ragdocs is a solid open-source RAG MCP server. Pathfinder adds filesystem exploration, multi-source indexing, conversational sources, config-driven setup, and webhook auto-reindex on top of what ragdocs provides.</p>
+
+    <h2>Why Switch</h2>
+    <ul>
+        <li><strong>More than search.</strong> Pathfinder gives agents bash filesystem exploration (find, grep, cat, ls) alongside semantic search. Agents pick the right tool for each sub-task instead of relying solely on RAG.</li>
+        <li><strong>Multi-source indexing.</strong> Index docs, code, Slack threads, Discord forums, and Notion pages in one server. mcp-ragdocs indexes URLs one at a time.</li>
+        <li><strong>Config-driven.</strong> One <code>pathfinder.yaml</code> file defines all sources, tools, and behavior. No scattered environment variables to manage.</li>
+        <li><strong>No Qdrant dependency.</strong> Pathfinder uses PostgreSQL + pgvector for vector storage, or PGlite for zero-infra local development. No separate vector database to run.</li>
+        <li><strong>Webhook reindexing.</strong> Push to GitHub and your docs reindex automatically. No manual re-ingestion step.</li>
+        <li><strong>Knowledge and FAQ tools.</strong> Conversational sources (Slack, Discord) are distilled into Q&amp;A pairs that agents can query directly.</li>
+    </ul>
+
+    <h2>Config Comparison</h2>
+    <p>Here's how a typical mcp-ragdocs setup compares to the equivalent Pathfinder config:</p>
+
+    <div class="config-compare">
+        <div class="config-panel">
+            <div class="config-header">mcp-ragdocs (.env + MCP config)</div>
+            <div class="config-body"><span class="comment"># Environment variables</span>
+<span class="key">QDRANT_URL</span>=<span class="value">http://localhost:6333</span>
+<span class="key">OPENAI_API_KEY</span>=<span class="value">sk-...</span>
+<span class="key">EMBEDDING_MODEL</span>=<span class="value">text-embedding-ada-002</span>
+<span class="key">COLLECTION_NAME</span>=<span class="value">my-docs</span>
+
+<span class="comment"># MCP client config</span>
+{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"ragdocs"</span>: {
+      <span class="key">"command"</span>: <span class="value">"npx"</span>,
+      <span class="key">"args"</span>: [<span class="value">"mcp-ragdocs"</span>],
+      <span class="key">"env"</span>: {
+        <span class="key">"QDRANT_URL"</span>: <span class="value">"..."</span>,
+        <span class="key">"OPENAI_API_KEY"</span>: <span class="value">"..."</span>
+      }
+    }
+  }
+}</div>
+        </div>
+        <div class="config-panel">
+            <div class="config-header highlight">Pathfinder (pathfinder.yaml)</div>
+            <div class="config-body"><span class="key">server:</span>
+  <span class="key">name:</span> <span class="value">my-project</span>
+
+<span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">docs</span>
+    <span class="key">type:</span> <span class="value">markdown</span>
+    <span class="key">repo:</span> <span class="value">https://github.com/your-org/your-repo.git</span>
+    <span class="key">path:</span> <span class="value">docs/</span>
+
+<span class="key">tools:</span>
+  - <span class="key">name:</span> <span class="value">search-docs</span>
+    <span class="key">type:</span> <span class="value">search</span>
+    <span class="key">source:</span> <span class="value">docs</span>
+
+  - <span class="key">name:</span> <span class="value">explore-docs</span>
+    <span class="key">type:</span> <span class="value">bash</span>
+    <span class="key">sources:</span> [<span class="value">docs</span>]</div>
+        </div>
+    </div>
+
+    <h2>Migration Walkthrough</h2>
+
+    <div class="step">
+        <div class="step-num">1</div>
+        <div class="step-content">
+            <h3>Install Pathfinder</h3>
+            <p><strong>CLI:</strong></p>
+            <div class="code-block"><span class="cmd">$</span> npx @copilotkit/pathfinder init
+<span class="cmd">$</span> npx @copilotkit/pathfinder serve</div>
+            <p><strong>Docker:</strong></p>
+            <div class="code-block"><span class="cmd">$</span> docker pull ghcr.io/copilotkit/pathfinder</div>
+            <p>See <a href="/usage">full setup guide</a> for detailed instructions.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">2</div>
+        <div class="step-content">
+            <h3>Create pathfinder.yaml</h3>
+            <p>Translate what mcp-ragdocs was indexing into a Pathfinder source. If you were adding URLs pointing to your docs repo, map them to a git source:</p>
+            <div class="code-block"><span class="key">server:</span>
+  <span class="key">name:</span> <span class="value">my-project</span>
+
+<span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">docs</span>
+    <span class="key">type:</span> <span class="value">markdown</span>
+    <span class="key">repo:</span> <span class="value">https://github.com/your-org/your-repo.git</span>
+    <span class="key">path:</span> <span class="value">docs/</span>
+    <span class="key">file_patterns:</span> [<span class="value">"**/*.md"</span>, <span class="value">"**/*.mdx"</span>]
+
+<span class="key">tools:</span>
+  <span class="comment"># Semantic search — replaces ragdocs search_documentation</span>
+  - <span class="key">name:</span> <span class="value">search-docs</span>
+    <span class="key">type:</span> <span class="value">search</span>
+    <span class="key">source:</span> <span class="value">docs</span>
+    <span class="key">default_limit:</span> <span class="value">5</span>
+
+  <span class="comment"># Filesystem exploration — ragdocs doesn't have this</span>
+  - <span class="key">name:</span> <span class="value">explore-docs</span>
+    <span class="key">type:</span> <span class="value">bash</span>
+    <span class="key">sources:</span> [<span class="value">docs</span>]
+    <span class="key">bash:</span>
+      <span class="key">session_state:</span> <span class="value">true</span>
+      <span class="key">grep_strategy:</span> <span class="value">hybrid</span></div>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">3</div>
+        <div class="step-content">
+            <h3>Start serving</h3>
+            <p>No Qdrant needed. Pathfinder uses PGlite by default for zero-infra local development:</p>
+            <div class="code-block"><span class="cmd">$</span> npx @copilotkit/pathfinder serve</div>
+            <p>The first boot automatically indexes your sources. For production, set <code>DATABASE_URL</code> to a PostgreSQL instance with pgvector.</p>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">4</div>
+        <div class="step-content">
+            <h3>Update your MCP client config</h3>
+            <p>Replace the mcp-ragdocs server entry with Pathfinder:</p>
+            <div class="code-block"><span class="comment">// Before (mcp-ragdocs)</span>
+{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"ragdocs"</span>: {
+      <span class="key">"command"</span>: <span class="value">"npx"</span>,
+      <span class="key">"args"</span>: [<span class="value">"mcp-ragdocs"</span>]
+    }
+  }
+}
+
+<span class="comment">// After (Pathfinder)</span>
+{
+  <span class="key">"mcpServers"</span>: {
+    <span class="key">"docs"</span>: { <span class="key">"url"</span>: <span class="value">"http://localhost:3001/mcp"</span> }
+  }
+}</div>
+        </div>
+    </div>
+
+    <div class="step">
+        <div class="step-num">5</div>
+        <div class="step-content">
+            <h3>Add sources ragdocs couldn't do (optional)</h3>
+            <p>Now that you're on Pathfinder, you can index conversational sources too:</p>
+            <div class="code-block"><span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">docs</span>
+    <span class="key">type:</span> <span class="value">markdown</span>
+    <span class="key">repo:</span> <span class="value">https://github.com/your-org/your-repo.git</span>
+    <span class="key">path:</span> <span class="value">docs/</span>
+
+  <span class="comment"># Slack support threads</span>
+  - <span class="key">name:</span> <span class="value">support</span>
+    <span class="key">type:</span> <span class="value">slack</span>
+    <span class="key">channels:</span>
+      - <span class="key">id:</span> <span class="value">"C0123456789"</span>
+        <span class="key">type:</span> <span class="value">support</span>
+
+  <span class="comment"># Discord community forums</span>
+  - <span class="key">name:</span> <span class="value">community</span>
+    <span class="key">type:</span> <span class="value">discord</span>
+    <span class="key">guild_id:</span> <span class="value">"123456789"</span>
+    <span class="key">channels:</span>
+      - <span class="key">id:</span> <span class="value">"111111111"</span>
+        <span class="key">type:</span> <span class="value">forum</span>
+
+  <span class="comment"># Source code</span>
+  - <span class="key">name:</span> <span class="value">code</span>
+    <span class="key">type:</span> <span class="value">code</span>
+    <span class="key">repo:</span> <span class="value">https://github.com/your-org/your-repo.git</span>
+    <span class="key">path:</span> <span class="value">src/</span></div>
+        </div>
+    </div>
+
+    <h2>What You Gain</h2>
+    <div class="callout-grid">
+        <div class="callout-card">
+            <div class="icon">&#128270;</div>
+            <h4>Search + Explore</h4>
+            <p>Agents get both semantic search and bash filesystem tools. They pick the right approach for each sub-task instead of being limited to RAG only.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#128196;</div>
+            <h4>Multi-Source</h4>
+            <p>Docs, code, Slack, Discord, Notion — all indexed in one server. mcp-ragdocs indexes one URL at a time; Pathfinder indexes everything at once.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#9889;</div>
+            <h4>Zero-Infra Start</h4>
+            <p>PGlite means no database to install for local dev. Bash-only mode needs no API keys at all. Add RAG when you're ready — it's just config.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#128260;</div>
+            <h4>Webhook Reindexing</h4>
+            <p>Push to GitHub and docs reindex automatically. No manual add_documentation calls. Nightly full reindex on schedule.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#128172;</div>
+            <h4>Knowledge Tools</h4>
+            <p>Conversational sources are distilled into Q&amp;A pairs. Agents query community knowledge directly, not just documentation.</p>
+        </div>
+        <div class="callout-card">
+            <div class="icon">&#128203;</div>
+            <h4>Config-Driven</h4>
+            <p>One YAML file defines sources, tools, behavior, and webhooks. No scattered environment variables or manual setup steps.</p>
+        </div>
+    </div>
+
+    <h2>What's Different</h2>
+    <p>Pathfinder is not a drop-in replacement. Here's what works differently:</p>
+
+    <div class="gap-card">
+        <h4>No URL-based ingestion</h4>
+        <p>mcp-ragdocs lets you add arbitrary URLs for indexing. Pathfinder indexes git repos and local files instead. For web content, use the <code>html</code> source type to index specific sites.</p>
+    </div>
+    <div class="gap-card">
+        <h4>Different vector database</h4>
+        <p>mcp-ragdocs uses Qdrant. Pathfinder uses PostgreSQL + pgvector. If you have an existing Qdrant deployment, you'll be moving to a different storage backend. Your embeddings will be regenerated on first index.</p>
+    </div>
+    <div class="gap-card">
+        <h4>Managed embeddings pipeline</h4>
+        <p>Pathfinder manages its own embeddings — you don't need a separate embedding service or configure embedding models per-collection. Set the model once in config and Pathfinder handles the rest.</p>
+    </div>
+
+    <a href="/" class="back-link">&larr; Back to Pathfinder</a>
+</article>
+
+<aside id="page-sidebar"></aside>
+<script src="/sidebar.js"></script>
+
+<footer>
+  <div class="container">
+    <div class="footer-brand"><span class="prompt">$</span> pathfinder &middot; <a href="https://github.com/CopilotKit/pathfinder/blob/main/LICENSE" target="_blank" rel="noopener" style="color:inherit;text-decoration:underline">Elastic License 2.0</a> &mdash; free to use, modify, and self-host</div>
+    <ul class="footer-links">
+        <li><a href="/">Home</a></li>
+        <li><a href="https://github.com/CopilotKit/pathfinder" target="_blank" rel="noopener">GitHub</a></li>
+        <li><a href="https://www.npmjs.com/package/@copilotkit/pathfinder" target="_blank" rel="noopener">npm</a></li>
+        <li><a href="https://copilotkit.ai" target="_blank" rel="noopener">CopilotKit</a></li>
+    </ul>
+  </div>
+</footer>
+
+<script>
+(function(){
+  var btn=document.querySelector(".hamburger");
+  var menu=document.querySelector(".mobile-menu");
+  if(!btn||!menu)return;
+  btn.addEventListener("click",function(){
+    btn.classList.toggle("open");
+    menu.classList.toggle("open");
+  });
+  menu.addEventListener("click",function(e){
+    if(e.target.tagName==="A"){
+      btn.classList.remove("open");
+      menu.classList.remove("open");
+    }
+  });
+})();
+</script>
+</body>
+</html>

--- a/scripts/update-competitive-matrix.ts
+++ b/scripts/update-competitive-matrix.ts
@@ -1,0 +1,446 @@
+#!/usr/bin/env tsx
+/// <reference types="node" />
+/**
+ * update-competitive-matrix.ts
+ *
+ * Fetches competitor READMEs from GitHub, extracts feature signals via keyword
+ * matching, and compares against the comparison table in docs/index.html.
+ * When evidence of new capabilities is found, updates the table and outputs a
+ * markdown summary.
+ *
+ * Usage:
+ *   npx tsx scripts/update-competitive-matrix.ts                        # update in place
+ *   npx tsx scripts/update-competitive-matrix.ts --dry-run               # show changes only
+ *   npx tsx scripts/update-competitive-matrix.ts --summary out.md        # write markdown summary
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+// ── Types ────────────────────────────────────────────────────────────────────
+
+interface Competitor {
+  /** Display name matching the <th> text in the HTML table */
+  name: string;
+  /** GitHub owner/repo */
+  repo: string;
+}
+
+interface FeatureRule {
+  /** Row label as it appears in the first <td> of each <tr> */
+  rowLabel: string;
+  /** Patterns to search for (case-insensitive) */
+  keywords: string[];
+}
+
+interface DetectedChange {
+  competitor: string;
+  capability: string;
+  from: string;
+  to: string;
+}
+
+// ── Configuration ────────────────────────────────────────────────────────────
+
+const COMPETITORS: Competitor[] = [
+  { name: "Mintlify", repo: "mintlify/mintlify-cli" },
+  { name: "mcp-ragdocs", repo: "hannesrudolph/mcp-ragdocs" },
+  { name: "mcp-local-rag", repo: "shinpr/mcp-local-rag" },
+  { name: "mcp-rag-server", repo: "Daniel-Barta/mcp-rag-server" },
+];
+
+const FEATURE_RULES: FeatureRule[] = [
+  {
+    rowLabel: "Semantic search",
+    keywords: ["vector", "embedding", "semantic", "similarity"],
+  },
+  {
+    rowLabel: "Filesystem exploration",
+    keywords: ["filesystem", "bash", "shell", "find", "grep", "cat", "ls"],
+  },
+  {
+    rowLabel: "Multi-source",
+    keywords: ["multi.*source", "multiple.*source", "code.*doc"],
+  },
+  {
+    rowLabel: "Slack",
+    keywords: ["slack", "slack.*api", "slack.*bot"],
+  },
+  {
+    rowLabel: "Discord",
+    keywords: ["discord", "discord.*bot", "discord.*api"],
+  },
+  {
+    rowLabel: "Notion",
+    keywords: ["notion", "notion.*api", "notion.*page"],
+  },
+  {
+    rowLabel: "Webhook reindex",
+    keywords: ["webhook", "auto.*reindex", "push.*trigger"],
+  },
+  {
+    rowLabel: "Knowledge/FAQ",
+    keywords: ["knowledge", "faq", "q&a", "question.*answer"],
+  },
+  {
+    rowLabel: "Zero-infra",
+    keywords: ["no.*database", "zero.*config", "no.*setup", "pglite", "local.*only"],
+  },
+  {
+    rowLabel: "llms.txt",
+    keywords: ["llms\\.txt", "llms-full"],
+  },
+];
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+const DRY_RUN = process.argv.includes("--dry-run");
+const DOCS_PATH = resolve(import.meta.dirname ?? __dirname, "../docs/index.html");
+
+const GITHUB_TOKEN = process.env.GITHUB_TOKEN ?? "";
+const HEADERS: Record<string, string> = {
+  Accept: "application/vnd.github.v3+json",
+  "User-Agent": "pathfinder-competitive-matrix-updater",
+  ...(GITHUB_TOKEN ? { Authorization: `Bearer ${GITHUB_TOKEN}` } : {}),
+};
+
+async function fetchReadme(repo: string): Promise<string> {
+  const url = `https://api.github.com/repos/${repo}/readme`;
+  console.log(`  Fetching README from ${repo}...`);
+  const res = await fetch(url, { headers: HEADERS });
+  if (!res.ok) {
+    console.warn(`  WARNING: Failed to fetch README for ${repo}: ${res.status} ${res.statusText}`);
+    return "";
+  }
+  const json = (await res.json()) as { content?: string; encoding?: string };
+  if (json.content && json.encoding === "base64") {
+    return Buffer.from(json.content, "base64").toString("utf-8");
+  }
+  return "";
+}
+
+async function fetchPackageJson(repo: string): Promise<string> {
+  const url = `https://api.github.com/repos/${repo}/contents/package.json`;
+  console.log(`  Fetching package.json from ${repo}...`);
+  const res = await fetch(url, { headers: HEADERS });
+  if (!res.ok) return "";
+  const json = (await res.json()) as { content?: string; encoding?: string };
+  if (json.content && json.encoding === "base64") {
+    return Buffer.from(json.content, "base64").toString("utf-8");
+  }
+  return "";
+}
+
+function extractFeatures(text: string): Record<string, boolean> {
+  const lower = text.toLowerCase();
+  const result: Record<string, boolean> = {};
+  for (const rule of FEATURE_RULES) {
+    const found = rule.keywords.some((kw) => {
+      const pattern = new RegExp(kw.toLowerCase(), "i");
+      return pattern.test(lower);
+    });
+    result[rule.rowLabel] = found;
+  }
+  return result;
+}
+
+function escapeRegex(str: string): string {
+  return str.replace(/[.*+?^${}()|[\]\\/]/g, "\\$&");
+}
+
+// ── HTML Matrix Parsing & Updating ───────────────────────────────────────────
+
+/**
+ * Parses the comparison table from docs/index.html.
+ * Returns a map: competitorName -> { rowLabel -> cellHTML }
+ *
+ * The table uses class="comp-table" with <th> headers and <td> cells.
+ * The first column is "Capability", second is "Pathfinder", and
+ * remaining columns are competitors.
+ */
+function parseCurrentMatrix(html: string): {
+  headers: string[];
+  rows: Map<string, Map<string, string>>;
+} {
+  const tableMatch = html.match(/<table class="comp-table">([\s\S]*?)<\/table>/);
+  if (!tableMatch) {
+    throw new Error("Could not find comp-table in HTML");
+  }
+  const tableHtml = tableMatch[1];
+
+  // Extract header names from <th> elements
+  const thRegex = /<th[^>]*>(.*?)<\/th>/g;
+  const allHeaders: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = thRegex.exec(tableHtml)) !== null) {
+    allHeaders.push(m[1].trim());
+  }
+  // allHeaders[0] = "Capability", allHeaders[1] = "Pathfinder", allHeaders[2..] = competitors
+  const competitorHeaders = allHeaders.slice(1); // skip "Capability"
+
+  // Extract rows from <tbody>
+  const rows = new Map<string, Map<string, string>>();
+  const tbody = tableHtml.match(/<tbody>([\s\S]*?)<\/tbody>/)?.[1] ?? "";
+  const trIter = new RegExp(/<tr>([\s\S]*?)<\/tr>/g);
+  let tr: RegExpExecArray | null;
+
+  while ((tr = trIter.exec(tbody)) !== null) {
+    const tds: string[] = [];
+    const tdRegex = /<td[^>]*>([\s\S]*?)<\/td>/g;
+    let td: RegExpExecArray | null;
+    while ((td = tdRegex.exec(tr[1])) !== null) {
+      tds.push(td[1].trim());
+    }
+    if (tds.length < 2) continue;
+
+    const rowLabel = tds[0];
+    const rowMap = new Map<string, string>();
+    for (let i = 1; i < tds.length && i - 1 < competitorHeaders.length; i++) {
+      rowMap.set(competitorHeaders[i - 1], tds[i]);
+    }
+    rows.set(rowLabel, rowMap);
+  }
+
+  return { headers: competitorHeaders, rows };
+}
+
+/**
+ * Computes changes: finds competitor cells that currently indicate "No" / cross
+ * but where the keyword scan detected the feature. Only upgrades, never downgrades.
+ */
+function computeChanges(
+  matrix: { headers: string[]; rows: Map<string, Map<string, string>> },
+  competitorFeatures: Map<string, Record<string, boolean>>,
+): DetectedChange[] {
+  const changes: DetectedChange[] = [];
+
+  for (const [compName, features] of competitorFeatures) {
+    for (const [rowLabel, detected] of Object.entries(features)) {
+      if (!detected) continue;
+
+      const row = matrix.rows.get(rowLabel);
+      if (!row) continue;
+
+      const currentCell = row.get(compName);
+      if (!currentCell) continue;
+
+      // Only upgrade cells that contain the cross mark (&#10007; or the actual character)
+      const isCross = currentCell.includes("&#10007;") || currentCell.includes("\u2717");
+      if (isCross) {
+        changes.push({
+          competitor: compName,
+          capability: rowLabel,
+          from: "No",
+          to: "Yes",
+        });
+      }
+    }
+  }
+
+  return changes;
+}
+
+/**
+ * Applies detected changes to the HTML by finding the exact table cells
+ * and replacing cross marks with check marks.
+ */
+function applyChanges(html: string, changes: DetectedChange[]): string {
+  if (changes.length === 0) return html;
+
+  // Parse the table to determine column indices
+  const tableMatch = html.match(/<table class="comp-table">([\s\S]*?)<\/table>/);
+  if (!tableMatch) return html;
+  const tableHtml = tableMatch[1];
+
+  const thRegex = /<th[^>]*>(.*?)<\/th>/g;
+  const allHeaders: string[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = thRegex.exec(tableHtml)) !== null) {
+    allHeaders.push(m[1].trim());
+  }
+  // Column index in <td> array: "Capability" = 0, "Pathfinder" = 1, competitors = 2+
+  const compColumnIndex = (name: string): number => {
+    const idx = allHeaders.indexOf(name);
+    return idx === -1 ? -1 : idx; // index in <td> array matches <th> array
+  };
+
+  let result = html;
+
+  for (const change of changes) {
+    const colIdx = compColumnIndex(change.competitor);
+    if (colIdx === -1) continue;
+
+    // Find the <tr> containing this capability row by matching the first <td> text
+    const rowPattern = new RegExp(
+      `(<tr><td>${escapeRegex(change.capability)}</td>)([\\s\\S]*?)(</tr>)`,
+    );
+    const rowMatch = result.match(rowPattern);
+    if (!rowMatch) continue;
+
+    const prefix = rowMatch[1];
+    const cellsHtml = rowMatch[2];
+    const suffix = rowMatch[3];
+
+    // Find the Nth <td> in cellsHtml (colIdx - 1 because the first <td> is already in prefix)
+    const targetTdIdx = colIdx - 1; // 0-based within the remaining cells
+    let tdCount = 0;
+    const tdReplace = cellsHtml.replace(
+      /<td[^>]*>[\s\S]*?<\/td>/g,
+      (fullMatch) => {
+        const currentIdx = tdCount++;
+        if (currentIdx === targetTdIdx && fullMatch.includes("cross")) {
+          // Replace cross with check
+          return fullMatch
+            .replace(/class="cross"/, `class="check"`)
+            .replace(/&#10007;[\s\S]*/, `&#10003;</span></td>`);
+        }
+        return fullMatch;
+      },
+    );
+
+    result = result.replace(rowPattern, prefix + tdReplace + suffix);
+  }
+
+  return result;
+}
+
+// ── Summary Writing ──────────────────────────────────────────────────────────
+
+function parseSummaryArg(): string | null {
+  const idx = process.argv.indexOf("--summary");
+  if (idx === -1 || idx + 1 >= process.argv.length) return null;
+  return resolve(process.argv[idx + 1]);
+}
+
+function writeSummary(summaryPath: string, changes: DetectedChange[]): void {
+  let md: string;
+
+  if (changes.length === 0) {
+    md = "No competitive matrix changes detected this week.\n";
+  } else {
+    const lines: string[] = [];
+    lines.push("## Competitive Matrix Changes");
+    lines.push("");
+    lines.push("| Competitor | Capability | Change |");
+    lines.push("| --- | --- | --- |");
+    for (const ch of changes) {
+      lines.push(`| ${ch.competitor} | ${ch.capability} | ${ch.from} -> ${ch.to} |`);
+    }
+    lines.push("");
+    md = lines.join("\n");
+  }
+
+  writeFileSync(summaryPath, md, "utf-8");
+  console.log(`\nSummary written to ${summaryPath}`);
+}
+
+// ── Main ─────────────────────────────────────────────────────────────────────
+
+async function main(): Promise<void> {
+  console.log("=== Competitive Matrix Updater ===\n");
+
+  if (DRY_RUN) {
+    console.log("  [DRY RUN] No files will be modified.\n");
+  }
+
+  // 1. Fetch competitor data
+  const competitorFeatures = new Map<string, Record<string, boolean>>();
+
+  for (const comp of COMPETITORS) {
+    console.log(`\n--- ${comp.name} (${comp.repo}) ---`);
+    const [readme, pkg] = await Promise.all([fetchReadme(comp.repo), fetchPackageJson(comp.repo)]);
+
+    if (!readme && !pkg) {
+      console.log(`  No data fetched, skipping.`);
+      continue;
+    }
+
+    const combined = `${readme}\n${pkg}`;
+    const features = extractFeatures(combined);
+    competitorFeatures.set(comp.name, features);
+
+    // Log detected features
+    const detected = Object.entries(features)
+      .filter(([, v]) => v)
+      .map(([k]) => k);
+    if (detected.length > 0) {
+      console.log(`  Detected features: ${detected.join(", ")}`);
+    } else {
+      console.log(`  No features detected from keywords.`);
+    }
+  }
+
+  // 2. Read current HTML
+  console.log(`\nReading ${DOCS_PATH}...`);
+  const html = readFileSync(DOCS_PATH, "utf-8");
+
+  // 3. Parse current matrix
+  let matrix: ReturnType<typeof parseCurrentMatrix>;
+  try {
+    matrix = parseCurrentMatrix(html);
+  } catch (err) {
+    console.error(`Failed to parse comparison table: ${err}`);
+    console.log("The comparison table may need competitor columns added before this script can update them.");
+    // Still write summary with detected features even if table parse fails
+    const summaryPath = parseSummaryArg();
+    if (summaryPath) {
+      const lines: string[] = [];
+      lines.push("## Competitive Matrix Scan Results");
+      lines.push("");
+      lines.push("Could not parse comparison table. Detected features per competitor:");
+      lines.push("");
+      for (const [name, features] of competitorFeatures) {
+        const detected = Object.entries(features)
+          .filter(([, v]) => v)
+          .map(([k]) => k);
+        lines.push(`### ${name}`);
+        if (detected.length > 0) {
+          lines.push(detected.map((d) => `- ${d}`).join("\n"));
+        } else {
+          lines.push("- No features detected");
+        }
+        lines.push("");
+      }
+      writeFileSync(summaryPath, lines.join("\n"), "utf-8");
+      console.log(`\nSummary written to ${summaryPath}`);
+    }
+    return;
+  }
+
+  console.log(
+    `Parsed ${matrix.rows.size} capability rows, ${matrix.headers.length} columns.`,
+  );
+
+  // 4. Compute changes
+  const changes = computeChanges(matrix, competitorFeatures);
+
+  const summaryPath = parseSummaryArg();
+
+  if (changes.length === 0) {
+    console.log("\nNo changes detected. Competitive matrix is up to date.");
+    if (summaryPath) writeSummary(summaryPath, changes);
+    return;
+  }
+
+  console.log(`\n${changes.length} change(s) detected:`);
+  for (const ch of changes) {
+    console.log(`  ${ch.competitor} / ${ch.capability}: ${ch.from} -> ${ch.to}`);
+  }
+
+  if (summaryPath) writeSummary(summaryPath, changes);
+
+  if (DRY_RUN) {
+    console.log("\n[DRY RUN] Would update docs/index.html with the above changes.");
+    return;
+  }
+
+  // 5. Apply changes to index.html
+  const updated = applyChanges(html, changes);
+  writeFileSync(DOCS_PATH, updated, "utf-8");
+  console.log("\nUpdated docs/index.html successfully.");
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

- Add 5-column competitive comparison matrix to homepage (Pathfinder vs Mintlify, GitBook, mcp-ragdocs, mcp-local-rag) — fact-checked with live research
- Add 3 new migration guides: GitBook, mcp-ragdocs, mcp-local-rag
- Update homepage "Switch to Pathfinder" section with links to all 4 guides
- Add weekly competitive matrix automation (script + GitHub workflow)
- Add Slack notifications to publish-release and deploy-pages workflows
- Add static quality checks workflow (prettier + build + test on PRs)
- Update unreleased changes check to match aimock pattern

## New pages
- `/migrate-from-gitbook` — 7-section guide with concept mapping, migration walkthrough, honest "what's different"
- `/migrate-from-ragdocs` — side-by-side config comparison, 5-step migration
- `/migrate-from-local-rag` — honest "when to stay" section acknowledging local-rag's strengths

## Automation
- `scripts/update-competitive-matrix.ts` — fetches competitor READMEs weekly, keyword-matches features, auto-PRs changes
- `.github/workflows/update-competitive-matrix.yml` — Monday 9am UTC cron
- `.github/workflows/static-quality.yml` — prettier + build + test on PRs

## Test plan
- [x] Build clean
- [x] 1698 tests pass
- [x] Comparison matrix fact-checked by research agent (6 corrections applied)
- [ ] Visual review of homepage comparison section
- [ ] Visual review of each migration guide page