### PR TITLE
v1.8.0: Hybrid Search (Vector + BM25 with RRF)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,15 @@
 # @copilotkit/pathfinder
 
-## 1.10.0
+## 1.11.0
 
 ### Minor Changes
 
-- **Auto-Generate from URL**: New `pathfinder init --from <url>` command that crawls a documentation site and generates a working `pathfinder.yaml`. Three-tier discovery: sitemap.xml, robots.txt Sitemap directives, recursive link following
-- **Site Crawler**: Rate-limited crawler with retry/backoff for 429/5xx, page caching, SPA detection warnings, and robots.txt compliance
-- **Config Generator**: Auto-detects source type (HTML/markdown), derives base URL from common path prefix, detects content selectors, and supports GitHub/GitLab repo detection
-- **CLI Flags**: `--rate-limit <ms>`, `--max-pages <n>`, `--force` flags for controlling crawl behavior
-
-## 1.9.0
-
-### Minor Changes
-
-- **PDF/DOCX Ingestion**: New `document` source type for indexing PDF and DOCX files. Format detected from file extension, with page-break and section-aware chunking
-- **Content Extractors**: Dynamic import of `pdf-parse` (PDF) and `mammoth` (DOCX) as optional peer dependencies — only loaded when a `document` source is configured
-- **Document Chunker**: Intelligent splitting on page breaks (form feed), ALL CAPS section headers, numbered section headers, and paragraph boundaries with configurable overlap
-- **Scanned PDF Detection**: Warns when a multi-page PDF produces very little text, indicating a scanned document without a text layer
-- **10MB Default File Size**: Document sources default to 10MB max file size (vs 100KB for text sources)
+- **Analytics Dashboard**: Built-in query analytics with embedded Chart.js dashboard at `/analytics`. Track query volume, latency (avg + p95), empty result rates, top queries, and queries by source
+- **Query Logging**: Fire-and-forget instrumentation in search and knowledge tool handlers. Logs query text, result count, top similarity score, latency, source, and session ID
+- **Analytics REST API**: Three endpoints (`/api/analytics/summary`, `/queries`, `/empty-queries`) with Bearer token authentication via config or `ANALYTICS_TOKEN` env var
+- **Analytics Config**: New `analytics` section in pathfinder.yaml with `enabled`, `log_queries`, `token`, and `retention_days` fields. Fully optional and backwards compatible
+- **Auto-Cleanup**: Old query_log rows automatically pruned during nightly reindex cycle based on `retention_days` (default 90)
+- **PGlite Compatible**: p95 latency computed in application code (not SQL `percentile_cont`) for PGlite compatibility
 
 ## 1.8.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # @copilotkit/pathfinder
 
+## 1.9.0
+
+### Minor Changes
+
+- **PDF/DOCX Ingestion**: New `document` source type for indexing PDF and DOCX files. Format detected from file extension, with page-break and section-aware chunking
+- **Content Extractors**: Dynamic import of `pdf-parse` (PDF) and `mammoth` (DOCX) as optional peer dependencies — only loaded when a `document` source is configured
+- **Document Chunker**: Intelligent splitting on page breaks (form feed), ALL CAPS section headers, numbered section headers, and paragraph boundaries with configurable overlap
+- **Scanned PDF Detection**: Warns when a multi-page PDF produces very little text, indicating a scanned document without a text layer
+- **10MB Default File Size**: Document sources default to 10MB max file size (vs 100KB for text sources)
+
 ## 1.8.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @copilotkit/pathfinder
 
+## 1.8.0
+
+### Minor Changes
+
+- **Hybrid Search**: Combine vector similarity and full-text keyword search using Reciprocal Rank Fusion (RRF). Three search modes: `vector` (default, unchanged), `keyword` (tsvector-based full-text), `hybrid` (both + RRF merge)
+- **Keyword Search Upgrade**: Replaced ILIKE with PostgreSQL tsvector/tsquery for proper full-text search with ranking via ts_rank
+- **search_mode Config**: New `search_mode` field on search tools — set to `'vector'`, `'keyword'`, or `'hybrid'` (defaults to `'vector'` for backwards compatibility)
+- **tsvector Schema Migration**: Adds `tsv` tsvector column with GIN index for fast full-text search, with PGlite-safe trigger fallback
+
 ## 1.7.0
 
 ### Minor Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # @copilotkit/pathfinder
 
+## 1.10.0
+
+### Minor Changes
+
+- **Auto-Generate from URL**: New `pathfinder init --from <url>` command that crawls a documentation site and generates a working `pathfinder.yaml`. Three-tier discovery: sitemap.xml, robots.txt Sitemap directives, recursive link following
+- **Site Crawler**: Rate-limited crawler with retry/backoff for 429/5xx, page caching, SPA detection warnings, and robots.txt compliance
+- **Config Generator**: Auto-detects source type (HTML/markdown), derives base URL from common path prefix, detects content selectors, and supports GitHub/GitLab repo detection
+- **CLI Flags**: `--rate-limit <ms>`, `--max-pages <n>`, `--force` flags for controlling crawl behavior
+
 ## 1.9.0
 
 ### Minor Changes

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Pathfinder indexes your GitHub repos — docs (Markdown, MDX, HTML) and source c
 
 - **[Semantic Search](https://pathfinder.copilotkit.dev/search)** — pgvector RAG with configurable chunk sizes, overlap, and score thresholds
 - **[Filesystem Exploration](https://pathfinder.copilotkit.dev/search)** — QuickJS WASM sandbox with session state, `qmd` semantic grep, `related` files
-- **[7 Source Types](https://pathfinder.copilotkit.dev/config)** — Markdown, code, raw-text, HTML, Slack, Discord, Notion — with pluggable chunker registry
+- **[8 Source Types](https://pathfinder.copilotkit.dev/config)** — Markdown, code, raw-text, HTML, document (PDF/DOCX), Slack, Discord, Notion — with pluggable chunker registry
 - **[Multiple Embedding Providers](https://pathfinder.copilotkit.dev/config)** — OpenAI, Ollama (local HTTP), or transformers.js (zero external deps, CPU-only)
 - **[Config-Driven](https://pathfinder.copilotkit.dev/config)** — Everything in one `pathfinder.yaml`: sources, tools, embedding, indexing, webhooks
 - **[Client Setup](https://pathfinder.copilotkit.dev/clients)** — Claude Desktop, Claude Code, Cursor, Codex, VS Code, any Streamable HTTP client

--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ Pathfinder indexes your GitHub repos — docs (Markdown, MDX, HTML) and source c
 - **[Auto-Generated Endpoints](https://pathfinder.copilotkit.dev/usage)** — `/llms.txt`, `/llms-full.txt`, `/faq.txt`, `/.well-known/skills/default/skill.md`
 - **[Webhook Reindexing](https://pathfinder.copilotkit.dev/deploy)** — GitHub push triggers incremental reindex
 - **[IP Rate Limiting](https://pathfinder.copilotkit.dev/config)** — Per-IP session caps and configurable TTL
+- **[Analytics](https://pathfinder.copilotkit.dev/analytics)** — Query logging, top queries, empty results, latency metrics at `/analytics`
 
 ## CLI
 
 ```bash
 # Scaffold config
 npx @copilotkit/pathfinder init
+
+# Auto-generate config from an existing docs site
+npx @copilotkit/pathfinder init --from <url>
 
 # Start server (uses PGlite if no DATABASE_URL)
 npx @copilotkit/pathfinder serve

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pathfinder Analytics</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; padding: 24px; }
+        h1 { font-size: 1.5rem; margin-bottom: 24px; }
+        .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 32px; }
+        .stat-card { background: #1e293b; border-radius: 8px; padding: 16px; }
+        .stat-card .label { font-size: 0.75rem; text-transform: uppercase; color: #94a3b8; margin-bottom: 4px; }
+        .stat-card .value { font-size: 1.5rem; font-weight: 700; }
+        .chart-row { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
+        .chart-box { background: #1e293b; border-radius: 8px; padding: 16px; }
+        .chart-box h2 { font-size: 1rem; margin-bottom: 12px; }
+        table { width: 100%; border-collapse: collapse; background: #1e293b; border-radius: 8px; overflow: hidden; margin-bottom: 32px; }
+        th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid #334155; }
+        th { background: #0f172a; font-size: 0.75rem; text-transform: uppercase; color: #94a3b8; }
+        .empty { color: #f87171; }
+        .error { color: #f87171; padding: 24px; text-align: center; }
+        @media (max-width: 768px) { .chart-row { grid-template-columns: 1fr; } }
+    </style>
+</head>
+<body>
+    <h1>Pathfinder Analytics</h1>
+    <div id="error" class="error" style="display:none"></div>
+
+    <div class="stats" id="stats"></div>
+
+    <div class="chart-row">
+        <div class="chart-box">
+            <h2>Queries per Day (7d)</h2>
+            <canvas id="dailyChart"></canvas>
+        </div>
+        <div class="chart-box">
+            <h2>Queries by Source</h2>
+            <canvas id="sourceChart"></canvas>
+        </div>
+    </div>
+
+    <h2 style="margin-bottom: 12px;">Top Queries (7d)</h2>
+    <table id="topQueriesTable">
+        <thead><tr><th>Query</th><th>Count</th><th>Avg Results</th><th>Avg Score</th></tr></thead>
+        <tbody></tbody>
+    </table>
+
+    <h2 style="margin-bottom: 12px;">Empty Result Queries (7d) <span class="empty">&#x26a0;</span></h2>
+    <table id="emptyQueriesTable">
+        <thead><tr><th>Query</th><th>Tool</th><th>Source</th><th>Count</th><th>Last Seen</th></tr></thead>
+        <tbody></tbody>
+    </table>
+
+    <script>
+        const TOKEN = new URLSearchParams(window.location.search).get('token') || '';
+        const headers = TOKEN ? { 'Authorization': 'Bearer ' + TOKEN } : {};
+
+        async function fetchJson(url) {
+            var res = await fetch(url, { headers: headers });
+            if (!res.ok) {
+                var body = await res.json().catch(function() { return {}; });
+                throw new Error(body.error || 'HTTP ' + res.status);
+            }
+            return res.json();
+        }
+
+        async function load() {
+            try {
+                var results = await Promise.all([
+                    fetchJson('/api/analytics/summary'),
+                    fetchJson('/api/analytics/queries?days=7&limit=50'),
+                    fetchJson('/api/analytics/empty-queries?days=7&limit=50'),
+                ]);
+                var summary = results[0];
+                var topQueries = results[1];
+                var emptyQueries = results[2];
+
+                // Stats cards
+                document.getElementById('stats').innerHTML = [
+                    { label: 'Total Queries', value: summary.total_queries.toLocaleString() },
+                    { label: 'Queries (7d)', value: summary.total_queries_7d.toLocaleString() },
+                    { label: 'Empty Result Rate (7d)', value: (summary.empty_result_rate_7d * 100).toFixed(1) + '%' },
+                    { label: 'Avg Latency (7d)', value: summary.avg_latency_ms_7d + 'ms' },
+                    { label: 'P95 Latency (7d)', value: summary.p95_latency_ms_7d + 'ms' },
+                    { label: 'Empty Queries (7d)', value: summary.empty_result_count_7d.toLocaleString() },
+                ].map(function(s) { return '<div class="stat-card"><div class="label">' + s.label + '</div><div class="value">' + s.value + '</div></div>'; }).join('');
+
+                // Daily chart
+                new Chart(document.getElementById('dailyChart'), {
+                    type: 'bar',
+                    data: {
+                        labels: summary.queries_per_day_7d.map(function(d) { return d.day; }),
+                        datasets: [{ label: 'Queries', data: summary.queries_per_day_7d.map(function(d) { return d.count; }), backgroundColor: '#3b82f6' }],
+                    },
+                    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } },
+                });
+
+                // Source chart
+                if (summary.queries_by_source.length > 0) {
+                    new Chart(document.getElementById('sourceChart'), {
+                        type: 'doughnut',
+                        data: {
+                            labels: summary.queries_by_source.map(function(s) { return s.source_name; }),
+                            datasets: [{ data: summary.queries_by_source.map(function(s) { return s.count; }), backgroundColor: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'] }],
+                        },
+                        options: { responsive: true },
+                    });
+                }
+
+                // Top queries table
+                var topBody = document.querySelector('#topQueriesTable tbody');
+                topBody.innerHTML = topQueries.map(function(q) {
+                    return '<tr><td>' + esc(q.query_text) + '</td><td>' + q.count + '</td><td>' + q.avg_result_count.toFixed(1) + '</td><td>' + (q.avg_top_score != null ? q.avg_top_score.toFixed(2) : '-') + '</td></tr>';
+                }).join('') || '<tr><td colspan="4">No queries logged yet.</td></tr>';
+
+                // Empty queries table
+                var emptyBody = document.querySelector('#emptyQueriesTable tbody');
+                emptyBody.innerHTML = emptyQueries.map(function(q) {
+                    return '<tr class="empty"><td>' + esc(q.query_text) + '</td><td>' + esc(q.tool_name) + '</td><td>' + esc(q.source_name || '-') + '</td><td>' + q.count + '</td><td>' + new Date(q.last_seen).toLocaleString() + '</td></tr>';
+                }).join('') || '<tr><td colspan="5">No empty-result queries.</td></tr>';
+
+            } catch (err) {
+                document.getElementById('error').style.display = 'block';
+                document.getElementById('error').textContent = 'Failed to load analytics: ' + err.message;
+            }
+        }
+
+        function esc(s) {
+            var d = document.createElement('div');
+            d.textContent = s;
+            return d.innerHTML;
+        }
+
+        load();
+    </script>
+</body>
+</html>

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -235,6 +235,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
             <li><a href="#source-slack">Slack</a></li>
             <li><a href="#source-discord">Discord</a></li>
             <li><a href="#source-notion">Notion</a></li>
+            <li><a href="#source-document">Document</a></li>
             <li><a href="#tools">Tools</a></li>
             <li><a href="#tool-search">Search</a></li>
             <li><a href="#tool-bash">Bash</a></li>
@@ -243,6 +244,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
             <li><a href="#embedding">Embedding</a></li>
             <li><a href="#indexing">Indexing</a></li>
             <li><a href="#webhook">Webhook</a></li>
+            <li><a href="#analytics">Analytics</a></li>
         </ul>
     </div>
 
@@ -269,7 +271,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
     <div class="code-block"><span class="key">sources:</span>
   - <span class="key">name:</span> <span class="value">docs</span>                        <span class="comment"># Unique name, referenced by tools</span>
-    <span class="key">type:</span> <span class="value">markdown</span>                    <span class="comment"># markdown | code | raw-text | html | slack | discord | notion</span>
+    <span class="key">type:</span> <span class="value">markdown</span>                    <span class="comment"># markdown | code | raw-text | html | document | slack | discord | notion</span>
     <span class="key">repo:</span> <span class="value">https://github.com/org/repo.git</span>  <span class="comment"># Git repo URL (optional for local paths)</span>
     <span class="key">branch:</span> <span class="value">main</span>                      <span class="comment"># Git branch to track (default: default branch)</span>
     <span class="key">path:</span> <span class="value">docs/</span>                       <span class="comment"># Directory within the repo to index</span>
@@ -298,7 +300,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
       <span class="key">overlap_lines:</span> <span class="value">10</span>              <span class="comment"># Line overlap between chunks</span></div>
 
     <ul>
-        <li><strong>type</strong> — Determines chunking strategy. <code>markdown</code> splits on headings and uses token-based chunks. <code>code</code> splits on function boundaries and uses line-based chunks. <code>raw-text</code> treats content as plain text with token-based chunks. <code>html</code> parses HTML structure and extracts text content with token-based chunks.</li>
+        <li><strong>type</strong> — Determines chunking strategy. <code>markdown</code> splits on headings and uses token-based chunks. <code>code</code> splits on function boundaries and uses line-based chunks. <code>raw-text</code> treats content as plain text with token-based chunks. <code>html</code> parses HTML structure and extracts text content with token-based chunks. <code>document</code> extracts text from PDF and DOCX files with token-based chunks.</li>
         <li><strong>category</strong> — Optional tag applied to all chunks from this source. Sources with <code>category: faq</code> contribute to the <code>/faq.txt</code> endpoint and can be queried via knowledge tools.</li>
         <li><strong>repo</strong> — If provided, Pathfinder clones and updates from this repo. Omit for local directories.</li>
         <li><strong>version</strong> — Tags all indexed chunks with this version string. Used for version-filtered search queries.</li>
@@ -416,6 +418,28 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     <p>By default, Notion sources are indexed as documents and referenced by <code>search</code> tools. To also make them available via <code>knowledge</code> tools and the <code>/faq.txt</code> endpoint, add <code>category: faq</code> to the source config — useful for Notion databases structured as Q&amp;A or FAQ collections.</p>
 
     <p><em>Note: The <code>chunk</code> config is available on all source types. For Slack and Discord, the Q&amp;A chunker produces one chunk per Q&amp;A pair (chunk settings have no effect). For Notion, the markdown chunker respects <code>target_tokens</code> and <code>overlap_tokens</code>.</em></p>
+
+    <h3 id="source-document">Source type: document</h3>
+
+    <p>Index PDF and DOCX files. Requires optional peer dependencies: <code>npm install pdf-parse</code> for PDF support and <code>npm install mammoth</code> for DOCX support. Uses token-based chunks like markdown sources.</p>
+
+    <div class="code-block"><span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">manuals</span>
+    <span class="key">type:</span> <span class="value">document</span>
+    <span class="key">path:</span> <span class="value">./documents</span>
+    <span class="key">file_patterns:</span>
+      - <span class="value">"**/*.pdf"</span>
+      - <span class="value">"**/*.docx"</span>
+    <span class="key">max_file_size:</span> <span class="value">10485760</span>              <span class="comment"># 10MB default limit</span>
+    <span class="key">chunk:</span>
+      <span class="key">target_tokens:</span> <span class="value">600</span>
+      <span class="key">overlap_tokens:</span> <span class="value">50</span></div>
+
+    <ul>
+        <li><strong>PDF support</strong> — Requires <code>pdf-parse</code> peer dependency. Text is extracted page-by-page. Scanned PDFs (image-only pages with no extractable text) are detected and skipped with a warning.</li>
+        <li><strong>DOCX support</strong> — Requires <code>mammoth</code> peer dependency. Document content is converted to plain text for chunking.</li>
+        <li><strong>max_file_size</strong> — Defaults to 10MB (10485760 bytes) for document sources. Large files are skipped with a warning.</li>
+    </ul>
 
     <h3>url_derivation example</h3>
 
@@ -603,6 +627,25 @@ https://docs.example.com/getting-started</div>
     <span class="key">docs:</span> [<span class="value">"docs/"</span>]</div>
 
     <p>Point a GitHub webhook at <code>https://your-server/webhooks/github</code> with the <code>push</code> event. Set <code>GITHUB_WEBHOOK_SECRET</code> to match the webhook secret.</p>
+
+    <h2 id="analytics">analytics</h2>
+
+    <p>Optional. Enables query logging and the built-in analytics dashboard at <code>/analytics</code>.</p>
+
+    <div class="code-block"><span class="key">analytics:</span>
+  <span class="key">enabled:</span> <span class="value">false</span>                       <span class="comment"># Enable analytics (default: false)</span>
+  <span class="key">log_queries:</span> <span class="value">true</span>                    <span class="comment"># Log all search queries (default: true)</span>
+  <span class="key">token:</span> <span class="value">${ANALYTICS_TOKEN}</span>             <span class="comment"># Bearer token for the /api/analytics endpoints</span>
+  <span class="key">retention_days:</span> <span class="value">90</span>                  <span class="comment"># Days to retain analytics data (default: 90)</span></div>
+
+    <ul>
+        <li><strong>enabled</strong> — When <code>true</code>, Pathfinder logs queries and serves the analytics dashboard at <code>/analytics</code>. Default <code>false</code>.</li>
+        <li><strong>log_queries</strong> — When <code>true</code>, all search queries are logged with latency and result counts. Default <code>true</code> (when analytics is enabled).</li>
+        <li><strong>token</strong> — Bearer token for authenticating requests to <code>/api/analytics/*</code> endpoints. Use the <code>ANALYTICS_TOKEN</code> environment variable. Required when analytics is enabled.</li>
+        <li><strong>retention_days</strong> — How long to keep analytics data before automatic cleanup. Default 90 days.</li>
+    </ul>
+
+    <p>The analytics dashboard provides top queries, empty result tracking, and latency metrics. API endpoints: <code>/api/analytics/summary</code>, <code>/api/analytics/queries</code>, <code>/api/analytics/empty-queries</code>.</p>
 
     <h2>Example Configs</h2>
 

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -464,7 +464,18 @@ https://docs.example.com/getting-started</div>
     <span class="key">default_limit:</span> <span class="value">5</span>                  <span class="comment"># Default number of results</span>
     <span class="key">max_limit:</span> <span class="value">20</span>                     <span class="comment"># Maximum results an agent can request</span>
     <span class="key">result_format:</span> <span class="value">docs</span>               <span class="comment"># docs | code | raw</span>
-    <span class="key">min_score:</span> <span class="value">0.3</span>                    <span class="comment"># Minimum cosine similarity threshold (0-1, optional)</span></div>
+    <span class="key">min_score:</span> <span class="value">0.3</span>                    <span class="comment"># Minimum cosine similarity threshold (0-1, optional)</span>
+    <span class="key">search_mode:</span> <span class="value">vector</span>               <span class="comment"># vector (default) | keyword | hybrid</span></div>
+
+    <h3 id="search-modes">Search Modes</h3>
+
+    <p>The <code>search_mode</code> field controls how search queries are executed:</p>
+
+    <ul>
+      <li><strong>vector</strong> (default) — cosine similarity on embeddings. Best for semantic/conceptual queries.</li>
+      <li><strong>keyword</strong> — PostgreSQL full-text search (tsvector/tsquery). Best for exact terms, error codes, and technical identifiers. Does not require an embedding call at query time.</li>
+      <li><strong>hybrid</strong> — runs both vector and keyword searches in parallel, then merges results using Reciprocal Rank Fusion (RRF, k=60). Best overall recall for mixed query types.</li>
+    </ul>
 
     <h3 id="tool-bash">bash</h3>
 

--- a/docs/deploy/index.html
+++ b/docs/deploy/index.html
@@ -382,6 +382,7 @@ server {
             <tr><td><code>NODE_ENV</code></td><td>No</td><td><code>development</code></td><td>Set to <code>production</code> for deployed instances</td></tr>
             <tr><td><code>LOG_LEVEL</code></td><td>No</td><td><code>info</code></td><td>Logging verbosity (debug, info, warn, error)</td></tr>
             <tr><td><code>CLONE_DIR</code></td><td>No</td><td><code>/tmp/mcp-repos</code></td><td>Directory for git repo clones</td></tr>
+            <tr><td><code>ANALYTICS_TOKEN</code></td><td>When analytics enabled</td><td>-</td><td>Bearer token for authenticating <code>/api/analytics/*</code> endpoints</td></tr>
         </tbody>
     </table>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -429,6 +429,30 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
                 <td><span class="no">&#10007;</span></td>
             </tr>
             <tr>
+                <td>Local embeddings (no API key)</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="yes">&#10003;</span> <span class="partial">uses local models</span></td>
+            </tr>
+            <tr>
+                <td>Hybrid search (vector + keyword)</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>PDF/DOCX support</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="partial">&#10003; partial — PDF via ingest</span></td>
+            </tr>
+            <tr>
                 <td>Hosted option</td>
                 <td class="col-pathfinder"><span class="no">&#10007;</span></td>
                 <td><span class="yes">&#10003;</span></td>

--- a/docs/migrate-from-gitbook/index.html
+++ b/docs/migrate-from-gitbook/index.html
@@ -438,8 +438,8 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
         <p>GitBook's browser-based editor is a key feature. Pathfinder reads your existing Markdown/HTML files &mdash; you edit them however you already do (VS Code, Obsidian, vim, etc.).</p>
     </div>
     <div class="gap-card">
-        <h4>No built-in analytics</h4>
-        <p>Telemetry data (file access patterns, search queries) goes to the database but there's no built-in visualization yet. Query it directly or build your own dashboard.</p>
+        <h4>Analytics dashboard included</h4>
+        <p>Pathfinder includes a built-in analytics dashboard at <code>/analytics</code> with query logging, top queries, empty result tracking, and latency metrics. Enable it with <code>analytics.enabled: true</code> in your config.</p>
     </div>
 
     <a href="/" class="back-link">&larr; Back to Pathfinder</a>

--- a/docs/migrate-from-local-rag/index.html
+++ b/docs/migrate-from-local-rag/index.html
@@ -263,7 +263,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     </div>
     <div class="stay-card">
         <h4>Fully offline operation</h4>
-        <p>mcp-local-rag uses local embedding models — no API keys, no network calls. Pathfinder requires an OpenAI API key for embeddings (local embedding support is on the roadmap).</p>
+        <p>mcp-local-rag uses local embedding models — no API keys, no network calls. Pathfinder supports local embeddings via Ollama and @xenova/transformers — no API keys needed — but requires a running server process.</p>
     </div>
     <div class="stay-card">
         <h4>Zero dependencies</h4>
@@ -406,8 +406,8 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     <p>Pathfinder is more capable, but it's also more involved. Here's what changes:</p>
 
     <div class="gap-card">
-        <h4>Requires an OpenAI API key for embeddings</h4>
-        <p>mcp-local-rag uses local embedding models with zero API dependencies. Pathfinder uses OpenAI embeddings by default. Local embedding support is on the roadmap. If you only use bash tools (no semantic search), you can skip the API key entirely.</p>
+        <h4>OpenAI embeddings are the default, but local options are available</h4>
+        <p>mcp-local-rag uses local embedding models with zero API dependencies. Pathfinder uses OpenAI embeddings by default, but also supports Ollama and @xenova/transformers for fully local, API-key-free embeddings. If you only use bash tools (no semantic search), you can skip the embedding provider entirely.</p>
     </div>
     <div class="gap-card">
         <h4>Server process stays running</h4>

--- a/docs/migrate-from-mintlify/index.html
+++ b/docs/migrate-from-mintlify/index.html
@@ -444,8 +444,8 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
         <p>You run the infrastructure. Docker Compose makes this straightforward, but there's no managed cloud offering (yet). You need PostgreSQL and optionally an OpenAI API key.</p>
     </div>
     <div class="gap-card">
-        <h4>No analytics dashboard</h4>
-        <p>Telemetry data (file access patterns, grep misses) goes to the database but there's no built-in visualization. Query it directly or build your own dashboard.</p>
+        <h4>Analytics dashboard included</h4>
+        <p>Pathfinder includes a built-in analytics dashboard at <code>/analytics</code> with query logging, top queries, empty result tracking, and latency metrics. Enable it with <code>analytics.enabled: true</code> in your config.</p>
     </div>
 
     <a href="/" class="back-link">&larr; Back to Pathfinder</a>

--- a/docs/usage/index.html
+++ b/docs/usage/index.html
@@ -285,6 +285,17 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
         <li><strong><code>/.well-known/skills/default/skill.md</code></strong> — A dynamic agent capability description that reflects your current tool configuration. Agents can read this to understand what Pathfinder can do.</li>
         <li><strong><code>/faq.txt</code></strong> — Q&amp;A pairs from FAQ-category sources (Slack threads, Discord forums), filtered by confidence. Only generated when sources with <code>category: faq</code> are configured.</li>
         <li><strong><code>/health</code></strong> — JSON health check with uptime, indexing status, and chunk counts per source.</li>
+        <li><strong><code>/analytics</code></strong> — Built-in analytics dashboard with query logging, top queries, empty result tracking, and latency metrics. Requires <code>analytics.enabled: true</code> in config.</li>
+    </ul>
+
+    <h3>Analytics API Endpoints</h3>
+
+    <p>When analytics is enabled, the following API endpoints are available (authenticated via <code>ANALYTICS_TOKEN</code> bearer token):</p>
+
+    <ul>
+        <li><strong><code>/api/analytics/summary</code></strong> — Overview of query volume, average latency, and top queries.</li>
+        <li><strong><code>/api/analytics/queries</code></strong> — Paginated list of all logged search queries with timestamps, latency, and result counts.</li>
+        <li><strong><code>/api/analytics/empty-queries</code></strong> — Queries that returned zero results, useful for identifying content gaps.</li>
     </ul>
 
     <p>All HTTP responses include <code>Link</code> headers pointing to <code>/llms.txt</code> and, when available, <code>&lt;/faq.txt&gt;; rel="faq"</code>, so clients can discover these endpoints automatically.</p>
@@ -293,6 +304,13 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
     <ul>
         <li><strong><code>pathfinder init</code></strong> — Scaffold a new <code>pathfinder.yaml</code> config file interactively.</li>
+        <li><strong><code>pathfinder init --from &lt;url&gt;</code></strong> — Crawl a documentation site and auto-generate a <code>pathfinder.yaml</code> config. Options:
+            <ul>
+                <li><code>--rate-limit &lt;ms&gt;</code> — Milliseconds between requests (default: 500)</li>
+                <li><code>--max-pages &lt;n&gt;</code> — Maximum pages to crawl (default: 500)</li>
+                <li><code>--force</code> — Overwrite existing <code>pathfinder.yaml</code></li>
+            </ul>
+        </li>
         <li><strong><code>pathfinder serve</code></strong> — Start the MCP server. Uses PGlite if no <code>DATABASE_URL</code> is set. Options:
             <ul>
                 <li><code>-p, --port &lt;number&gt;</code> — Override the default port (3001)</li>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.8.0",
-    "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
+    "version": "1.9.0",
+    "description": "The knowledge server for AI agents — index docs, code, PDF, DOCX, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
     "type": "module",
     "repository": {
         "type": "git",
@@ -67,10 +67,18 @@
         "zod": "^3.23.8"
     },
     "peerDependencies": {
-        "@xenova/transformers": "^2.17.0"
+        "@xenova/transformers": "^2.17.0",
+        "pdf-parse": "^1.1.1",
+        "mammoth": "^1.8.0"
     },
     "peerDependenciesMeta": {
         "@xenova/transformers": {
+            "optional": true
+        },
+        "pdf-parse": {
+            "optional": true
+        },
+        "mammoth": {
             "optional": true
         }
     },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.10.0",
-    "description": "The knowledge server for AI agents — index docs, code, PDF, DOCX, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
+    "version": "1.11.0",
+    "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
     "type": "module",
     "repository": {
         "type": "git",
@@ -67,18 +67,10 @@
         "zod": "^3.23.8"
     },
     "peerDependencies": {
-        "@xenova/transformers": "^2.17.0",
-        "pdf-parse": "^1.1.1",
-        "mammoth": "^1.8.0"
+        "@xenova/transformers": "^2.17.0"
     },
     "peerDependenciesMeta": {
         "@xenova/transformers": {
-            "optional": true
-        },
-        "pdf-parse": {
-            "optional": true
-        },
-        "mammoth": {
             "optional": true
         }
     },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.9.0",
+    "version": "1.10.0",
     "description": "The knowledge server for AI agents — index docs, code, PDF, DOCX, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
     "type": "module",
     "repository": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.7.0",
+    "version": "1.8.0",
     "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
     "type": "module",
     "repository": {

--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -44,6 +44,7 @@ tools:
     default_limit: 5
     max_limit: 20
     result_format: docs
+    # search_mode: vector   # 'vector' (default) | 'keyword' | 'hybrid'
 
   # Filesystem exploration — no database or API keys needed
   - name: explore-docs

--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -27,6 +27,15 @@ sources:
 #      target_tokens: 600
 #      overlap_tokens: 50
 
+# ── Document source (requires pdf-parse and/or mammoth) ──
+#  - name: specs
+#    type: document
+#    path: docs/specs/
+#    file_patterns: ["**/*.pdf", "**/*.docx"]
+#    chunk:
+#      target_tokens: 600
+#      overlap_tokens: 50
+
 # ── Slack source (requires SLACK_BOT_TOKEN + OPENAI_API_KEY) ──
 #  - name: community
 #    type: slack

--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -94,3 +94,9 @@ indexing:
   auto_reindex: true
   reindex_hour_utc: 3
   stale_threshold_hours: 24
+
+# ── Analytics (query logging and dashboard) ──
+# analytics:
+#   enabled: true
+#   log_queries: true
+#   retention_days: 90

--- a/plugin/SKILL.md
+++ b/plugin/SKILL.md
@@ -19,6 +19,8 @@ Finds content by meaning, not just keywords. Use this when you need to understan
 - "Error handling middleware"
 - "Database migration workflow"
 
+> **Note:** Some search tools may be configured for hybrid mode (combining vector and keyword search) or keyword-only mode. The tool handles this internally — always provide a natural language query regardless of mode.
+
 ### explore (bash/filesystem)
 
 A sandboxed bash shell for browsing the indexed filesystem. Files are read-only (except `/workspace/`). Use this for precise lookups, structural exploration, and when you need exact file contents.

--- a/src/__tests__/analytics-config.test.ts
+++ b/src/__tests__/analytics-config.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { AnalyticsConfigSchema, ServerConfigSchema } from "../types.js";
+
+describe("AnalyticsConfigSchema", () => {
+  it("accepts a fully specified config", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      enabled: true,
+      log_queries: true,
+      token: "secret-token-123",
+      retention_days: 30,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      enabled: true,
+      log_queries: true,
+      token: "secret-token-123",
+      retention_days: 30,
+    });
+  });
+
+  it("applies defaults for missing optional fields", () => {
+    const result = AnalyticsConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      enabled: false,
+      log_queries: true,
+      retention_days: 90,
+    });
+  });
+
+  it("rejects empty token string", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      enabled: true,
+      token: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-positive retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 30.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects retention_days of fractional value", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 30.7,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts very large retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 3650, // 10 years
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("ServerConfigSchema with analytics", () => {
+  const minimalServerConfig = {
+    server: { name: "test", version: "1.0.0" },
+    sources: [
+      {
+        name: "s",
+        type: "markdown",
+        path: ".",
+        file_patterns: ["**/*.md"],
+        chunk: {},
+      },
+    ],
+    tools: [
+      { name: "bash", type: "bash", description: "bash", sources: ["s"] },
+    ],
+  };
+
+  it("accepts config without analytics section", () => {
+    const result = ServerConfigSchema.safeParse(minimalServerConfig);
+    expect(result.success).toBe(true);
+    expect(result.data!.analytics).toBeUndefined();
+  });
+
+  it("accepts config with analytics section", () => {
+    const result = ServerConfigSchema.safeParse({
+      ...minimalServerConfig,
+      analytics: { enabled: true, token: "abc123" },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data!.analytics?.enabled).toBe(true);
+    expect(result.data!.analytics?.token).toBe("abc123");
+  });
+});

--- a/src/__tests__/analytics-endpoints.test.ts
+++ b/src/__tests__/analytics-endpoints.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// These tests verify the auth middleware logic and endpoint parameter parsing.
+// They mock the analytics DB functions and test the Express handler logic.
+
+const mockGetAnalyticsSummary = vi.fn();
+const mockGetTopQueries = vi.fn();
+const mockGetEmptyQueries = vi.fn();
+
+vi.mock("../db/analytics.js", () => ({
+  getAnalyticsSummary: (...args: unknown[]) =>
+    mockGetAnalyticsSummary(...args),
+  getTopQueries: (...args: unknown[]) => mockGetTopQueries(...args),
+  getEmptyQueries: (...args: unknown[]) => mockGetEmptyQueries(...args),
+}));
+
+// Mock getServerConfig to control analytics config in tests
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn(),
+  getConfig: vi.fn().mockReturnValue({
+    port: 3001,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+  }),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import { getServerConfig } from "../config.js";
+import { analyticsAuth } from "../server.js";
+
+const mockGetServerConfigFn = vi.mocked(getServerConfig);
+
+function mockRes() {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  return { status, json };
+}
+
+describe("analyticsAuth middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANALYTICS_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.ANALYTICS_TOKEN;
+  });
+
+  it("returns 404 when analytics not enabled", () => {
+    mockGetServerConfigFn.mockReturnValue({} as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth({ headers: {} } as never, res as never, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when enabled and no token configured", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth({ headers: {} } as never, res as never, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("returns 401 when token required but no auth header", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth({ headers: {} } as never, res as never, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when token does not match", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer wrong" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when token matches", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer secret" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("returns 401 for malformed auth header (no space after Bearer)", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearersecret" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("uses ANALYTICS_TOKEN env var as fallback when config has no token", () => {
+    process.env.ANALYTICS_TOKEN = "env-secret";
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer env-secret" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("rejects when ANALYTICS_TOKEN env var is set but wrong token provided", () => {
+    process.env.ANALYTICS_TOKEN = "env-secret";
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer wrong" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Endpoint parameter parsing
+// ---------------------------------------------------------------------------
+
+describe("endpoint parameter parsing", () => {
+  it("/api/analytics/queries with non-numeric days defaults to 7", () => {
+    const days = parseInt("abc") || 7;
+    const limit = parseInt("") || 50;
+    expect(days).toBe(7);
+    expect(limit).toBe(50);
+  });
+
+  it("/api/analytics/queries caps limit at 200", () => {
+    const limit = Math.min(parseInt("999"), 200);
+    expect(limit).toBe(200);
+  });
+});

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the pool before importing analytics module
+const mockQuery = vi.fn();
+vi.mock("../db/client.js", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+import {
+  logQuery,
+  getAnalyticsSummary,
+  getTopQueries,
+  getEmptyQueries,
+  cleanupOldQueryLogs,
+} from "../db/analytics.js";
+import type { QueryLogEntry } from "../db/analytics.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// logQuery
+// ---------------------------------------------------------------------------
+
+describe("logQuery", () => {
+  const baseEntry: QueryLogEntry = {
+    tool_name: "search-docs",
+    query_text: "how to install",
+    result_count: 5,
+    top_score: 0.92,
+    latency_ms: 42,
+    source_name: "docs",
+    session_id: "sess-123",
+  };
+
+  it("inserts a row with all fields", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await logQuery(baseEntry);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("INSERT INTO query_log");
+    expect(params).toEqual([
+      "search-docs",
+      "how to install",
+      5,
+      0.92,
+      42,
+      "docs",
+      "sess-123",
+    ]);
+  });
+
+  it("redacts query_text when logQueryText is false", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await logQuery(baseEntry, false);
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[1]).toBe("<redacted>");
+  });
+
+  it("passes null for nullable fields", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await logQuery({
+      ...baseEntry,
+      top_score: null,
+      source_name: null,
+      session_id: null,
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[3]).toBeNull(); // top_score
+    expect(params[5]).toBeNull(); // source_name
+    expect(params[6]).toBeNull(); // session_id
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logQuery error handling
+// ---------------------------------------------------------------------------
+
+describe("logQuery error handling", () => {
+  it("propagates DB connection error to caller", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("connection refused"));
+    await expect(
+      logQuery({
+        tool_name: "search",
+        query_text: "test",
+        result_count: 0,
+        top_score: null,
+        latency_ms: 10,
+        source_name: null,
+        session_id: null,
+      }),
+    ).rejects.toThrow("connection refused");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAnalyticsSummary
+// ---------------------------------------------------------------------------
+
+describe("getAnalyticsSummary", () => {
+  it("returns aggregated summary data", async () => {
+    // Mock order: total, summary7d, latency rows, bySource, perDay
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 1000 }] }) // total
+      .mockResolvedValueOnce({
+        rows: [{ total: 200, empty: 10, avg_latency: 45 }],
+      }) // 7d summary
+      .mockResolvedValueOnce({
+        rows: Array.from({ length: 200 }, (_, i) => ({
+          latency_ms: i + 1,
+        })),
+      }) // latency rows for p95 computation
+      .mockResolvedValueOnce({
+        rows: [{ source_name: "docs", count: 150 }],
+      }) // by source
+      .mockResolvedValueOnce({
+        rows: [
+          { day: "2026-04-10", count: 30 },
+          { day: "2026-04-11", count: 25 },
+        ],
+      }); // per day
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.total_queries).toBe(1000);
+    expect(result.total_queries_7d).toBe(200);
+    expect(result.empty_result_count_7d).toBe(10);
+    expect(result.empty_result_rate_7d).toBeCloseTo(0.05);
+    expect(result.avg_latency_ms_7d).toBe(45);
+    // p95 of [1..200] sorted: index = floor(200 * 0.95) = 190, value = 191
+    expect(result.p95_latency_ms_7d).toBe(191);
+    expect(result.queries_by_source).toEqual([
+      { source_name: "docs", count: 150 },
+    ]);
+    expect(result.queries_per_day_7d).toHaveLength(2);
+  });
+
+  it("handles zero queries gracefully", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 0, empty: 0, avg_latency: 0 }],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // empty latency rows
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.total_queries).toBe(0);
+    expect(result.empty_result_rate_7d).toBe(0);
+    expect(result.p95_latency_ms_7d).toBe(0);
+    expect(result.queries_by_source).toEqual([]);
+    expect(result.queries_per_day_7d).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// p95 computation edge cases (tested indirectly via getAnalyticsSummary)
+// ---------------------------------------------------------------------------
+
+describe("p95 computation edge cases", () => {
+  it("p95 of single latency value returns that value", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 1, empty: 0, avg_latency: 42 }],
+      })
+      .mockResolvedValueOnce({ rows: [{ latency_ms: 42 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+    expect(result.p95_latency_ms_7d).toBe(42);
+  });
+
+  it("p95 of all identical values returns that value", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 100 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 100, empty: 0, avg_latency: 50 }],
+      })
+      .mockResolvedValueOnce({
+        rows: Array.from({ length: 100 }, () => ({ latency_ms: 50 })),
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+    expect(result.p95_latency_ms_7d).toBe(50);
+  });
+
+  it("p95 of two values returns the higher one", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 2 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 2, empty: 0, avg_latency: 75 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ latency_ms: 50 }, { latency_ms: 100 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+    // floor(2 * 0.95) = 1, sorted[1] = 100
+    expect(result.p95_latency_ms_7d).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTopQueries
+// ---------------------------------------------------------------------------
+
+describe("getTopQueries", () => {
+  it("returns top queries with frequency and avg stats", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: "install guide",
+          count: 42,
+          avg_result_count: "3.5",
+          avg_top_score: "0.88",
+        },
+        {
+          query_text: "api reference",
+          count: 30,
+          avg_result_count: "5.0",
+          avg_top_score: null,
+        },
+      ],
+    });
+
+    const result = await getTopQueries(7, 50);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].query_text).toBe("install guide");
+    expect(result[0].count).toBe(42);
+    expect(result[0].avg_result_count).toBeCloseTo(3.5);
+    expect(result[0].avg_top_score).toBeCloseTo(0.88);
+    expect(result[1].avg_top_score).toBeNull();
+  });
+
+  it("passes days and limit to query params", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getTopQueries(30, 10);
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params).toEqual([30, 10]);
+  });
+
+  it("excludes redacted queries", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getTopQueries();
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("query_text != '<redacted>'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTopQueries edge cases
+// ---------------------------------------------------------------------------
+
+describe("getTopQueries edge cases", () => {
+  it("handles days=0 gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getTopQueries(0, 50);
+    expect(result).toEqual([]);
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[0]).toBe(0);
+  });
+
+  it("handles limit=0 gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getTopQueries(7, 0);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEmptyQueries
+// ---------------------------------------------------------------------------
+
+describe("getEmptyQueries", () => {
+  it("returns empty-result queries grouped by text+tool+source", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: "nonexistent thing",
+          tool_name: "search-docs",
+          source_name: "docs",
+          count: 15,
+          last_seen: "2026-04-11T10:00:00Z",
+        },
+      ],
+    });
+
+    const result = await getEmptyQueries(7, 50);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].query_text).toBe("nonexistent thing");
+    expect(result[0].count).toBe(15);
+    expect(result[0].source_name).toBe("docs");
+  });
+
+  it("filters on result_count = 0", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getEmptyQueries();
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("result_count = 0");
+  });
+
+  it("returns null for missing source_name", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: "q",
+          tool_name: "t",
+          source_name: null,
+          count: 1,
+          last_seen: "2026-04-11",
+        },
+      ],
+    });
+
+    const result = await getEmptyQueries();
+    expect(result[0].source_name).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEmptyQueries edge cases
+// ---------------------------------------------------------------------------
+
+describe("getEmptyQueries edge cases", () => {
+  it("handles limit=0 gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getEmptyQueries(7, 0);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOldQueryLogs
+// ---------------------------------------------------------------------------
+
+describe("cleanupOldQueryLogs", () => {
+  it("deletes rows older than retention period and returns count", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 150 });
+    const deleted = await cleanupOldQueryLogs(90);
+    expect(deleted).toBe(150);
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("DELETE FROM query_log");
+    expect(params).toEqual([90]);
+  });
+
+  it("returns 0 when no rows match", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+    const deleted = await cleanupOldQueryLogs(90);
+    expect(deleted).toBe(0);
+  });
+
+  it("handles null rowCount gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: null });
+    const deleted = await cleanupOldQueryLogs(90);
+    expect(deleted).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOldQueryLogs error handling
+// ---------------------------------------------------------------------------
+
+describe("cleanupOldQueryLogs error handling", () => {
+  it("propagates DB error to caller", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("disk full"));
+    await expect(cleanupOldQueryLogs(90)).rejects.toThrow("disk full");
+  });
+});

--- a/src/__tests__/cli-init-from.test.ts
+++ b/src/__tests__/cli-init-from.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+describe('init --from <url> integration', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pathfinder-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('validates URL format before crawling', async () => {
+        const { validateInitUrl } = await import('../cli-init.js');
+        expect(() => validateInitUrl('not-a-url')).toThrow('Invalid URL');
+        expect(() => validateInitUrl('ftp://example.com')).toThrow('must be http or https');
+        expect(() => validateInitUrl('https://docs.example.com')).not.toThrow();
+    });
+
+    it('creates pathfinder.yaml in target directory', async () => {
+        const { writeGeneratedConfig } = await import('../cli-init.js');
+        const yamlContent = `server:\n  name: test\n  version: "1.0.0"\nsources: []\ntools: []`;
+
+        writeGeneratedConfig(tmpDir, yamlContent);
+
+        const written = fs.readFileSync(path.join(tmpDir, 'pathfinder.yaml'), 'utf-8');
+        expect(written).toBe(yamlContent);
+    });
+
+    it('refuses to overwrite existing pathfinder.yaml without --force', async () => {
+        const { writeGeneratedConfig } = await import('../cli-init.js');
+
+        fs.writeFileSync(path.join(tmpDir, 'pathfinder.yaml'), 'existing: true');
+
+        expect(() => writeGeneratedConfig(tmpDir, 'new: true', false)).toThrow('already exists');
+    });
+
+    it('overwrites existing pathfinder.yaml with --force', async () => {
+        const { writeGeneratedConfig } = await import('../cli-init.js');
+
+        fs.writeFileSync(path.join(tmpDir, 'pathfinder.yaml'), 'existing: true');
+        writeGeneratedConfig(tmpDir, 'new: true', true);
+
+        const written = fs.readFileSync(path.join(tmpDir, 'pathfinder.yaml'), 'utf-8');
+        expect(written).toBe('new: true');
+    });
+});
+
+// ── URL validation edge cases ───────────────────────────────────────────────
+
+describe('URL validation edge cases', () => {
+    it('accepts http:// URLs', async () => {
+        const { validateInitUrl } = await import('../cli-init.js');
+        expect(() => validateInitUrl('http://docs.example.com')).not.toThrow();
+    });
+
+    it('accepts localhost URLs', async () => {
+        const { validateInitUrl } = await import('../cli-init.js');
+        expect(() => validateInitUrl('http://localhost:3000/docs')).not.toThrow();
+    });
+
+    it('rejects empty string', async () => {
+        const { validateInitUrl } = await import('../cli-init.js');
+        expect(() => validateInitUrl('')).toThrow('Invalid URL');
+    });
+
+    it('rejects URL with no hostname', async () => {
+        const { validateInitUrl } = await import('../cli-init.js');
+        expect(() => validateInitUrl('https://')).toThrow();
+    });
+});
+
+describe('cache directory', () => {
+    let tmpDir: string;
+
+    beforeEach(() => {
+        tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'pathfinder-test-'));
+    });
+
+    afterEach(() => {
+        fs.rmSync(tmpDir, { recursive: true, force: true });
+    });
+
+    it('creates cache directory from hostname', async () => {
+        const { writeGeneratedConfig } = await import('../cli-init.js');
+        const yamlContent = 'server:\n  name: test\n';
+        writeGeneratedConfig(tmpDir, yamlContent);
+        expect(fs.existsSync(path.join(tmpDir, 'pathfinder.yaml'))).toBe(true);
+    });
+});

--- a/src/__tests__/config-generator.test.ts
+++ b/src/__tests__/config-generator.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect } from 'vitest';
+import { generateConfig, detectSourceType, deriveBaseUrl, deriveFilePatterns, detectContentSelector } from '../config-generator.js';
+import type { CrawlResult, CrawledPage } from '../crawl.js';
+
+// ── Source type detection ───────────────────────────────────────────────────
+
+describe('detectSourceType', () => {
+    it('returns "html" for pages with text/html content-type', () => {
+        const pages: CrawledPage[] = [
+            { url: 'https://docs.example.com/intro', html: '<html><body>Hi</body></html>', contentType: 'text/html; charset=utf-8', textLength: 100 },
+        ];
+        expect(detectSourceType(pages)).toBe('html');
+    });
+
+    it('returns "markdown" when URLs end in .md', () => {
+        const pages: CrawledPage[] = [
+            { url: 'https://raw.github.com/repo/docs/intro.md', html: '# Intro\nSome text', contentType: 'text/plain', textLength: 100 },
+            { url: 'https://raw.github.com/repo/docs/guide.md', html: '# Guide\nMore text', contentType: 'text/plain', textLength: 100 },
+        ];
+        expect(detectSourceType(pages)).toBe('markdown');
+    });
+
+    it('defaults to "html" for mixed content', () => {
+        const pages: CrawledPage[] = [
+            { url: 'https://docs.example.com/intro', html: '<html><body>Hi</body></html>', contentType: 'text/html', textLength: 100 },
+            { url: 'https://docs.example.com/raw.md', html: '# Raw', contentType: 'text/plain', textLength: 50 },
+        ];
+        expect(detectSourceType(pages)).toBe('html');
+    });
+});
+
+// ── Base URL derivation ────────────────────────────────────────────────────
+
+describe('deriveBaseUrl', () => {
+    it('finds common path prefix across all page URLs', () => {
+        const urls = [
+            'https://docs.example.com/docs/getting-started',
+            'https://docs.example.com/docs/api-reference',
+            'https://docs.example.com/docs/faq',
+        ];
+        expect(deriveBaseUrl(urls)).toBe('https://docs.example.com/docs');
+    });
+
+    it('returns origin when pages are at root', () => {
+        const urls = [
+            'https://docs.example.com/intro',
+            'https://docs.example.com/guide',
+        ];
+        expect(deriveBaseUrl(urls)).toBe('https://docs.example.com');
+    });
+
+    it('handles single page', () => {
+        const urls = ['https://docs.example.com/docs/intro'];
+        expect(deriveBaseUrl(urls)).toBe('https://docs.example.com/docs');
+    });
+});
+
+// ── File pattern derivation ────────────────────────────────────────────────
+
+describe('deriveFilePatterns', () => {
+    it('generates **/*.html for HTML source type', () => {
+        expect(deriveFilePatterns('html')).toEqual(['**/*.html']);
+    });
+
+    it('generates markdown patterns for markdown source type', () => {
+        expect(deriveFilePatterns('markdown')).toEqual(['**/*.md', '**/*.mdx']);
+    });
+});
+
+// ── Content selector detection ─────────────────────────────────────────────
+
+describe('detectContentSelector', () => {
+    it('detects <main> element', () => {
+        const html = '<html><body><nav>Nav</nav><main><h1>Content</h1><p>Text here</p></main></body></html>';
+        expect(detectContentSelector(html)).toBe('main');
+    });
+
+    it('detects <article> element', () => {
+        const html = '<html><body><article><h1>Post</h1><p>Body</p></article></body></html>';
+        expect(detectContentSelector(html)).toBe('article');
+    });
+
+    it('detects role="main"', () => {
+        const html = '<html><body><div role="main"><p>Content</p></div></body></html>';
+        expect(detectContentSelector(html)).toBe('[role="main"]');
+    });
+
+    it('returns null when no semantic container found', () => {
+        const html = '<html><body><div><p>Just divs</p></div></body></html>';
+        expect(detectContentSelector(html)).toBeNull();
+    });
+});
+
+// ── Full config generation ─────────────────────────────────────────────────
+
+describe('generateConfig', () => {
+    it('produces valid pathfinder.yaml content for an HTML site', () => {
+        const crawlResult: CrawlResult = {
+            pages: [
+                { url: 'https://docs.example.com/docs/intro', html: '<html><head><title>Intro - Example</title></head><body><main><h1>Intro</h1></main></body></html>', contentType: 'text/html', textLength: 200 },
+                { url: 'https://docs.example.com/docs/guide', html: '<html><head><title>Guide - Example</title></head><body><main><h1>Guide</h1></main></body></html>', contentType: 'text/html', textLength: 300 },
+            ],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://docs.example.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const config = generateConfig(crawlResult, 'https://docs.example.com');
+
+        expect(config.server.name).toBe('example-docs');
+        expect(config.sources).toHaveLength(1);
+        expect(config.sources[0].type).toBe('html');
+        expect(config.sources[0].base_url).toBe('https://docs.example.com/docs');
+        expect(config.sources[0].file_patterns).toEqual(['**/*.html']);
+        expect(config.tools).toHaveLength(1);
+        expect(config.tools[0].type).toBe('search');
+        expect(config.embedding).toBeDefined();
+        expect(config.embedding.provider).toBe('openai');
+        expect(config.indexing).toBeDefined();
+    });
+
+    it('derives server name from hostname', () => {
+        const crawlResult: CrawlResult = {
+            pages: [{ url: 'https://my-awesome-lib.readthedocs.io/en/latest/intro', html: '<html><body>Hi</body></html>', contentType: 'text/html', textLength: 100 }],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://my-awesome-lib.readthedocs.io',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const config = generateConfig(crawlResult, 'https://my-awesome-lib.readthedocs.io');
+        expect(config.server.name).toBe('my-awesome-lib-docs');
+    });
+
+    it('uses cache directory as source path', () => {
+        const crawlResult: CrawlResult = {
+            pages: [{ url: 'https://docs.example.com/page', html: '<html><body>Hi</body></html>', contentType: 'text/html', textLength: 100 }],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://docs.example.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const config = generateConfig(crawlResult, 'https://docs.example.com');
+        expect(config.sources[0].path).toBe('.pathfinder/cache/docs.example.com');
+    });
+
+    it('detects git-hosted docs and uses repo source', () => {
+        const crawlResult: CrawlResult = {
+            pages: [{ url: 'https://github.com/org/repo/blob/main/docs/README.md', html: '# README', contentType: 'text/plain', textLength: 100 }],
+            discoveryMethod: 'crawl',
+            baseUrl: 'https://github.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const config = generateConfig(crawlResult, 'https://github.com/org/repo');
+        expect(config.sources[0].repo).toBeDefined();
+        expect(config.sources[0].type).toBe('markdown');
+    });
+});
+
+// ── generateConfig edge cases ───────────────────────────────────────────────
+
+describe('generateConfig edge cases', () => {
+    it('handles zero pages (empty crawl result)', () => {
+        const crawlResult: CrawlResult = {
+            pages: [],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://docs.example.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const config = generateConfig(crawlResult, 'https://docs.example.com');
+        expect(config.server.name).toBe('example-docs');
+        expect(config.sources).toHaveLength(1);
+        expect(config.sources[0].type).toBe('html');
+    });
+
+    it('detects GitLab repos correctly', () => {
+        const crawlResult: CrawlResult = {
+            pages: [{ url: 'https://gitlab.com/org/repo/-/blob/main/docs/README.md', html: '# README', contentType: 'text/plain', textLength: 100 }],
+            discoveryMethod: 'crawl',
+            baseUrl: 'https://gitlab.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const config = generateConfig(crawlResult, 'https://gitlab.com/org/repo');
+        expect(config.sources[0].repo).toContain('gitlab.com');
+    });
+
+    it('wires detected content_selector into source config', () => {
+        const crawlResult: CrawlResult = {
+            pages: [
+                { url: 'https://docs.example.com/page', html: '<html><body><main><h1>Title</h1><p>Content</p></main></body></html>', contentType: 'text/html', textLength: 200 },
+            ],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://docs.example.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const config = generateConfig(crawlResult, 'https://docs.example.com');
+        // Fix I2: detectContentSelector should find <main> and include it
+        expect((config.sources[0] as any).content_selector).toBe('main');
+    });
+});
+
+// ── YAML serialization ─────────────────────────────────────────────────────
+
+describe('generateConfigYaml', () => {
+    it('produces parseable YAML string', async () => {
+        const { generateConfigYaml } = await import('../config-generator.js');
+        const { parse: parseYaml } = await import('yaml');
+
+        const crawlResult: CrawlResult = {
+            pages: [
+                { url: 'https://docs.example.com/intro', html: '<html><body><main>Content</main></body></html>', contentType: 'text/html', textLength: 200 },
+            ],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://docs.example.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const yaml = generateConfigYaml(crawlResult, 'https://docs.example.com');
+        const parsed = parseYaml(yaml);
+
+        expect(parsed.server).toBeDefined();
+        expect(parsed.sources).toBeInstanceOf(Array);
+        expect(parsed.tools).toBeInstanceOf(Array);
+        expect(parsed.embedding).toBeDefined();
+    });
+});

--- a/src/__tests__/config-generator.test.ts
+++ b/src/__tests__/config-generator.test.ts
@@ -192,7 +192,7 @@ describe('generateConfig edge cases', () => {
         expect(config.sources[0].repo).toContain('gitlab.com');
     });
 
-    it('wires detected content_selector into source config', () => {
+    it('does not include content_selector in config (emitted as YAML comment instead)', () => {
         const crawlResult: CrawlResult = {
             pages: [
                 { url: 'https://docs.example.com/page', html: '<html><body><main><h1>Title</h1><p>Content</p></main></body></html>', contentType: 'text/html', textLength: 200 },
@@ -204,8 +204,25 @@ describe('generateConfig edge cases', () => {
         };
 
         const config = generateConfig(crawlResult, 'https://docs.example.com');
-        // Fix I2: detectContentSelector should find <main> and include it
-        expect((config.sources[0] as any).content_selector).toBe('main');
+        // content_selector must NOT be in the config object (would fail Zod validation)
+        expect((config.sources[0] as any).content_selector).toBeUndefined();
+    });
+
+    it('emits content_selector as YAML comment when detected', async () => {
+        const { generateConfigYaml } = await import('../config-generator.js');
+
+        const crawlResult: CrawlResult = {
+            pages: [
+                { url: 'https://docs.example.com/page', html: '<html><body><main><h1>Title</h1><p>Content</p></main></body></html>', contentType: 'text/html', textLength: 200 },
+            ],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://docs.example.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const yaml = generateConfigYaml(crawlResult, 'https://docs.example.com');
+        expect(yaml).toContain('# content_selector: "main"');
     });
 });
 

--- a/src/__tests__/content-extractors.test.ts
+++ b/src/__tests__/content-extractors.test.ts
@@ -1,0 +1,350 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+import { extractContent } from "../indexing/content-extractors.js";
+
+describe("extractContent", () => {
+  let tmpDir: string;
+
+  beforeEach(async () => {
+    tmpDir = await fs.promises.mkdtemp(
+      path.join(os.tmpdir(), "extract-test-"),
+    );
+  });
+
+  // ── Non-document types pass through as UTF-8 ──────────────────────────
+
+  it("reads plain text for non-document source types", async () => {
+    const filePath = path.join(tmpDir, "readme.md");
+    await fs.promises.writeFile(filePath, "# Hello World");
+    const result = await extractContent(filePath, "markdown");
+    expect(result.content).toBe("# Hello World");
+    expect(result.metadata).toBeUndefined();
+  });
+
+  it("reads plain text for html source type", async () => {
+    const filePath = path.join(tmpDir, "page.html");
+    await fs.promises.writeFile(filePath, "<h1>Title</h1>");
+    const result = await extractContent(filePath, "html");
+    expect(result.content).toBe("<h1>Title</h1>");
+  });
+
+  // ── Document type with unknown extension falls back to UTF-8 ──────────
+
+  it("falls back to UTF-8 for unknown extension under document type", async () => {
+    const filePath = path.join(tmpDir, "notes.txt");
+    await fs.promises.writeFile(filePath, "Plain text notes");
+    const result = await extractContent(filePath, "document");
+    expect(result.content).toBe("Plain text notes");
+  });
+
+  // ── PDF extraction ────────────────────────────────────────────────────
+
+  describe("PDF extraction", () => {
+    beforeEach(() => {
+      vi.resetModules();
+    });
+
+    it("extracts text from a PDF file", async () => {
+      const mockPdfParse = vi.fn().mockResolvedValue({
+        text: "Page 1 content\n\nPage 2 content",
+        numpages: 2,
+        info: { Title: "Test Document", Author: "Test Author" },
+      });
+
+      vi.doMock("pdf-parse", () => ({ default: mockPdfParse }));
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "test.pdf");
+      await fs.promises.writeFile(filePath, Buffer.from("fake-pdf-bytes"));
+
+      const result = await extractContentMocked(filePath, "document");
+      expect(result.content).toBe("Page 1 content\n\nPage 2 content");
+      expect(result.metadata).toEqual({
+        title: "Test Document",
+        author: "Test Author",
+        pageCount: 2,
+      });
+      expect(mockPdfParse).toHaveBeenCalledWith(expect.any(Buffer));
+    });
+
+    it("throws a clear error when pdf-parse is not installed", async () => {
+      vi.doMock("pdf-parse", () => {
+        throw new Error("Cannot find module 'pdf-parse'");
+      });
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "test.pdf");
+      await fs.promises.writeFile(filePath, Buffer.from("fake-pdf-bytes"));
+
+      await expect(
+        extractContentMocked(filePath, "document"),
+      ).rejects.toThrow(/install pdf-parse/i);
+    });
+
+    it("warns when PDF produces very little text (likely scanned)", async () => {
+      const mockPdfParse = vi.fn().mockResolvedValue({
+        text: "Hi",
+        numpages: 10,
+        info: {},
+      });
+
+      vi.doMock("pdf-parse", () => ({ default: mockPdfParse }));
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "scanned.pdf");
+      await fs.promises.writeFile(filePath, Buffer.from("fake-pdf-bytes"));
+
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      const result = await extractContentMocked(filePath, "document");
+      expect(result.content).toBe("Hi");
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringContaining("very little text"),
+      );
+      warnSpy.mockRestore();
+    });
+  });
+
+  // ── DOCX extraction ───────────────────────────────────────────────────
+
+  describe("DOCX extraction", () => {
+    beforeEach(() => {
+      vi.resetModules();
+    });
+
+    it("extracts text from a DOCX file", async () => {
+      const mockMammoth = {
+        extractRawText: vi.fn().mockResolvedValue({
+          value:
+            "Document heading\n\nParagraph one.\n\nParagraph two.",
+          messages: [],
+        }),
+      };
+
+      vi.doMock("mammoth", () => ({ default: mockMammoth }));
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "test.docx");
+      await fs.promises.writeFile(
+        filePath,
+        Buffer.from("fake-docx-bytes"),
+      );
+
+      const result = await extractContentMocked(filePath, "document");
+      expect(result.content).toBe(
+        "Document heading\n\nParagraph one.\n\nParagraph two.",
+      );
+      expect(mockMammoth.extractRawText).toHaveBeenCalledWith({
+        path: filePath,
+      });
+    });
+
+    it("throws a clear error when mammoth is not installed", async () => {
+      vi.doMock("mammoth", () => {
+        throw new Error("Cannot find module 'mammoth'");
+      });
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "test.docx");
+      await fs.promises.writeFile(
+        filePath,
+        Buffer.from("fake-docx-bytes"),
+      );
+
+      await expect(
+        extractContentMocked(filePath, "document"),
+      ).rejects.toThrow(/install mammoth/i);
+    });
+  });
+
+  // ── .PDF / .DOCX case insensitivity ───────────────────────────────────
+
+  it("handles uppercase .PDF extension", async () => {
+    vi.resetModules();
+    const mockPdfParse = vi.fn().mockResolvedValue({
+      text: "Uppercase PDF",
+      numpages: 1,
+      info: {},
+    });
+
+    vi.doMock("pdf-parse", () => ({ default: mockPdfParse }));
+
+    const { extractContent: extractContentMocked } = await import(
+      "../indexing/content-extractors.js"
+    );
+
+    const filePath = path.join(tmpDir, "TEST.PDF");
+    await fs.promises.writeFile(filePath, Buffer.from("fake"));
+
+    const result = await extractContentMocked(filePath, "document");
+    expect(result.content).toBe("Uppercase PDF");
+  });
+
+  it("handles uppercase .DOCX extension", async () => {
+    vi.resetModules();
+    const mockMammoth = {
+      extractRawText: vi.fn().mockResolvedValue({
+        value: "Uppercase DOCX",
+        messages: [],
+      }),
+    };
+
+    vi.doMock("mammoth", () => ({ default: mockMammoth }));
+
+    const { extractContent: extractContentMocked } = await import(
+      "../indexing/content-extractors.js"
+    );
+
+    const filePath = path.join(tmpDir, "TEST.DOCX");
+    await fs.promises.writeFile(filePath, Buffer.from("fake"));
+
+    const result = await extractContentMocked(filePath, "document");
+    expect(result.content).toBe("Uppercase DOCX");
+  });
+
+  // ── Corrupt/error files ─────────────────────────────────────────────────
+
+  describe("PDF extraction error handling", () => {
+    it("throws a meaningful error when pdf-parse fails on corrupt file", async () => {
+      vi.resetModules();
+      const mockPdfParse = vi
+        .fn()
+        .mockRejectedValue(new Error("Invalid PDF structure"));
+      vi.doMock("pdf-parse", () => ({ default: mockPdfParse }));
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "corrupt.pdf");
+      await fs.promises.writeFile(
+        filePath,
+        Buffer.from("not-a-real-pdf"),
+      );
+
+      await expect(
+        extractContentMocked(filePath, "document"),
+      ).rejects.toThrow("Invalid PDF structure");
+    });
+
+    it("handles PDF with zero pages", async () => {
+      vi.resetModules();
+      const mockPdfParse = vi.fn().mockResolvedValue({
+        text: "",
+        numpages: 0,
+        info: {},
+      });
+      vi.doMock("pdf-parse", () => ({ default: mockPdfParse }));
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "empty.pdf");
+      await fs.promises.writeFile(filePath, Buffer.from("fake"));
+
+      const result = await extractContentMocked(filePath, "document");
+      expect(result.content).toBe("");
+    });
+
+    it("handles very large PDF text output without crashing", async () => {
+      vi.resetModules();
+      const largeText = "Word ".repeat(100_000); // ~500KB of text
+      const mockPdfParse = vi.fn().mockResolvedValue({
+        text: largeText,
+        numpages: 200,
+        info: {},
+      });
+      vi.doMock("pdf-parse", () => ({ default: mockPdfParse }));
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "large.pdf");
+      await fs.promises.writeFile(filePath, Buffer.from("fake"));
+
+      const result = await extractContentMocked(filePath, "document");
+      expect(result.content.length).toBe(largeText.length);
+    });
+  });
+
+  describe("DOCX extraction error handling", () => {
+    it("surfaces mammoth warning messages to console", async () => {
+      vi.resetModules();
+      const mockMammoth = {
+        extractRawText: vi.fn().mockResolvedValue({
+          value: "Some text",
+          messages: [
+            {
+              type: "warning",
+              message: "Unrecognized style: CustomStyle",
+            },
+          ],
+        }),
+      };
+      vi.doMock("mammoth", () => ({ default: mockMammoth }));
+
+      const { extractContent: extractContentMocked } = await import(
+        "../indexing/content-extractors.js"
+      );
+
+      const filePath = path.join(tmpDir, "warnings.docx");
+      await fs.promises.writeFile(filePath, Buffer.from("fake"));
+
+      const result = await extractContentMocked(filePath, "document");
+      expect(result.content).toBe("Some text");
+      // Mammoth warnings should not prevent extraction
+    });
+  });
+
+  // ── File system errors ──────────────────────────────────────────────────
+
+  describe("file system errors", () => {
+    it("throws when file does not exist", async () => {
+      await expect(
+        extractContent("/nonexistent/file.pdf", "document"),
+      ).rejects.toThrow();
+    });
+
+    it("throws when file path is a directory", async () => {
+      await expect(
+        extractContent(tmpDir, "document"),
+      ).rejects.toThrow();
+    });
+  });
+
+  // ── Source type pass-through ────────────────────────────────────────────
+
+  describe("non-document source types with binary content", () => {
+    it("reads binary-looking content as UTF-8 for non-document types (no crash)", async () => {
+      const filePath = path.join(tmpDir, "binary.md");
+      // Write content with some high-byte characters
+      await fs.promises.writeFile(
+        filePath,
+        Buffer.from([0xc0, 0xc1, 0x48, 0x65, 0x6c, 0x6c, 0x6f]),
+      );
+      // Should not throw — reads as UTF-8 with replacement characters
+      const result = await extractContent(filePath, "markdown");
+      expect(typeof result.content).toBe("string");
+    });
+  });
+});

--- a/src/__tests__/crawl.test.ts
+++ b/src/__tests__/crawl.test.ts
@@ -1,0 +1,547 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { crawlSite, parseSitemap, parseSitemapIndex, extractLinks, respectsRobotsTxt } from '../crawl.js';
+
+// ── Sitemap parsing ─────────────────────────────────────────────────────────
+
+describe('parseSitemap', () => {
+    it('extracts <loc> entries from a valid sitemap.xml', () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/getting-started</loc></url>
+  <url><loc>https://docs.example.com/api-reference</loc></url>
+  <url><loc>https://docs.example.com/faq</loc></url>
+</urlset>`;
+        const urls = parseSitemap(xml);
+        expect(urls).toEqual([
+            'https://docs.example.com/getting-started',
+            'https://docs.example.com/api-reference',
+            'https://docs.example.com/faq',
+        ]);
+    });
+
+    it('returns empty array for malformed XML', () => {
+        expect(parseSitemap('<not-a-sitemap>')).toEqual([]);
+    });
+
+    it('returns empty array for empty string', () => {
+        expect(parseSitemap('')).toEqual([]);
+    });
+
+    it('handles sitemap with extra whitespace in <loc> tags', () => {
+        const xml = `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>  https://docs.example.com/page  </loc></url>
+</urlset>`;
+        expect(parseSitemap(xml)).toEqual(['https://docs.example.com/page']);
+    });
+});
+
+describe('parseSitemapIndex', () => {
+    it('extracts sitemap URLs from a sitemap index', () => {
+        const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://docs.example.com/sitemap-docs.xml</loc></sitemap>
+  <sitemap><loc>https://docs.example.com/sitemap-blog.xml</loc></sitemap>
+</sitemapindex>`;
+        const urls = parseSitemapIndex(xml);
+        expect(urls).toEqual([
+            'https://docs.example.com/sitemap-docs.xml',
+            'https://docs.example.com/sitemap-blog.xml',
+        ]);
+    });
+
+    it('returns empty array when not a sitemap index', () => {
+        expect(parseSitemapIndex('<urlset></urlset>')).toEqual([]);
+    });
+});
+
+// ── Sitemap edge cases ──────────────────────────────────────────────────────
+
+describe('parseSitemap edge cases', () => {
+    it('handles very large sitemap with 10000+ URLs', () => {
+        const urls = Array.from({ length: 10000 }, (_, i) =>
+            `<url><loc>https://docs.example.com/page-${i}</loc></url>`
+        ).join('\n');
+        const xml = `<?xml version="1.0"?><urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">${urls}</urlset>`;
+        const result = parseSitemap(xml);
+        expect(result).toHaveLength(10000);
+    });
+
+    it('handles sitemap with CDATA-wrapped URLs', () => {
+        const xml = `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc><![CDATA[https://docs.example.com/page?a=1&b=2]]></loc></url>
+</urlset>`;
+        const result = parseSitemap(xml);
+        expect(result).toHaveLength(1);
+        expect(result[0]).toContain('page?a=1&b=2');
+    });
+});
+
+// ── Link extraction ─────────────────────────────────────────────────────────
+
+describe('extractLinks', () => {
+    it('extracts same-origin links from HTML', () => {
+        const html = `<html><body>
+            <a href="/docs/intro">Intro</a>
+            <a href="/docs/api">API</a>
+            <a href="https://other.com/page">External</a>
+            <a href="https://docs.example.com/docs/faq">Same origin absolute</a>
+        </body></html>`;
+        const links = extractLinks(html, 'https://docs.example.com');
+        expect(links).toContain('https://docs.example.com/docs/intro');
+        expect(links).toContain('https://docs.example.com/docs/api');
+        expect(links).toContain('https://docs.example.com/docs/faq');
+        expect(links).not.toContain('https://other.com/page');
+    });
+
+    it('deduplicates links', () => {
+        const html = `<html><body>
+            <a href="/page">Link 1</a>
+            <a href="/page">Link 2</a>
+            <a href="/page#section">With hash</a>
+        </body></html>`;
+        const links = extractLinks(html, 'https://example.com');
+        const pageLinks = links.filter(l => l === 'https://example.com/page');
+        expect(pageLinks).toHaveLength(1);
+    });
+
+    it('strips hash fragments', () => {
+        const html = `<html><body><a href="/page#section">Link</a></body></html>`;
+        const links = extractLinks(html, 'https://example.com');
+        expect(links).toContain('https://example.com/page');
+        expect(links.some(l => l.includes('#'))).toBe(false);
+    });
+
+    it('ignores mailto: and javascript: links', () => {
+        const html = `<html><body>
+            <a href="mailto:test@test.com">Email</a>
+            <a href="javascript:void(0)">JS</a>
+            <a href="/real-page">Real</a>
+        </body></html>`;
+        const links = extractLinks(html, 'https://example.com');
+        expect(links).toEqual(['https://example.com/real-page']);
+    });
+
+    it('handles relative links with path prefix', () => {
+        const html = `<html><body><a href="sub-page">Sub</a></body></html>`;
+        const links = extractLinks(html, 'https://example.com/docs/');
+        expect(links).toContain('https://example.com/docs/sub-page');
+    });
+});
+
+// ── extractLinks edge cases ─────────────────────────────────────────────────
+
+describe('extractLinks edge cases', () => {
+    it('ignores data: URIs', () => {
+        const html = `<html><body>
+            <a href="data:text/html,<h1>Hi</h1>">Data</a>
+            <a href="/real-page">Real</a>
+        </body></html>`;
+        const links = extractLinks(html, 'https://example.com');
+        expect(links).toEqual(['https://example.com/real-page']);
+    });
+
+    it('handles relative URLs with ../ path traversal', () => {
+        const html = `<html><body><a href="../other-section/page">Link</a></body></html>`;
+        const links = extractLinks(html, 'https://example.com/docs/guide/');
+        expect(links).toContain('https://example.com/docs/other-section/page');
+    });
+
+    it('ignores tel: links', () => {
+        const html = `<html><body><a href="tel:+1234567890">Call</a></body></html>`;
+        const links = extractLinks(html, 'https://example.com');
+        expect(links).toEqual([]);
+    });
+
+    it('handles URLs with query parameters (preserves params, strips hash)', () => {
+        const html = `<html><body><a href="/page?tab=api#section">Link</a></body></html>`;
+        const links = extractLinks(html, 'https://example.com');
+        expect(links).toContain('https://example.com/page?tab=api');
+        expect(links.some(l => l.includes('#'))).toBe(false);
+    });
+});
+
+// ── robots.txt ──────────────────────────────────────────────────────────────
+
+describe('respectsRobotsTxt', () => {
+    it('returns true when path is not disallowed', () => {
+        const robotsTxt = `User-agent: *\nDisallow: /admin/\nDisallow: /private/`;
+        expect(respectsRobotsTxt(robotsTxt, '/docs/intro')).toBe(true);
+    });
+
+    it('returns false when path is disallowed', () => {
+        const robotsTxt = `User-agent: *\nDisallow: /admin/\nDisallow: /private/`;
+        expect(respectsRobotsTxt(robotsTxt, '/admin/settings')).toBe(false);
+    });
+
+    it('extracts Sitemap directives', () => {
+        const robotsTxt = `User-agent: *\nDisallow: /admin/\nSitemap: https://example.com/sitemap.xml\nSitemap: https://example.com/sitemap2.xml`;
+        // respectsRobotsTxt only checks allow/disallow; sitemap extraction is separate
+        expect(respectsRobotsTxt(robotsTxt, '/docs/page')).toBe(true);
+    });
+
+    it('handles empty robots.txt (everything allowed)', () => {
+        expect(respectsRobotsTxt('', '/anything')).toBe(true);
+    });
+
+    it('handles Disallow: / (everything blocked)', () => {
+        const robotsTxt = `User-agent: *\nDisallow: /`;
+        expect(respectsRobotsTxt(robotsTxt, '/docs/page')).toBe(false);
+    });
+});
+
+// ── extractSitemapUrls from robots.txt ──────────────────────────────────────
+
+describe('extractSitemapsFromRobotsTxt', () => {
+    it('extracts Sitemap: directives', async () => {
+        const { extractSitemapsFromRobotsTxt } = await import('../crawl.js');
+        const robotsTxt = `User-agent: *\nDisallow: /admin/\nSitemap: https://example.com/sitemap.xml\nSitemap: https://example.com/sitemap-blog.xml`;
+        expect(extractSitemapsFromRobotsTxt(robotsTxt)).toEqual([
+            'https://example.com/sitemap.xml',
+            'https://example.com/sitemap-blog.xml',
+        ]);
+    });
+});
+
+// ── crawlSite (integration-level, mocked fetch) ────────────────────────────
+
+describe('crawlSite', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('discovers pages via sitemap.xml', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url === 'https://docs.example.com/sitemap.xml') {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/intro</loc></url>
+  <url><loc>https://docs.example.com/guide</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url === 'https://docs.example.com/intro' || url === 'https://docs.example.com/guide') {
+                return new Response('<html><head><title>Page</title></head><body><main><h1>Hello</h1><p>Content here</p></main></body></html>', {
+                    status: 200,
+                    headers: { 'content-type': 'text/html' },
+                });
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages).toHaveLength(2);
+        expect(result.pages.map(p => p.url).sort()).toEqual([
+            'https://docs.example.com/guide',
+            'https://docs.example.com/intro',
+        ]);
+        expect(result.discoveryMethod).toBe('sitemap');
+    });
+
+    it('falls back to robots.txt Sitemap: directive when sitemap.xml 404s', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url === 'https://docs.example.com/sitemap.xml') {
+                return new Response('', { status: 404 });
+            }
+            if (url === 'https://docs.example.com/sitemap_index.xml') {
+                return new Response('', { status: 404 });
+            }
+            if (url === 'https://docs.example.com/robots.txt') {
+                return new Response(
+                    'User-agent: *\nDisallow: /admin/\nSitemap: https://docs.example.com/alt-sitemap.xml',
+                    { status: 200, headers: { 'content-type': 'text/plain' } },
+                );
+            }
+            if (url === 'https://docs.example.com/alt-sitemap.xml') {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/page1</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url === 'https://docs.example.com/page1') {
+                return new Response('<html><body><p>Content</p></body></html>', {
+                    status: 200,
+                    headers: { 'content-type': 'text/html' },
+                });
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages).toHaveLength(1);
+        expect(result.pages[0].url).toBe('https://docs.example.com/page1');
+        expect(result.discoveryMethod).toBe('robots-sitemap');
+    });
+
+    it('falls back to recursive link crawling when no sitemap or robots', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url.endsWith('sitemap.xml') || url.endsWith('sitemap_index.xml')) {
+                return new Response('', { status: 404 });
+            }
+            if (url.endsWith('robots.txt')) {
+                return new Response('', { status: 404 });
+            }
+            if (url === 'https://docs.example.com' || url === 'https://docs.example.com/') {
+                return new Response(`<html><body>
+                    <a href="/page-a">A</a>
+                    <a href="/page-b">B</a>
+                </body></html>`, { status: 200, headers: { 'content-type': 'text/html' } });
+            }
+            if (url === 'https://docs.example.com/page-a') {
+                return new Response('<html><body><p>Page A content</p></body></html>', {
+                    status: 200, headers: { 'content-type': 'text/html' },
+                });
+            }
+            if (url === 'https://docs.example.com/page-b') {
+                return new Response('<html><body><p>Page B content</p></body></html>', {
+                    status: 200, headers: { 'content-type': 'text/html' },
+                });
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            maxDepth: 3,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages.length).toBeGreaterThanOrEqual(1);
+        expect(result.discoveryMethod).toBe('crawl');
+    });
+
+    it('respects maxPages limit', async () => {
+        const pageUrls = Array.from({ length: 20 }, (_, i) =>
+            `https://docs.example.com/page-${i}`
+        );
+        const sitemapXml = `<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  ${pageUrls.map(u => `<url><loc>${u}</loc></url>`).join('\n')}
+</urlset>`;
+
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url.endsWith('sitemap.xml')) {
+                return new Response(sitemapXml, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            return new Response('<html><body><p>Content</p></body></html>', {
+                status: 200, headers: { 'content-type': 'text/html' },
+            });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 5,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages).toHaveLength(5);
+    });
+
+    it('retries on 429 with backoff', async () => {
+        let attempt = 0;
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url.endsWith('sitemap.xml')) {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/page</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url === 'https://docs.example.com/page') {
+                attempt++;
+                if (attempt <= 2) {
+                    return new Response('', { status: 429, headers: { 'retry-after': '0' } });
+                }
+                return new Response('<html><body><p>Finally</p></body></html>', {
+                    status: 200, headers: { 'content-type': 'text/html' },
+                });
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages).toHaveLength(1);
+        expect(attempt).toBe(3);
+    });
+
+    it('detects SPA shells (body text < 100 chars) and warns', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url.endsWith('sitemap.xml')) {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://spa.example.com/page</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url === 'https://spa.example.com/page') {
+                return new Response('<html><body><div id="root"></div><script src="/app.js"></script></body></html>', {
+                    status: 200, headers: { 'content-type': 'text/html' },
+                });
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://spa.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            cacheDir: undefined,
+        });
+
+        // Fix I4: use expect.arrayContaining for SPA detection assertion
+        expect(result.warnings).toEqual(
+            expect.arrayContaining([expect.stringContaining('SPA')])
+        );
+    });
+
+    it('records 401/403 pages in failedUrls', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url.endsWith('sitemap.xml')) {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/public</loc></url>
+  <url><loc>https://docs.example.com/private</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url.includes('/public')) {
+                return new Response('<html><body><p>Public</p></body></html>', {
+                    status: 200, headers: { 'content-type': 'text/html' },
+                });
+            }
+            if (url.includes('/private')) {
+                return new Response('', { status: 403 });
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages).toHaveLength(1);
+        expect(result.failedUrls).toHaveLength(1);
+        expect(result.failedUrls[0].url).toBe('https://docs.example.com/private');
+        expect(result.failedUrls[0].status).toBe(403);
+    });
+});
+
+// ── crawlSite network errors ────────────────────────────────────────────────
+
+describe('crawlSite network errors', () => {
+    let fetchMock: ReturnType<typeof vi.fn>;
+
+    beforeEach(() => {
+        fetchMock = vi.fn();
+        vi.stubGlobal('fetch', fetchMock);
+    });
+
+    afterEach(() => {
+        vi.unstubAllGlobals();
+    });
+
+    it('handles fetch timeout (AbortSignal) gracefully', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url.endsWith('sitemap.xml')) {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/page</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url === 'https://docs.example.com/page') {
+                throw new DOMException('The operation was aborted', 'AbortError');
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            maxRetries: 1,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages).toHaveLength(0);
+    });
+
+    it('handles all pages returning 5xx after max retries', async () => {
+        fetchMock.mockImplementation(async (url: string) => {
+            if (url.endsWith('sitemap.xml')) {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/page1</loc></url>
+  <url><loc>https://docs.example.com/page2</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            return new Response('Internal Server Error', { status: 500 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            maxRetries: 1,
+            cacheDir: undefined,
+        });
+
+        expect(result.pages).toHaveLength(0);
+        expect(result.failedUrls.length).toBeGreaterThan(0);
+    });
+
+    it('tries sitemap_index.xml as fallback when sitemap.xml 404s', async () => {
+        const fetchedUrls: string[] = [];
+        fetchMock.mockImplementation(async (url: string) => {
+            fetchedUrls.push(url);
+            if (url === 'https://docs.example.com/sitemap.xml') {
+                return new Response('', { status: 404 });
+            }
+            if (url === 'https://docs.example.com/sitemap_index.xml') {
+                return new Response(`<?xml version="1.0"?>
+<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <sitemap><loc>https://docs.example.com/sitemap-pages.xml</loc></sitemap>
+</sitemapindex>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url === 'https://docs.example.com/sitemap-pages.xml') {
+                return new Response(`<?xml version="1.0"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url><loc>https://docs.example.com/page</loc></url>
+</urlset>`, { status: 200, headers: { 'content-type': 'application/xml' } });
+            }
+            if (url === 'https://docs.example.com/page') {
+                return new Response('<html><body><p>Content</p></body></html>', {
+                    status: 200, headers: { 'content-type': 'text/html' },
+                });
+            }
+            return new Response('', { status: 404 });
+        });
+
+        const result = await crawlSite('https://docs.example.com', {
+            rateLimit: 100,
+            maxPages: 10,
+            cacheDir: undefined,
+        });
+
+        expect(fetchedUrls).toContain('https://docs.example.com/sitemap_index.xml');
+        expect(result.pages).toHaveLength(1);
+    });
+});

--- a/src/__tests__/document-chunker.test.ts
+++ b/src/__tests__/document-chunker.test.ts
@@ -1,0 +1,324 @@
+import { describe, it, expect } from "vitest";
+import { chunkDocument } from "../indexing/chunking/document.js";
+import type { SourceConfig } from "../types.js";
+
+function mkConfig(
+  overrides: { target_tokens?: number; overlap_tokens?: number } = {},
+): SourceConfig {
+  return {
+    name: "test",
+    type: "document",
+    path: "/tmp",
+    file_patterns: ["**/*.pdf"],
+    chunk: {
+      target_tokens: overrides.target_tokens,
+      overlap_tokens: overrides.overlap_tokens,
+    },
+  } as SourceConfig;
+}
+
+describe("chunkDocument", () => {
+  // ── Empty / whitespace input ────────────────────────────────────────
+
+  it("returns empty array for empty string", () => {
+    expect(chunkDocument("", "test.pdf", mkConfig())).toEqual([]);
+  });
+
+  it("returns empty array for whitespace-only string", () => {
+    expect(chunkDocument("   \n\n  ", "test.pdf", mkConfig())).toEqual(
+      [],
+    );
+  });
+
+  it("returns empty array for null/undefined content", () => {
+    expect(
+      chunkDocument(null as unknown as string, "test.pdf", mkConfig()),
+    ).toEqual([]);
+    expect(
+      chunkDocument(
+        undefined as unknown as string,
+        "test.pdf",
+        mkConfig(),
+      ),
+    ).toEqual([]);
+  });
+
+  // ── Single chunk ────────────────────────────────────────────────────
+
+  it("returns a single chunk for small content", () => {
+    const content = "This is a short document.";
+    const chunks = chunkDocument(content, "spec.pdf", mkConfig());
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toBe("This is a short document.");
+    expect(chunks[0].chunkIndex).toBe(0);
+  });
+
+  // ── Page break awareness (form feed \f) ─────────────────────────────
+
+  it("splits on form feed (page break) characters", () => {
+    const page1 = "Content of page one. ".repeat(50);
+    const page2 = "Content of page two. ".repeat(50);
+    const content = `${page1}\f${page2}`;
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100 }),
+    );
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+    expect(chunks[0].content).toContain("page one");
+    expect(chunks[chunks.length - 1].content).toContain("page two");
+  });
+
+  it("does not split on form feed when pages fit in one chunk", () => {
+    const content = "Page 1.\fPage 2.\fPage 3.";
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 600 }),
+    );
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toContain("Page 1");
+    expect(chunks[0].content).toContain("Page 3");
+  });
+
+  // ── Section header detection ────────────────────────────────────────
+
+  it("splits on ALL CAPS section headers", () => {
+    const section1 =
+      "INTRODUCTION\n\nThis is the introduction. ".repeat(20);
+    const section2 =
+      "METHODOLOGY\n\nThis describes the method. ".repeat(20);
+    const content = `${section1}\n\n${section2}`;
+    const chunks = chunkDocument(
+      content,
+      "paper.pdf",
+      mkConfig({ target_tokens: 100 }),
+    );
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it('splits on numbered section headers (e.g., "1. Introduction")', () => {
+    const section1 =
+      "1. Introduction\n\nThis is the intro section. ".repeat(20);
+    const section2 =
+      "2. Background\n\nThis is the background. ".repeat(20);
+    const content = `${section1}\n\n${section2}`;
+    const chunks = chunkDocument(
+      content,
+      "paper.pdf",
+      mkConfig({ target_tokens: 100 }),
+    );
+    expect(chunks.length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("includes section header text in chunk title", () => {
+    const content =
+      "INTRODUCTION\n\nSome introduction text here that is meaningful.";
+    const chunks = chunkDocument(content, "paper.pdf", mkConfig());
+    expect(chunks[0].title).toBe("INTRODUCTION");
+  });
+
+  // ── Paragraph-based fallback ────────────────────────────────────────
+
+  it("falls back to paragraph splitting when no structure detected", () => {
+    const para = "This is a regular paragraph. ".repeat(50);
+    const content = Array.from({ length: 5 }, () => para).join("\n\n");
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100 }),
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  // ── chunkIndex numbering ────────────────────────────────────────────
+
+  it("sets chunkIndex sequentially", () => {
+    const page = "Content for a page. ".repeat(50);
+    const content = Array.from({ length: 5 }, () => page).join("\f");
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100 }),
+    );
+    for (let i = 0; i < chunks.length; i++) {
+      expect(chunks[i].chunkIndex).toBe(i);
+    }
+  });
+
+  // ── Overlap ─────────────────────────────────────────────────────────
+
+  it("applies overlap between chunks", () => {
+    const page = "EndMarker " + "Word ".repeat(200);
+    const content = `${page}\f${page}\f${page}`;
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100, overlap_tokens: 30 }),
+    );
+    if (chunks.length >= 2) {
+      // Second chunk should contain some text from end of first
+      expect(chunks[1].content.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("does not apply overlap to first chunk", () => {
+    const page = "Word ".repeat(200);
+    const content = `${page}\f${page}`;
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100, overlap_tokens: 30 }),
+    );
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("does not apply overlap when overlap_tokens is 0", () => {
+    const page = "Word ".repeat(200);
+    const content = `${page}\f${page}`;
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100, overlap_tokens: 0 }),
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+  });
+
+  // ── startLine / endLine as page numbers ─────────────────────────────
+
+  it("sets startLine/endLine as page numbers when content has page breaks", () => {
+    const page = "Page content here. ".repeat(50);
+    const content = `${page}\f${page}\f${page}`;
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100 }),
+    );
+    // First chunk should reference page 1
+    expect(chunks[0].startLine).toBe(1);
+    // Last chunk should reference the last page
+    const lastChunk = chunks[chunks.length - 1];
+    expect(lastChunk.startLine).toBeGreaterThanOrEqual(1);
+    expect(lastChunk.startLine).toBeLessThanOrEqual(3);
+  });
+
+  // ── Token-based sizing ──────────────────────────────────────────────
+
+  it("respects custom target_tokens", () => {
+    const content = "Word ".repeat(500);
+    const smallChunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 50 }),
+    );
+    const largeChunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 500 }),
+    );
+    expect(smallChunks.length).toBeGreaterThanOrEqual(largeChunks.length);
+  });
+
+  // ── Form feed normalization ─────────────────────────────────────────
+
+  it("replaces form feeds with double newlines in output content", () => {
+    const content = "Page one text.\fPage two text.";
+    const chunks = chunkDocument(content, "doc.pdf", mkConfig());
+    for (const chunk of chunks) {
+      expect(chunk.content).not.toContain("\f");
+    }
+  });
+
+  // ── Many small paragraphs merge ─────────────────────────────────────
+
+  it("merges many small paragraphs into fewer chunks", () => {
+    const content = Array.from(
+      { length: 50 },
+      (_, i) => `Paragraph ${i}.`,
+    ).join("\n\n");
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 600 }),
+    );
+    expect(chunks.length).toBeLessThan(50);
+  });
+
+  // ── Special characters ──────────────────────────────────────────────
+
+  it("handles unicode content", () => {
+    const content =
+      "Unicode: \u{1F680}\u{1F30D} and CJK: \u4F60\u597D\u4E16\u754C";
+    const chunks = chunkDocument(content, "doc.pdf", mkConfig());
+    expect(chunks[0].content).toContain("\u{1F680}");
+  });
+
+  // ── Extremely long single paragraph ─────────────────────────────────
+
+  it("splits extremely long paragraph with no natural breaks", () => {
+    // Single continuous text with no paragraph breaks, no page breaks, no headers
+    const content = "word ".repeat(5000); // ~25000 chars, ~6250 tokens
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 200 }),
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+    // Each chunk should not wildly exceed target_tokens * 4 chars
+    for (const chunk of chunks) {
+      // Allow some overshoot since we split on paragraph boundaries
+      expect(chunk.content.length).toBeLessThan(200 * 4 * 3); // 3x target as safety bound
+    }
+  });
+
+  // ── Mixed content ────────────────────────────────────────────────────
+
+  it("handles content with mixed page breaks, headers, and paragraphs", () => {
+    const content = [
+      "INTRODUCTION\n\nFirst paragraph of intro.",
+      "\f",
+      "CHAPTER ONE\n\nFirst paragraph of chapter one. ".repeat(20),
+      "\n\n",
+      "Second paragraph of chapter one. ".repeat(20),
+      "\f",
+      "CHAPTER TWO\n\nContent of chapter two.",
+    ].join("");
+    const chunks = chunkDocument(
+      content,
+      "doc.pdf",
+      mkConfig({ target_tokens: 100 }),
+    );
+    expect(chunks.length).toBeGreaterThan(1);
+    // Verify page numbering is maintained
+    expect(chunks[0].startLine).toBe(1); // page 1
+  });
+
+  // ── Content with only form feeds (no text between them) ──────────────
+
+  it("handles content with consecutive form feeds (empty pages)", () => {
+    const content = "Page 1.\f\f\fPage 4.";
+    const chunks = chunkDocument(content, "doc.pdf", mkConfig());
+    expect(chunks.length).toBeGreaterThanOrEqual(1);
+    // Empty pages should be skipped
+    for (const chunk of chunks) {
+      expect(chunk.content.trim().length).toBeGreaterThan(0);
+    }
+  });
+
+  // ── Title extraction with numbered headers ───────────────────────────
+
+  it("includes numbered section header in chunk title", () => {
+    const content =
+      "1. Getting Started\n\nThis section helps you get started.";
+    const chunks = chunkDocument(content, "doc.pdf", mkConfig());
+    expect(chunks[0].title).toBe("1. Getting Started");
+  });
+
+  // ── Very short content ──────────────────────────────────────────────
+
+  it("handles single word content", () => {
+    const chunks = chunkDocument("Hello", "doc.pdf", mkConfig());
+    expect(chunks).toHaveLength(1);
+    expect(chunks[0].content).toBe("Hello");
+  });
+});

--- a/src/__tests__/document-integration.test.ts
+++ b/src/__tests__/document-integration.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { FileSourceConfigSchema } from "../types.js";
+
+describe("document type schema validation", () => {
+  it("accepts document as a valid source type", () => {
+    const result = FileSourceConfigSchema.safeParse({
+      name: "specs",
+      type: "document",
+      path: "docs/",
+      file_patterns: ["**/*.pdf"],
+      chunk: {},
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("document type registration", () => {
+  it("document type is registered in provider registry", async () => {
+    // Import the registry and verify 'document' maps to FileDataProvider
+    const { getProvider } = await import(
+      "../indexing/providers/index.js"
+    );
+    const provider = getProvider("document");
+    expect(provider).toBeDefined();
+  });
+
+  it("document type is registered in chunker registry", async () => {
+    const { getChunker } = await import(
+      "../indexing/chunking/index.js"
+    );
+    const chunker = getChunker("document");
+    expect(chunker).toBeDefined();
+  });
+});
+
+describe("backwards compatibility", () => {
+  it("markdown source type still works after document type addition", async () => {
+    const { getProvider } = await import(
+      "../indexing/providers/index.js"
+    );
+    const provider = getProvider("markdown");
+    expect(provider).toBeDefined();
+  });
+
+  it("html source type still works after document type addition", async () => {
+    const { getProvider } = await import(
+      "../indexing/providers/index.js"
+    );
+    const provider = getProvider("html");
+    expect(provider).toBeDefined();
+  });
+
+  it("code source type still works after document type addition", async () => {
+    const { getProvider } = await import(
+      "../indexing/providers/index.js"
+    );
+    const provider = getProvider("code");
+    expect(provider).toBeDefined();
+  });
+});

--- a/src/__tests__/knowledge-analytics.test.ts
+++ b/src/__tests__/knowledge-analytics.test.ts
@@ -1,0 +1,118 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { KnowledgeToolConfig } from "../types.js";
+
+vi.mock("../db/queries.js", () => ({
+  getFaqChunks: vi.fn(),
+  searchChunks: vi.fn(),
+}));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn(),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn(),
+}));
+
+import { registerKnowledgeTool } from "../mcp/tools/knowledge.js";
+import { getFaqChunks, searchChunks } from "../db/queries.js";
+import { logQuery } from "../db/analytics.js";
+import { getServerConfig } from "../config.js";
+
+const mockGetFaqChunks = vi.mocked(getFaqChunks);
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockLogQuery = vi.mocked(logQuery);
+const mockGetServerConfig = vi.mocked(getServerConfig);
+const mockEmbed = vi.fn();
+
+const toolConfig: KnowledgeToolConfig = {
+  name: "faq",
+  type: "knowledge",
+  description: "FAQ",
+  sources: ["slack-faq"],
+  min_confidence: 0.7,
+  default_limit: 20,
+  max_limit: 100,
+};
+
+describe("knowledge tool analytics instrumentation", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "test", version: "1.0.0" });
+    registerKnowledgeTool(
+      server as never,
+      { embed: mockEmbed } as never,
+      toolConfig,
+    );
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    client = new Client({ name: "tc", version: "1.0.0" });
+    await client.connect(ct);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("logs browse-mode query when analytics enabled", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockGetFaqChunks.mockResolvedValueOnce([]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({ name: "faq", arguments: {} });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.query_text).toBe("<browse>");
+    expect(entry.tool_name).toBe("faq");
+  });
+
+  it("logs search-mode query with actual query text", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+    mockGetFaqChunks.mockResolvedValueOnce([]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "faq",
+      arguments: { query: "how to deploy" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.query_text).toBe("how to deploy");
+  });
+
+  it("does not log when analytics disabled", async () => {
+    mockGetServerConfig.mockReturnValue({} as never);
+    mockGetFaqChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({ name: "faq", arguments: {} });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/knowledge-mcp.test.ts
+++ b/src/__tests__/knowledge-mcp.test.ts
@@ -20,6 +20,12 @@ vi.mock("../db/queries.js", () => ({
   getFaqChunks: vi.fn(),
   searchChunks: vi.fn(),
 }));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({}),
+}));
 
 import { registerKnowledgeTool } from "../mcp/tools/knowledge.js";
 import { getFaqChunks, searchChunks } from "../db/queries.js";

--- a/src/__tests__/rrf-merge.test.ts
+++ b/src/__tests__/rrf-merge.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from "vitest";
+import { rrfMerge, RRF_K } from "../db/queries.js";
+import type { ChunkResult } from "../types.js";
+
+function makeResult(id: number, similarity: number = 0.5): ChunkResult {
+  return {
+    id,
+    source_name: "docs",
+    source_url: null,
+    title: `Result ${id}`,
+    content: `Content for chunk ${id}`,
+    repo_url: null,
+    file_path: `docs/file-${id}.md`,
+    start_line: null,
+    end_line: null,
+    language: null,
+    similarity,
+  };
+}
+
+describe("rrfMerge", () => {
+  it("merges two disjoint result sets by RRF score", () => {
+    const vectorResults = [makeResult(1), makeResult(2)];
+    const keywordResults = [makeResult(3), makeResult(4)];
+
+    const merged = rrfMerge(vectorResults, keywordResults, 4);
+
+    expect(merged).toHaveLength(4);
+    // All have single-term RRF scores; rank 1 items from each list tie
+    const ids = merged.map((r) => r.id);
+    expect(ids.slice(0, 2).sort()).toEqual([1, 3]);
+    expect(ids.slice(2, 4).sort()).toEqual([2, 4]);
+  });
+
+  it("boosts documents appearing in both lists", () => {
+    const vectorResults = [makeResult(1), makeResult(2)];
+    const keywordResults = [makeResult(1), makeResult(3)];
+
+    const merged = rrfMerge(vectorResults, keywordResults, 3);
+
+    expect(merged).toHaveLength(3);
+    expect(merged[0].id).toBe(1);
+    expect(merged[0].similarity).toBeCloseTo(2 / (RRF_K + 1), 6);
+  });
+
+  it("respects the limit parameter", () => {
+    const vectorResults = [makeResult(1), makeResult(2), makeResult(3)];
+    const keywordResults = [makeResult(4), makeResult(5), makeResult(6)];
+
+    const merged = rrfMerge(vectorResults, keywordResults, 2);
+
+    expect(merged).toHaveLength(2);
+  });
+
+  it("handles empty vector results", () => {
+    const keywordResults = [makeResult(1), makeResult(2)];
+
+    const merged = rrfMerge([], keywordResults, 5);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].id).toBe(1);
+    expect(merged[0].similarity).toBeCloseTo(1 / (RRF_K + 1), 6);
+  });
+
+  it("handles empty keyword results", () => {
+    const vectorResults = [makeResult(1), makeResult(2)];
+
+    const merged = rrfMerge(vectorResults, [], 5);
+
+    expect(merged).toHaveLength(2);
+    expect(merged[0].id).toBe(1);
+    expect(merged[0].similarity).toBeCloseTo(1 / (RRF_K + 1), 6);
+  });
+
+  it("handles both lists empty", () => {
+    const merged = rrfMerge([], [], 5);
+    expect(merged).toHaveLength(0);
+  });
+
+  it("sets similarity to RRF score on returned results", () => {
+    const vectorResults = [makeResult(1, 0.95)];
+    const keywordResults: ChunkResult[] = [];
+
+    const merged = rrfMerge(vectorResults, keywordResults, 5);
+
+    // Original similarity (0.95) is replaced with RRF score
+    expect(merged[0].similarity).toBeCloseTo(1 / (RRF_K + 1), 6);
+    expect(merged[0].similarity).not.toBe(0.95);
+  });
+
+  it("preserves result metadata from the vector result when doc appears in both", () => {
+    const vectorResult = makeResult(1);
+    vectorResult.title = "From Vector";
+    const keywordResult = makeResult(1);
+    keywordResult.title = "From Keyword";
+
+    const merged = rrfMerge([vectorResult], [keywordResult], 5);
+
+    expect(merged[0].title).toBe("From Vector");
+  });
+
+  it("handles duplicate chunk IDs within a single result list", () => {
+    const vectorResults = [makeResult(1, 0.9), makeResult(1, 0.8)];
+    const keywordResults = [makeResult(2)];
+
+    const merged = rrfMerge(vectorResults, keywordResults, 5);
+    expect(merged.length).toBeGreaterThan(0);
+    expect(merged.find((r) => r.id === 2)).toBeDefined();
+  });
+
+  it("handles very large result sets efficiently", () => {
+    const vectorResults = Array.from({ length: 1000 }, (_, i) =>
+      makeResult(i, 0.5),
+    );
+    const keywordResults = Array.from({ length: 1000 }, (_, i) =>
+      makeResult(i + 500, 0.3),
+    );
+
+    const merged = rrfMerge(vectorResults, keywordResults, 10);
+    expect(merged).toHaveLength(10);
+    // Items appearing in both lists (IDs 500-999) should rank higher
+    expect(merged[0].id).toBeGreaterThanOrEqual(500);
+    expect(merged[0].id).toBeLessThan(1000);
+  });
+
+  it("limit of 0 returns empty array", () => {
+    const vectorResults = [makeResult(1)];
+    const merged = rrfMerge(vectorResults, [], 0);
+    expect(merged).toEqual([]);
+  });
+});

--- a/src/__tests__/schema-tsv.test.ts
+++ b/src/__tests__/schema-tsv.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect } from "vitest";
+import {
+  generatePostSchemaMigration,
+  generateTsvTriggerDdl,
+} from "../db/schema.js";
+
+describe("generatePostSchemaMigration includes tsvector support", () => {
+  const sql = generatePostSchemaMigration();
+
+  it("adds tsv column", () => {
+    expect(sql).toContain(
+      "ALTER TABLE chunks ADD COLUMN IF NOT EXISTS tsv tsvector",
+    );
+  });
+
+  it("creates GIN index on tsv", () => {
+    expect(sql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_chunks_tsv ON chunks USING GIN (tsv)",
+    );
+  });
+
+  it("populates existing rows", () => {
+    expect(sql).toContain(
+      "UPDATE chunks SET tsv = to_tsvector('english', content) WHERE tsv IS NULL",
+    );
+  });
+
+  it("does not include trigger DDL (applied separately for PGlite safety)", () => {
+    expect(sql).not.toContain("CREATE TRIGGER");
+    expect(sql).not.toContain("LANGUAGE plpgsql");
+  });
+});
+
+describe("generateTsvTriggerDdl", () => {
+  it("returns trigger DDL separately from core migration", () => {
+    const triggerSql = generateTsvTriggerDdl();
+    expect(triggerSql).toContain(
+      "CREATE OR REPLACE FUNCTION chunks_tsv_trigger()",
+    );
+    expect(triggerSql).toContain("CREATE TRIGGER chunks_tsv_update");
+  });
+});
+
+describe("PGlite trigger skip path", () => {
+  it("core migration DDL does not contain PL/pgSQL", () => {
+    // The core DDL (column + index + populate) should work on PGlite
+    // The trigger DDL is separate and wrapped in try-catch
+    expect(typeof generateTsvTriggerDdl).toBe("function");
+  });
+});

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -171,4 +171,35 @@ describe("generatePostSchemaMigration", () => {
       "CREATE INDEX IF NOT EXISTS idx_chunks_version ON chunks (version)",
     );
   });
+
+  it("creates query_log table", () => {
+    const sql = generatePostSchemaMigration();
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS query_log");
+  });
+
+  it("includes query_log required columns", () => {
+    const sql = generatePostSchemaMigration();
+    for (const col of [
+      "tool_name",
+      "query_text",
+      "result_count",
+      "top_score",
+      "latency_ms",
+      "source_name",
+      "session_id",
+      "created_at",
+    ]) {
+      expect(sql).toContain(col);
+    }
+  });
+
+  it("creates indexes on query_log", () => {
+    const sql = generatePostSchemaMigration();
+    expect(sql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_query_log_created_at ON query_log (created_at)",
+    );
+    expect(sql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_query_log_tool_name ON query_log (tool_name)",
+    );
+  });
 });

--- a/src/__tests__/search-analytics.test.ts
+++ b/src/__tests__/search-analytics.test.ts
@@ -1,0 +1,240 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { SearchToolConfig, ChunkResult } from "../types.js";
+
+// Mock dependencies
+vi.mock("../db/queries.js", () => ({
+  searchChunks: vi.fn(),
+  textSearchChunks: vi.fn(),
+  hybridSearchChunks: vi.fn(),
+}));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn(),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn(),
+}));
+
+import { registerSearchTool } from "../mcp/tools/search.js";
+import { searchChunks } from "../db/queries.js";
+import { logQuery } from "../db/analytics.js";
+import { getServerConfig } from "../config.js";
+
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockLogQuery = vi.mocked(logQuery);
+const mockGetServerConfig = vi.mocked(getServerConfig);
+const mockEmbed = vi.fn();
+
+function makeChunkResult(overrides: Partial<ChunkResult> = {}): ChunkResult {
+  return {
+    id: 1,
+    source_name: "docs",
+    source_url: null,
+    title: "Title",
+    content: "Content",
+    repo_url: null,
+    file_path: "f.md",
+    start_line: null,
+    end_line: null,
+    language: null,
+    similarity: 0.9,
+    ...overrides,
+  };
+}
+
+const toolConfig: SearchToolConfig = {
+  name: "search-docs",
+  type: "search",
+  description: "Search",
+  source: "docs",
+  default_limit: 5,
+  max_limit: 20,
+  result_format: "docs",
+  search_mode: "vector",
+};
+
+describe("search tool analytics instrumentation", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "test", version: "1.0.0" });
+    registerSearchTool(
+      server as never,
+      { embed: mockEmbed } as never,
+      toolConfig,
+    );
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    client = new Client({ name: "tc", version: "1.0.0" });
+    await client.connect(ct);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("logs query when analytics is enabled", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([makeChunkResult()]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+
+    // logQuery is fire-and-forget, give it a tick
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [entry, logText] = mockLogQuery.mock.calls[0];
+    expect(entry.tool_name).toBe("search-docs");
+    expect(entry.query_text).toBe("test");
+    expect(entry.result_count).toBe(1);
+    expect(entry.top_score).toBeCloseTo(0.9);
+    expect(entry.latency_ms).toBeGreaterThanOrEqual(0);
+    expect(entry.source_name).toBe("docs");
+    expect(logText).toBe(true);
+  });
+
+  it("does not log when analytics is disabled", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: false, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+
+  it("does not log when analytics config is absent", async () => {
+    mockGetServerConfig.mockReturnValue({} as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+
+  it("passes log_queries: false to logQuery when configured", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: false, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([makeChunkResult()]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "secret" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [, logText] = mockLogQuery.mock.calls[0];
+    expect(logText).toBe(false);
+  });
+
+  it("does not fail the search when logQuery throws", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([makeChunkResult()]);
+    mockLogQuery.mockRejectedValueOnce(new Error("DB write failed"));
+
+    const result = await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("logs null top_score when no results", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "nothing" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.result_count).toBe(0);
+    expect(entry.top_score).toBeNull();
+  });
+
+  it("does not log analytics when search itself fails", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockRejectedValueOnce(new Error("API error"));
+
+    const result = await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(result.isError).toBe(true);
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+
+  it("computes correct top_score from multiple results", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([
+      makeChunkResult({ similarity: 0.7 }),
+      makeChunkResult({ id: 2, similarity: 0.95 }),
+      makeChunkResult({ id: 3, similarity: 0.6 }),
+    ]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.top_score).toBeCloseTo(0.95);
+    expect(entry.result_count).toBe(3);
+  });
+});

--- a/src/__tests__/search-hybrid.test.ts
+++ b/src/__tests__/search-hybrid.test.ts
@@ -17,6 +17,12 @@ vi.mock("../db/queries.js", () => ({
   textSearchChunks: vi.fn(),
   hybridSearchChunks: vi.fn(),
 }));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({}),
+}));
 
 import { registerSearchTool } from "../mcp/tools/search.js";
 import {

--- a/src/__tests__/search-hybrid.test.ts
+++ b/src/__tests__/search-hybrid.test.ts
@@ -232,6 +232,7 @@ describe("search tool keyword mode", () => {
       "ECONNREFUSED",
       5,
       "docs",
+      undefined,
     );
     expect(result.isError).toBeFalsy();
     const text = (result.content as Array<{ type: string; text: string }>)[0]

--- a/src/__tests__/search-hybrid.test.ts
+++ b/src/__tests__/search-hybrid.test.ts
@@ -1,0 +1,343 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { SearchToolConfig, ChunkResult } from "../types.js";
+
+vi.mock("../db/queries.js", () => ({
+  searchChunks: vi.fn(),
+  textSearchChunks: vi.fn(),
+  hybridSearchChunks: vi.fn(),
+}));
+
+import { registerSearchTool } from "../mcp/tools/search.js";
+import {
+  searchChunks,
+  textSearchChunks,
+  hybridSearchChunks,
+} from "../db/queries.js";
+
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockTextSearchChunks = vi.mocked(textSearchChunks);
+const mockHybridSearchChunks = vi.mocked(hybridSearchChunks);
+const mockEmbed = vi.fn();
+
+function makeChunkResult(overrides: Partial<ChunkResult> = {}): ChunkResult {
+  return {
+    id: 1,
+    source_name: "docs",
+    source_url: "https://docs.example.com/page",
+    title: "Test Page",
+    content: "Test content.",
+    repo_url: null,
+    file_path: "docs/page.md",
+    start_line: null,
+    end_line: null,
+    language: null,
+    similarity: 0.9,
+    ...overrides,
+  };
+}
+
+// ── Hybrid mode tests ─────────────────────────────────────────────────────
+
+describe("search tool hybrid mode", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "test-hybrid", version: "1.0.0" });
+    const embeddingClient = { embed: mockEmbed };
+    const hybridConfig: SearchToolConfig = {
+      name: "search-hybrid",
+      type: "search",
+      description: "Hybrid search",
+      source: "docs",
+      default_limit: 5,
+      max_limit: 20,
+      result_format: "docs",
+      search_mode: "hybrid",
+    };
+    registerSearchTool(
+      server as never,
+      embeddingClient as never,
+      hybridConfig,
+    );
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(clientTransport);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("calls hybridSearchChunks with embedding and query text", async () => {
+    const embedding = [0.1, 0.2];
+    mockEmbed.mockResolvedValueOnce(embedding);
+    mockHybridSearchChunks.mockResolvedValueOnce([
+      makeChunkResult({ title: "Hybrid Result" }),
+    ]);
+
+    const result = await client.callTool({
+      name: "search-hybrid",
+      arguments: { query: "test query" },
+    });
+
+    expect(mockEmbed).toHaveBeenCalledWith("test query");
+    expect(mockHybridSearchChunks).toHaveBeenCalledWith(
+      embedding,
+      "test query",
+      5, // default_limit
+      "docs", // source
+      undefined, // version
+      undefined, // minScore (no config or request min_score)
+    );
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Hybrid Result");
+  });
+
+  it("passes min_score to hybridSearchChunks for vector candidate filtering", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockHybridSearchChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({
+      name: "search-hybrid",
+      arguments: { query: "test", min_score: 0.5 },
+    });
+
+    expect(mockHybridSearchChunks).toHaveBeenCalledWith(
+      [0.1],
+      "test",
+      5,
+      "docs",
+      undefined,
+      0.5,
+    );
+  });
+
+  it("does not call searchChunks or textSearchChunks directly", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockHybridSearchChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({
+      name: "search-hybrid",
+      arguments: { query: "test" },
+    });
+
+    expect(mockSearchChunks).not.toHaveBeenCalled();
+    expect(mockTextSearchChunks).not.toHaveBeenCalled();
+  });
+
+  it("returns error response when embedding fails in hybrid mode", async () => {
+    mockEmbed.mockRejectedValueOnce(new Error("API key expired"));
+
+    const result = await client.callTool({
+      name: "search-hybrid",
+      arguments: { query: "test" },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Error");
+  });
+
+  it("returns error response when hybridSearchChunks throws", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockHybridSearchChunks.mockRejectedValueOnce(
+      new Error("DB connection lost"),
+    );
+
+    const result = await client.callTool({
+      name: "search-hybrid",
+      arguments: { query: "test" },
+    });
+
+    expect(result.isError).toBe(true);
+  });
+});
+
+// ── Keyword mode tests ────────────────────────────────────────────────────
+
+describe("search tool keyword mode", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "test-keyword", version: "1.0.0" });
+    const embeddingClient = { embed: mockEmbed };
+    const keywordConfig: SearchToolConfig = {
+      name: "search-keyword",
+      type: "search",
+      description: "Keyword search",
+      source: "docs",
+      default_limit: 5,
+      max_limit: 20,
+      result_format: "docs",
+      search_mode: "keyword",
+    };
+    registerSearchTool(
+      server as never,
+      embeddingClient as never,
+      keywordConfig,
+    );
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(clientTransport);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("calls textSearchChunks without embedding", async () => {
+    mockTextSearchChunks.mockResolvedValueOnce([
+      makeChunkResult({ title: "Keyword Result" }),
+    ]);
+
+    const result = await client.callTool({
+      name: "search-keyword",
+      arguments: { query: "ECONNREFUSED" },
+    });
+
+    expect(mockEmbed).not.toHaveBeenCalled();
+    expect(mockTextSearchChunks).toHaveBeenCalledWith(
+      "ECONNREFUSED",
+      5,
+      "docs",
+    );
+    expect(result.isError).toBeFalsy();
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Keyword Result");
+  });
+
+  it("does not apply min_score filtering", async () => {
+    mockTextSearchChunks.mockResolvedValueOnce([
+      makeChunkResult({ similarity: 0.01, title: "Low Rank" }),
+    ]);
+
+    const result = await client.callTool({
+      name: "search-keyword",
+      arguments: { query: "test", min_score: 0.9 },
+    });
+
+    const text = (result.content as Array<{ type: string; text: string }>)[0]
+      .text;
+    expect(text).toContain("Low Rank");
+  });
+
+  it("keyword mode succeeds even when embedding client would throw", async () => {
+    mockTextSearchChunks.mockResolvedValueOnce([
+      makeChunkResult({ title: "Found it" }),
+    ]);
+
+    const result = await client.callTool({
+      name: "search-keyword",
+      arguments: { query: "error code 42" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockEmbed).not.toHaveBeenCalled();
+  });
+
+  it("keyword mode returns empty result for empty string query", async () => {
+    mockTextSearchChunks.mockResolvedValueOnce([]);
+
+    const result = await client.callTool({
+      name: "search-keyword",
+      arguments: { query: "" },
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+});
+
+// ── Default (vector) mode still works ─────────────────────────────────────
+
+describe("search tool default vector mode", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "test-default", version: "1.0.0" });
+    const embeddingClient = { embed: mockEmbed };
+    const defaultConfig: SearchToolConfig = {
+      name: "search-default",
+      type: "search",
+      description: "Default search",
+      source: "docs",
+      default_limit: 5,
+      max_limit: 20,
+      result_format: "docs",
+      search_mode: "vector",
+    };
+    registerSearchTool(
+      server as never,
+      embeddingClient as never,
+      defaultConfig,
+    );
+
+    const [clientTransport, serverTransport] =
+      InMemoryTransport.createLinkedPair();
+    await server.connect(serverTransport);
+    client = new Client({ name: "test-client", version: "1.0.0" });
+    await client.connect(clientTransport);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("calls searchChunks (vector) when search_mode is vector", async () => {
+    const embedding = [0.1, 0.2];
+    mockEmbed.mockResolvedValueOnce(embedding);
+    mockSearchChunks.mockResolvedValueOnce([makeChunkResult()]);
+
+    await client.callTool({
+      name: "search-default",
+      arguments: { query: "test" },
+    });
+
+    expect(mockSearchChunks).toHaveBeenCalledWith(
+      embedding,
+      5,
+      "docs",
+      undefined,
+    );
+    expect(mockHybridSearchChunks).not.toHaveBeenCalled();
+    expect(mockTextSearchChunks).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/search-tool.test.ts
+++ b/src/__tests__/search-tool.test.ts
@@ -15,6 +15,12 @@ import type { SearchToolConfig, ChunkResult } from "../types.js";
 vi.mock("../db/queries.js", () => ({
   searchChunks: vi.fn(),
 }));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({}),
+}));
 
 import { registerSearchTool } from "../mcp/tools/search.js";
 import { searchChunks } from "../db/queries.js";

--- a/src/__tests__/search-tool.test.ts
+++ b/src/__tests__/search-tool.test.ts
@@ -47,6 +47,7 @@ const baseToolConfig: SearchToolConfig = {
   default_limit: 5,
   max_limit: 20,
   result_format: "docs",
+  search_mode: "vector",
 };
 
 // ── Full MCP protocol tests ────────────────────────────────────────────────

--- a/src/__tests__/skill-md.test.ts
+++ b/src/__tests__/skill-md.test.ts
@@ -27,6 +27,7 @@ function makeConfig(
       default_limit: 5,
       max_limit: 20,
       result_format: "docs",
+      search_mode: "vector",
     },
     {
       name: "explore",

--- a/src/__tests__/text-search-tsvector.test.ts
+++ b/src/__tests__/text-search-tsvector.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the pool
+const mockQuery = vi.fn();
+vi.mock("../db/client.js", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+import { textSearchChunks } from "../db/queries.js";
+
+describe("textSearchChunks (tsvector-based)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("uses plainto_tsquery for safe query parsing", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await textSearchChunks("test query", 10);
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("plainto_tsquery('english'");
+    // Should NOT contain raw ILIKE
+    expect(sql).not.toContain("ILIKE");
+  });
+
+  it("handles SQL injection attempt in query safely", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await textSearchChunks("'; DROP TABLE chunks; --", 10);
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("plainto_tsquery");
+    expect(params[0]).toBe("'; DROP TABLE chunks; --");
+  });
+
+  it("handles unicode/CJK queries", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await textSearchChunks("\u4F60\u597D\u4E16\u754C", 10);
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[0]).toBe("\u4F60\u597D\u4E16\u754C");
+  });
+
+  it("handles empty string query without error", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const results = await textSearchChunks("", 10);
+    expect(results).toEqual([]);
+  });
+
+  it("handles stop-words-only query (may return no results)", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const results = await textSearchChunks("the a an", 10);
+    expect(results).toEqual([]);
+  });
+
+  it("passes sourceName filter when provided", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await textSearchChunks("test", 10, "docs");
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("source_name");
+    expect(params).toContain("docs");
+  });
+
+  it("orders results by ts_rank descending", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await textSearchChunks("test", 10);
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("ORDER BY ts_rank");
+    expect(sql).toContain("DESC");
+  });
+});

--- a/src/__tests__/types-search-mode.test.ts
+++ b/src/__tests__/types-search-mode.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect } from "vitest";
+import { SearchToolConfigSchema } from "../types.js";
+
+describe("SearchToolConfigSchema search_mode", () => {
+  const base = {
+    name: "test",
+    type: "search" as const,
+    description: "test",
+    source: "docs",
+    default_limit: 5,
+    max_limit: 20,
+    result_format: "docs" as const,
+  };
+
+  it("defaults search_mode to vector when not specified", () => {
+    const result = SearchToolConfigSchema.parse(base);
+    expect(result.search_mode).toBe("vector");
+  });
+
+  it("accepts vector as search_mode", () => {
+    const result = SearchToolConfigSchema.parse({
+      ...base,
+      search_mode: "vector",
+    });
+    expect(result.search_mode).toBe("vector");
+  });
+
+  it("accepts keyword as search_mode", () => {
+    const result = SearchToolConfigSchema.parse({
+      ...base,
+      search_mode: "keyword",
+    });
+    expect(result.search_mode).toBe("keyword");
+  });
+
+  it("accepts hybrid as search_mode", () => {
+    const result = SearchToolConfigSchema.parse({
+      ...base,
+      search_mode: "hybrid",
+    });
+    expect(result.search_mode).toBe("hybrid");
+  });
+
+  it("rejects invalid search_mode values", () => {
+    expect(() =>
+      SearchToolConfigSchema.parse({ ...base, search_mode: "bm25" }),
+    ).toThrow();
+  });
+
+  it("existing config without search_mode parses successfully", () => {
+    const result = SearchToolConfigSchema.parse({
+      name: "search-docs",
+      type: "search",
+      description: "Search docs",
+      source: "docs",
+      default_limit: 5,
+      max_limit: 20,
+      result_format: "docs",
+    });
+    expect(result.search_mode).toBe("vector");
+  });
+
+  it("existing config with min_score and no search_mode still works", () => {
+    const result = SearchToolConfigSchema.parse({
+      name: "search-docs",
+      type: "search",
+      description: "Search docs",
+      source: "docs",
+      default_limit: 5,
+      max_limit: 20,
+      result_format: "docs",
+      min_score: 0.7,
+    });
+    expect(result.search_mode).toBe("vector");
+    expect(result.min_score).toBe(0.7);
+  });
+});

--- a/src/cli-init.ts
+++ b/src/cli-init.ts
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import { crawlSite, type CrawlOptions } from './crawl.js';
-import { generateConfigYaml } from './config-generator.js';
+import { generateConfigYaml, detectSourceType } from './config-generator.js';
 
 /**
  * Validate that the input URL is a valid HTTP(S) URL.
@@ -97,8 +97,9 @@ export async function initFromUrl(options: {
     const yamlContent = generateConfigYaml(result, url);
     writeGeneratedConfig(targetDir, yamlContent, force);
 
+    const sourceType = result.pages.length > 0 ? detectSourceType(result.pages) : 'unknown';
     console.log(`\nGenerated pathfinder.yaml`);
-    console.log(`  Source type: ${result.pages.length > 0 ? 'html' : 'unknown'}`);
+    console.log(`  Source type: ${sourceType}`);
     console.log(`  Pages cached: ${result.pages.length} in ${cacheDir}`);
     console.log(`\nNext steps:`);
     console.log(`  1. Review pathfinder.yaml and adjust if needed`);

--- a/src/cli-init.ts
+++ b/src/cli-init.ts
@@ -1,0 +1,107 @@
+// CLI init --from logic: crawl a URL and generate pathfinder.yaml.
+
+import fs from 'fs';
+import path from 'path';
+import { crawlSite, type CrawlOptions } from './crawl.js';
+import { generateConfigYaml } from './config-generator.js';
+
+/**
+ * Validate that the input URL is a valid HTTP(S) URL.
+ */
+export function validateInitUrl(url: string): void {
+    let parsed: URL;
+    try {
+        parsed = new URL(url);
+    } catch {
+        throw new Error(`Invalid URL: "${url}". Please provide a full URL like https://docs.example.com`);
+    }
+
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+        throw new Error(`URL must be http or https, got: ${parsed.protocol}`);
+    }
+}
+
+/**
+ * Write generated config YAML to the target directory.
+ */
+export function writeGeneratedConfig(targetDir: string, yamlContent: string, force: boolean = false): void {
+    const dest = path.join(targetDir, 'pathfinder.yaml');
+    if (fs.existsSync(dest) && !force) {
+        throw new Error(
+            `pathfinder.yaml already exists at ${dest}. Use --force to overwrite.`
+        );
+    }
+    fs.writeFileSync(dest, yamlContent, 'utf-8');
+}
+
+/**
+ * Run the full init-from-url flow: crawl, generate config, write file.
+ */
+export async function initFromUrl(options: {
+    url: string;
+    targetDir: string;
+    rateLimit?: number;
+    maxPages?: number;
+    force?: boolean;
+}): Promise<void> {
+    const { url, targetDir, rateLimit, maxPages, force } = options;
+
+    validateInitUrl(url);
+
+    const hostname = new URL(url).hostname;
+    const cacheDir = path.join(targetDir, '.pathfinder', 'cache', hostname);
+
+    console.log(`\nCrawling ${url}...`);
+    console.log(`  Rate limit: ${rateLimit ?? 500}ms between requests`);
+    console.log(`  Max pages: ${maxPages ?? 500}`);
+    console.log(`  Cache dir: ${cacheDir}\n`);
+
+    const crawlOptions: CrawlOptions = {
+        rateLimit: rateLimit ?? 500,
+        maxPages: maxPages ?? 500,
+        cacheDir,
+    };
+
+    const result = await crawlSite(url, crawlOptions);
+
+    if (result.pages.length === 0) {
+        console.error('\nNo pages were successfully crawled.');
+        if (result.failedUrls.length > 0) {
+            console.error(`\nFailed URLs (${result.failedUrls.length}):`);
+            for (const failed of result.failedUrls.slice(0, 10)) {
+                console.error(`  ${failed.status} ${failed.url} (${failed.reason})`);
+            }
+        }
+        process.exit(1);
+    }
+
+    console.log(`\nCrawled ${result.pages.length} pages via ${result.discoveryMethod}.`);
+
+    if (result.warnings.length > 0) {
+        console.log('\nWarnings:');
+        for (const warning of result.warnings) {
+            console.log(`  Warning: ${warning}`);
+        }
+    }
+
+    if (result.failedUrls.length > 0) {
+        console.log(`\nFailed to fetch ${result.failedUrls.length} URLs:`);
+        for (const failed of result.failedUrls.slice(0, 5)) {
+            console.log(`  ${failed.status} ${failed.url} (${failed.reason})`);
+        }
+        if (result.failedUrls.length > 5) {
+            console.log(`  ... and ${result.failedUrls.length - 5} more`);
+        }
+    }
+
+    const yamlContent = generateConfigYaml(result, url);
+    writeGeneratedConfig(targetDir, yamlContent, force);
+
+    console.log(`\nGenerated pathfinder.yaml`);
+    console.log(`  Source type: ${result.pages.length > 0 ? 'html' : 'unknown'}`);
+    console.log(`  Pages cached: ${result.pages.length} in ${cacheDir}`);
+    console.log(`\nNext steps:`);
+    console.log(`  1. Review pathfinder.yaml and adjust if needed`);
+    console.log(`  2. Set OPENAI_API_KEY and DATABASE_URL in .env`);
+    console.log(`  3. Run: pathfinder serve`);
+}

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,14 +11,41 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("Agentic docs retrieval for AI agents")
-  .version("1.8.0");
+  .version("1.10.0");
 
 program
   .command("init")
-  .description("Scaffold a new Pathfinder project in the current directory")
-  .action(async () => {
+  .description(
+    "Scaffold a new Pathfinder project (use --from <url> to auto-generate from a docs site)",
+  )
+  .option(
+    "--from <url>",
+    "Auto-generate config by crawling a documentation URL",
+  )
+  .option(
+    "--rate-limit <ms>",
+    "Milliseconds between requests (default: 500)",
+    parseInt,
+  )
+  .option("--max-pages <n>", "Maximum pages to crawl (default: 500)", parseInt)
+  .option("--force", "Overwrite existing pathfinder.yaml")
+  .action(async (opts) => {
     const cwd = process.cwd();
 
+    if (opts.from) {
+      // Auto-generate from URL
+      const { initFromUrl } = await import("./cli-init.js");
+      await initFromUrl({
+        url: opts.from,
+        targetDir: cwd,
+        rateLimit: opts.rateLimit,
+        maxPages: opts.maxPages,
+        force: opts.force,
+      });
+      return;
+    }
+
+    // Original scaffold behavior
     const yamlDest = path.join(cwd, "pathfinder.yaml");
     if (fs.existsSync(yamlDest)) {
       console.log("pathfinder.yaml already exists, skipping.");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("Agentic docs retrieval for AI agents")
-  .version("1.10.0");
+  .version("1.11.0");
 
 program
   .command("init")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("Agentic docs retrieval for AI agents")
-  .version("1.7.0");
+  .version("1.8.0");
 
 program
   .command("init")

--- a/src/config-generator.ts
+++ b/src/config-generator.ts
@@ -32,7 +32,6 @@ interface GeneratedSource {
     file_patterns: string[];
     base_url: string;
     repo?: string;
-    content_selector?: string;
     chunk: {
         target_tokens: number;
         overlap_tokens: number;
@@ -197,11 +196,6 @@ export function generateConfig(crawlResult: CrawlResult, inputUrl: string): Gene
     const gitRepo = detectGitRepo(inputUrl);
     const hostname = new URL(inputUrl).hostname;
 
-    // Fix I2: detect content selector and wire into source config
-    const contentSelector = crawlResult.pages.length > 0
-        ? detectContentSelector(crawlResult.pages[0].html)
-        : null;
-
     const source: GeneratedSource = {
         name: 'docs',
         type: sourceType,
@@ -216,10 +210,6 @@ export function generateConfig(crawlResult: CrawlResult, inputUrl: string): Gene
 
     if (gitRepo) {
         source.repo = gitRepo.repoUrl;
-    }
-
-    if (contentSelector) {
-        source.content_selector = contentSelector;
     }
 
     const tool: GeneratedTool = {
@@ -258,6 +248,11 @@ export function generateConfig(crawlResult: CrawlResult, inputUrl: string): Gene
 export function generateConfigYaml(crawlResult: CrawlResult, inputUrl: string): string {
     const config = generateConfig(crawlResult, inputUrl);
 
+    // Detect content selector from crawled pages (not stored in config to avoid Zod validation failure)
+    const contentSelector = crawlResult.pages.length > 0
+        ? detectContentSelector(crawlResult.pages[0].html)
+        : null;
+
     const header = [
         '# Pathfinder configuration — auto-generated from ' + inputUrl,
         '# Review and customize before running: pathfinder serve',
@@ -265,9 +260,19 @@ export function generateConfigYaml(crawlResult: CrawlResult, inputUrl: string): 
         '',
     ].join('\n');
 
-    return header + stringifyYaml(config, {
+    let yaml = header + stringifyYaml(config, {
         lineWidth: 120,
         defaultStringType: 'QUOTE_DOUBLE',
         defaultKeyType: 'PLAIN',
     });
+
+    // Append content_selector as a comment after the source block if detected
+    if (contentSelector) {
+        yaml = yaml.replace(
+            /^( +)base_url:/m,
+            `$1# content_selector: "${contentSelector}" — detected from crawled pages\n$1base_url:`,
+        );
+    }
+
+    return yaml;
 }

--- a/src/config-generator.ts
+++ b/src/config-generator.ts
@@ -1,0 +1,273 @@
+// Config generator: produces pathfinder.yaml from crawl results.
+
+import * as cheerio from 'cheerio';
+import { stringify as stringifyYaml } from 'yaml';
+import type { CrawlResult, CrawledPage } from './crawl.js';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface GeneratedConfig {
+    server: {
+        name: string;
+        version: string;
+    };
+    sources: GeneratedSource[];
+    tools: GeneratedTool[];
+    embedding: {
+        provider: string;
+        model: string;
+        dimensions: number;
+    };
+    indexing: {
+        auto_reindex: boolean;
+        reindex_hour_utc: number;
+        stale_threshold_hours: number;
+    };
+}
+
+interface GeneratedSource {
+    name: string;
+    type: string;
+    path: string;
+    file_patterns: string[];
+    base_url: string;
+    repo?: string;
+    content_selector?: string;
+    chunk: {
+        target_tokens: number;
+        overlap_tokens: number;
+    };
+}
+
+interface GeneratedTool {
+    name: string;
+    type: string;
+    description: string;
+    source: string;
+    default_limit: number;
+    max_limit: number;
+    result_format: string;
+}
+
+// ── Source type detection ───────────────────────────────────────────────────
+
+/**
+ * Detect whether crawled pages are HTML or markdown.
+ * Checks URL extensions and content-type headers.
+ */
+export function detectSourceType(pages: CrawledPage[]): 'html' | 'markdown' {
+    if (pages.length === 0) return 'html';
+
+    const mdCount = pages.filter(p => {
+        const urlPath = new URL(p.url).pathname;
+        return urlPath.endsWith('.md') || urlPath.endsWith('.mdx');
+    }).length;
+
+    // If majority of pages are .md/.mdx files, it's a markdown source
+    if (mdCount > pages.length * 0.5) return 'markdown';
+    return 'html';
+}
+
+// ── Base URL derivation ────────────────────────────────────────────────────
+
+/**
+ * Find the common URL path prefix across all page URLs.
+ * Strips the final path component (which varies per page).
+ */
+export function deriveBaseUrl(urls: string[]): string {
+    if (urls.length === 0) return '';
+    if (urls.length === 1) {
+        const parsed = new URL(urls[0]);
+        const segments = parsed.pathname.split('/').filter(Boolean);
+        segments.pop(); // remove the page-specific segment
+        return parsed.origin + (segments.length > 0 ? '/' + segments.join('/') : '');
+    }
+
+    const parsed = urls.map(u => new URL(u));
+    const origin = parsed[0].origin;
+
+    // Find common path prefix
+    const pathSegments = parsed.map(p => p.pathname.split('/').filter(Boolean));
+    const minLen = Math.min(...pathSegments.map(s => s.length));
+
+    const commonSegments: string[] = [];
+    for (let i = 0; i < minLen; i++) {
+        const seg = pathSegments[0][i];
+        if (pathSegments.every(s => s[i] === seg)) {
+            commonSegments.push(seg);
+        } else {
+            break;
+        }
+    }
+
+    return origin + (commonSegments.length > 0 ? '/' + commonSegments.join('/') : '');
+}
+
+// ── File pattern derivation ────────────────────────────────────────────────
+
+export function deriveFilePatterns(sourceType: string): string[] {
+    if (sourceType === 'markdown') return ['**/*.md', '**/*.mdx'];
+    return ['**/*.html'];
+}
+
+// ── Content selector detection ─────────────────────────────────────────────
+
+/**
+ * Detect the main content container selector from an HTML page.
+ * Checks for semantic elements in priority order.
+ */
+export function detectContentSelector(html: string): string | null {
+    const $ = cheerio.load(html);
+
+    if ($('main').length > 0) return 'main';
+    if ($('article').length > 0) return 'article';
+    if ($('[role="main"]').length > 0) return '[role="main"]';
+    if ($('.content').length > 0) return '.content';
+    if ($('#content').length > 0) return '#content';
+
+    return null;
+}
+
+// ── Server name derivation ──────────────────────────────────────────────────
+
+function deriveServerName(url: string): string {
+    const parsed = new URL(url);
+    let hostname = parsed.hostname;
+
+    // Strip common prefixes
+    hostname = hostname.replace(/^(www|docs|api)\./, '');
+
+    // Strip common suffixes
+    hostname = hostname.replace(/\.(readthedocs|github|gitlab)\.(io|com|org)$/, '');
+    hostname = hostname.replace(/\.(com|org|io|dev|net)$/, '');
+
+    // Replace dots and special chars with hyphens
+    const name = hostname.replace(/[^a-zA-Z0-9-]/g, '-').replace(/-+/g, '-');
+
+    return `${name}-docs`;
+}
+
+// ── Git-hosted docs detection ───────────────────────────────────────────────
+
+interface GitRepoInfo {
+    repoUrl: string;
+    docsPath: string;
+}
+
+function detectGitRepo(url: string): GitRepoInfo | null {
+    const parsed = new URL(url);
+
+    // GitHub: https://github.com/org/repo or https://github.com/org/repo/tree/main/docs
+    if (parsed.hostname === 'github.com') {
+        const segments = parsed.pathname.split('/').filter(Boolean);
+        if (segments.length >= 2) {
+            const repoUrl = `https://github.com/${segments[0]}/${segments[1]}.git`;
+            // Try to extract docs path from URL
+            let docsPath = '';
+            if (segments.length > 4 && (segments[2] === 'tree' || segments[2] === 'blob')) {
+                // segments[3] is branch, segments[4+] is path
+                docsPath = segments.slice(4).join('/');
+            }
+            return { repoUrl, docsPath: docsPath || 'docs/' };
+        }
+    }
+
+    // GitLab: similar pattern
+    if (parsed.hostname === 'gitlab.com' || parsed.hostname.includes('gitlab')) {
+        const segments = parsed.pathname.split('/').filter(Boolean);
+        if (segments.length >= 2) {
+            const repoUrl = `https://${parsed.hostname}/${segments[0]}/${segments[1]}.git`;
+            return { repoUrl, docsPath: 'docs/' };
+        }
+    }
+
+    return null;
+}
+
+// ── Main config generation ──────────────────────────────────────────────────
+
+export function generateConfig(crawlResult: CrawlResult, inputUrl: string): GeneratedConfig {
+    const sourceType = detectSourceType(crawlResult.pages);
+    const pageUrls = crawlResult.pages.map(p => p.url);
+    const baseUrl = deriveBaseUrl(pageUrls);
+    const filePatterns = deriveFilePatterns(sourceType);
+    const serverName = deriveServerName(inputUrl);
+
+    // Check for git-hosted docs
+    const gitRepo = detectGitRepo(inputUrl);
+    const hostname = new URL(inputUrl).hostname;
+
+    // Fix I2: detect content selector and wire into source config
+    const contentSelector = crawlResult.pages.length > 0
+        ? detectContentSelector(crawlResult.pages[0].html)
+        : null;
+
+    const source: GeneratedSource = {
+        name: 'docs',
+        type: sourceType,
+        path: gitRepo ? gitRepo.docsPath : `.pathfinder/cache/${hostname}`,
+        file_patterns: filePatterns,
+        base_url: baseUrl || inputUrl,
+        chunk: {
+            target_tokens: 600,
+            overlap_tokens: 50,
+        },
+    };
+
+    if (gitRepo) {
+        source.repo = gitRepo.repoUrl;
+    }
+
+    if (contentSelector) {
+        source.content_selector = contentSelector;
+    }
+
+    const tool: GeneratedTool = {
+        name: 'search-docs',
+        type: 'search',
+        description: `Search ${serverName.replace(/-/g, ' ')} for relevant information`,
+        source: 'docs',
+        default_limit: 5,
+        max_limit: 20,
+        result_format: 'docs',
+    };
+
+    return {
+        server: {
+            name: serverName,
+            version: '1.0.0',
+        },
+        sources: [source],
+        tools: [tool],
+        embedding: {
+            provider: 'openai',
+            model: 'text-embedding-3-small',
+            dimensions: 1536,
+        },
+        indexing: {
+            auto_reindex: true,
+            reindex_hour_utc: 3,
+            stale_threshold_hours: 24,
+        },
+    };
+}
+
+/**
+ * Generate a complete pathfinder.yaml string from crawl results.
+ */
+export function generateConfigYaml(crawlResult: CrawlResult, inputUrl: string): string {
+    const config = generateConfig(crawlResult, inputUrl);
+
+    const header = [
+        '# Pathfinder configuration — auto-generated from ' + inputUrl,
+        '# Review and customize before running: pathfinder serve',
+        '# Full documentation: https://pathfinder.copilotkit.dev',
+        '',
+    ].join('\n');
+
+    return header + stringifyYaml(config, {
+        lineWidth: 120,
+        defaultStringType: 'QUOTE_DOUBLE',
+        defaultKeyType: 'PLAIN',
+    });
+}

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -1,0 +1,508 @@
+// Site crawler for auto-generating pathfinder.yaml from a documentation URL.
+// Strategy: sitemap.xml → sitemap_index.xml → robots.txt Sitemap: → recursive link following.
+
+import * as cheerio from 'cheerio';
+import fs from 'fs';
+import path from 'path';
+
+// ── Types ───────────────────────────────────────────────────────────────────
+
+export interface CrawlOptions {
+    /** Milliseconds between requests. Default 500 (2 req/s). */
+    rateLimit?: number;
+    /** Maximum pages to fetch. Default 500. */
+    maxPages?: number;
+    /** Maximum link-follow depth for recursive crawling. Default 3. */
+    maxDepth?: number;
+    /** Directory to cache fetched pages. Undefined = no caching. */
+    cacheDir?: string;
+    /** Maximum retries on 429/5xx. Default 3. */
+    maxRetries?: number;
+}
+
+export interface CrawledPage {
+    url: string;
+    html: string;
+    contentType: string;
+    /** Text content length (body text after stripping tags). */
+    textLength: number;
+}
+
+export interface CrawlResult {
+    pages: CrawledPage[];
+    discoveryMethod: 'sitemap' | 'sitemap-index' | 'robots-sitemap' | 'crawl';
+    baseUrl: string;
+    warnings: string[];
+    failedUrls: { url: string; status: number; reason: string }[];
+}
+
+// ── Sitemap parsing ─────────────────────────────────────────────────────────
+
+/**
+ * Parse a sitemap.xml and extract all <loc> URLs.
+ * Uses cheerio in XML mode for reliable parsing.
+ */
+export function parseSitemap(xml: string): string[] {
+    if (!xml || !xml.trim()) return [];
+    try {
+        const $ = cheerio.load(xml, { xml: true });
+        const urls: string[] = [];
+        $('url > loc').each((_, el) => {
+            const text = $(el).text().trim();
+            if (text) urls.push(text);
+        });
+        return urls;
+    } catch {
+        return [];
+    }
+}
+
+/**
+ * Parse a sitemap index and extract child sitemap URLs.
+ */
+export function parseSitemapIndex(xml: string): string[] {
+    if (!xml || !xml.trim()) return [];
+    try {
+        const $ = cheerio.load(xml, { xml: true });
+        const urls: string[] = [];
+        $('sitemap > loc').each((_, el) => {
+            const text = $(el).text().trim();
+            if (text) urls.push(text);
+        });
+        return urls;
+    } catch {
+        return [];
+    }
+}
+
+// ── Link extraction ─────────────────────────────────────────────────────────
+
+/**
+ * Extract same-origin links from an HTML page.
+ * Strips hash fragments, deduplicates, ignores mailto:/javascript:/tel:/data:.
+ */
+export function extractLinks(html: string, baseUrl: string): string[] {
+    const $ = cheerio.load(html);
+    const origin = new URL(baseUrl).origin;
+    const seen = new Set<string>();
+    const links: string[] = [];
+
+    $('a[href]').each((_, el) => {
+        const raw = $(el).attr('href');
+        if (!raw) return;
+        if (raw.startsWith('mailto:') || raw.startsWith('javascript:') || raw.startsWith('tel:') || raw.startsWith('data:')) return;
+
+        try {
+            const resolved = new URL(raw, baseUrl);
+            // Strip hash fragment
+            resolved.hash = '';
+            // Fix I1: push normalized URL (trailing slash removed) for consistent dedup
+            const normalized = resolved.href.replace(/\/$/, '');
+
+            if (resolved.origin === origin && !seen.has(normalized)) {
+                seen.add(normalized);
+                links.push(normalized);
+            }
+        } catch {
+            // Invalid URL, skip
+        }
+    });
+
+    return links;
+}
+
+// ── robots.txt ──────────────────────────────────────────────────────────────
+
+/**
+ * Check if a path is allowed by robots.txt rules.
+ * Simplified parser: only handles User-agent: * rules.
+ */
+export function respectsRobotsTxt(robotsTxt: string, path: string): boolean {
+    if (!robotsTxt.trim()) return true;
+
+    const lines = robotsTxt.split('\n');
+    let inGlobalBlock = false;
+    const disallowed: string[] = [];
+
+    for (const rawLine of lines) {
+        const line = rawLine.trim();
+        if (line.toLowerCase().startsWith('user-agent:')) {
+            const agent = line.slice('user-agent:'.length).trim();
+            inGlobalBlock = agent === '*';
+            continue;
+        }
+        if (inGlobalBlock && line.toLowerCase().startsWith('disallow:')) {
+            const rule = line.slice('disallow:'.length).trim();
+            if (rule) disallowed.push(rule);
+        }
+    }
+
+    for (const rule of disallowed) {
+        if (path.startsWith(rule)) return false;
+    }
+    return true;
+}
+
+/**
+ * Extract Sitemap: directives from robots.txt.
+ */
+export function extractSitemapsFromRobotsTxt(robotsTxt: string): string[] {
+    const sitemaps: string[] = [];
+    for (const rawLine of robotsTxt.split('\n')) {
+        const line = rawLine.trim();
+        if (line.toLowerCase().startsWith('sitemap:')) {
+            const url = line.slice('sitemap:'.length).trim();
+            if (url) sitemaps.push(url);
+        }
+    }
+    return sitemaps;
+}
+
+// ── Rate-limited fetcher ────────────────────────────────────────────────────
+
+async function sleep(ms: number): Promise<void> {
+    return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+interface FetchResult {
+    ok: boolean;
+    status: number;
+    body: string;
+    contentType: string;
+}
+
+async function rateLimitedFetch(
+    url: string,
+    rateLimit: number,
+    maxRetries: number,
+    lastFetchTime: { value: number },
+): Promise<FetchResult> {
+    // Rate limiting
+    const now = Date.now();
+    const elapsed = now - lastFetchTime.value;
+    if (elapsed < rateLimit) {
+        await sleep(rateLimit - elapsed);
+    }
+    lastFetchTime.value = Date.now();
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+        try {
+            const response = await fetch(url, {
+                headers: {
+                    'User-Agent': 'Pathfinder/1.0 (https://pathfinder.copilotkit.dev)',
+                    'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8',
+                },
+                signal: AbortSignal.timeout(15000),
+            });
+
+            if (response.status === 429) {
+                if (attempt < maxRetries) {
+                    const retryAfter = parseInt(response.headers.get('retry-after') || '2', 10);
+                    const backoff = Math.max(retryAfter * 1000, (attempt + 1) * 1000);
+                    await sleep(backoff);
+                    continue;
+                }
+            }
+
+            if (response.status >= 500 && attempt < maxRetries) {
+                await sleep((attempt + 1) * 1000);
+                continue;
+            }
+
+            const body = await response.text();
+            const contentType = response.headers.get('content-type') || '';
+
+            return {
+                ok: response.ok,
+                status: response.status,
+                body,
+                contentType,
+            };
+        } catch (err) {
+            if (attempt < maxRetries) {
+                await sleep((attempt + 1) * 1000);
+                continue;
+            }
+            return {
+                ok: false,
+                status: 0,
+                body: '',
+                contentType: '',
+            };
+        }
+    }
+
+    // Should not reach here, but TypeScript needs it
+    return { ok: false, status: 0, body: '', contentType: '' };
+}
+
+// ── Page content analysis ───────────────────────────────────────────────────
+
+/**
+ * Extract visible text length from HTML body.
+ * Used to detect SPA shells that render client-side.
+ */
+function getBodyTextLength(html: string): number {
+    const $ = cheerio.load(html);
+    $('script, style, noscript').remove();
+    return $('body').text().trim().length;
+}
+
+// ── Cache helpers ───────────────────────────────────────────────────────────
+
+function urlToCachePath(cacheDir: string, url: string): string {
+    const parsed = new URL(url);
+    // Convert URL path to filesystem path
+    let filePath = parsed.pathname.replace(/\/$/, '') || '/index';
+    if (!path.extname(filePath)) {
+        filePath += '.html';
+    }
+    return path.join(cacheDir, parsed.hostname, filePath);
+}
+
+function readCache(cachePath: string): string | null {
+    try {
+        return fs.readFileSync(cachePath, 'utf-8');
+    } catch {
+        return null;
+    }
+}
+
+function writeCache(cachePath: string, content: string): void {
+    try {
+        fs.mkdirSync(path.dirname(cachePath), { recursive: true });
+        fs.writeFileSync(cachePath, content, 'utf-8');
+    } catch {
+        // Non-fatal: cache write failure is silently ignored
+    }
+}
+
+// ── SPA detection helper ────────────────────────────────────────────────────
+
+function checkSpaWarnings(pages: CrawledPage[], warnings: string[]): void {
+    const spaPages = pages.filter(p => p.textLength < 100);
+    if (spaPages.length > pages.length * 0.5 && pages.length > 0) {
+        warnings.push(
+            `SPA detected: ${spaPages.length}/${pages.length} pages have very little text content. ` +
+            `This site may render content client-side with JavaScript. ` +
+            `Consider using a headless browser or finding a static/pre-rendered version.`
+        );
+    }
+}
+
+// ── Main crawl function ─────────────────────────────────────────────────────
+
+export async function crawlSite(url: string, options: CrawlOptions = {}): Promise<CrawlResult> {
+    const rateLimit = options.rateLimit ?? 500;
+    const maxPages = options.maxPages ?? 500;
+    const maxDepth = options.maxDepth ?? 3;
+    const maxRetries = options.maxRetries ?? 3;
+    const cacheDir = options.cacheDir;
+
+    const baseUrlObj = new URL(url);
+    const baseUrl = baseUrlObj.origin;
+    const lastFetchTime = { value: 0 };
+
+    const pages: CrawledPage[] = [];
+    const failedUrls: CrawlResult['failedUrls'] = [];
+    const warnings: string[] = [];
+    const visited = new Set<string>();
+
+    // Helper to fetch and store a page
+    async function fetchPage(pageUrl: string): Promise<CrawledPage | null> {
+        if (visited.has(pageUrl) || pages.length >= maxPages) return null;
+        visited.add(pageUrl);
+
+        // Check cache first
+        if (cacheDir) {
+            const cachePath = urlToCachePath(cacheDir, pageUrl);
+            const cached = readCache(cachePath);
+            if (cached !== null) {
+                const textLength = getBodyTextLength(cached);
+                return { url: pageUrl, html: cached, contentType: 'text/html', textLength };
+            }
+        }
+
+        const result = await rateLimitedFetch(pageUrl, rateLimit, maxRetries, lastFetchTime);
+
+        if (!result.ok) {
+            if (result.status === 401 || result.status === 403) {
+                failedUrls.push({ url: pageUrl, status: result.status, reason: 'auth-required' });
+            } else if (result.status !== 404) {
+                failedUrls.push({ url: pageUrl, status: result.status, reason: 'fetch-error' });
+            }
+            return null;
+        }
+
+        // Only process HTML responses
+        if (!result.contentType.includes('text/html') && !result.contentType.includes('application/xhtml')) {
+            return null;
+        }
+
+        const textLength = getBodyTextLength(result.body);
+
+        // Cache the page
+        if (cacheDir) {
+            const cachePath = urlToCachePath(cacheDir, pageUrl);
+            writeCache(cachePath, result.body);
+        }
+
+        return { url: pageUrl, html: result.body, contentType: result.contentType, textLength };
+    }
+
+    // Helper to fetch pages from a list of URLs discovered via sitemap
+    async function fetchSitemapPages(allPageUrls: string[]): Promise<void> {
+        const urlsToFetch = allPageUrls.slice(0, maxPages);
+        for (const pageUrl of urlsToFetch) {
+            if (pages.length >= maxPages) break;
+            const page = await fetchPage(pageUrl);
+            if (page) pages.push(page);
+        }
+    }
+
+    // ── Strategy 1: Try sitemap.xml ─────────────────────────────────────────
+
+    const sitemapResult = await rateLimitedFetch(`${baseUrl}/sitemap.xml`, rateLimit, maxRetries, lastFetchTime);
+    if (sitemapResult.ok) {
+        // Check if it's a sitemap index
+        const indexUrls = parseSitemapIndex(sitemapResult.body);
+        let allPageUrls: string[] = [];
+
+        if (indexUrls.length > 0) {
+            // Fetch each child sitemap
+            for (const sitemapUrl of indexUrls) {
+                const childResult = await rateLimitedFetch(sitemapUrl, rateLimit, maxRetries, lastFetchTime);
+                if (childResult.ok) {
+                    allPageUrls.push(...parseSitemap(childResult.body));
+                }
+            }
+        } else {
+            allPageUrls = parseSitemap(sitemapResult.body);
+        }
+
+        if (allPageUrls.length > 0) {
+            await fetchSitemapPages(allPageUrls);
+            checkSpaWarnings(pages, warnings);
+
+            return {
+                pages,
+                discoveryMethod: indexUrls.length > 0 ? 'sitemap-index' : 'sitemap',
+                baseUrl,
+                warnings,
+                failedUrls,
+            };
+        }
+    }
+
+    // ── Strategy 1b: Try sitemap_index.xml as fallback (Fix I3) ─────────────
+
+    const sitemapIndexResult = await rateLimitedFetch(`${baseUrl}/sitemap_index.xml`, rateLimit, maxRetries, lastFetchTime);
+    if (sitemapIndexResult.ok) {
+        const indexUrls = parseSitemapIndex(sitemapIndexResult.body);
+        if (indexUrls.length > 0) {
+            let allPageUrls: string[] = [];
+            for (const sitemapUrl of indexUrls) {
+                const childResult = await rateLimitedFetch(sitemapUrl, rateLimit, maxRetries, lastFetchTime);
+                if (childResult.ok) {
+                    allPageUrls.push(...parseSitemap(childResult.body));
+                }
+            }
+
+            if (allPageUrls.length > 0) {
+                await fetchSitemapPages(allPageUrls);
+                checkSpaWarnings(pages, warnings);
+
+                return {
+                    pages,
+                    discoveryMethod: 'sitemap-index',
+                    baseUrl,
+                    warnings,
+                    failedUrls,
+                };
+            }
+        }
+    }
+
+    // ── Strategy 2: Try robots.txt for Sitemap: directives ──────────────────
+
+    const robotsResult = await rateLimitedFetch(`${baseUrl}/robots.txt`, rateLimit, maxRetries, lastFetchTime);
+    let robotsTxt = '';
+    if (robotsResult.ok) {
+        robotsTxt = robotsResult.body;
+        const sitemapUrls = extractSitemapsFromRobotsTxt(robotsTxt);
+
+        if (sitemapUrls.length > 0) {
+            let allPageUrls: string[] = [];
+            for (const sitemapUrl of sitemapUrls) {
+                const smResult = await rateLimitedFetch(sitemapUrl, rateLimit, maxRetries, lastFetchTime);
+                if (smResult.ok) {
+                    // Could be sitemap index or regular sitemap
+                    const indexUrls = parseSitemapIndex(smResult.body);
+                    if (indexUrls.length > 0) {
+                        for (const childUrl of indexUrls) {
+                            const childResult = await rateLimitedFetch(childUrl, rateLimit, maxRetries, lastFetchTime);
+                            if (childResult.ok) {
+                                allPageUrls.push(...parseSitemap(childResult.body));
+                            }
+                        }
+                    } else {
+                        allPageUrls.push(...parseSitemap(smResult.body));
+                    }
+                }
+            }
+
+            if (allPageUrls.length > 0) {
+                await fetchSitemapPages(allPageUrls);
+                checkSpaWarnings(pages, warnings);
+
+                return {
+                    pages,
+                    discoveryMethod: 'robots-sitemap',
+                    baseUrl,
+                    warnings,
+                    failedUrls,
+                };
+            }
+        }
+    }
+
+    // ── Strategy 3: Recursive link crawling ─────────────────────────────────
+
+    // BFS crawl from the root URL
+    const queue: { url: string; depth: number }[] = [{ url, depth: 0 }];
+
+    while (queue.length > 0 && pages.length < maxPages) {
+        const current = queue.shift()!;
+        if (visited.has(current.url)) continue;
+
+        // Check robots.txt disallow rules
+        const pathname = new URL(current.url).pathname;
+        if (robotsTxt && !respectsRobotsTxt(robotsTxt, pathname)) {
+            continue;
+        }
+
+        const page = await fetchPage(current.url);
+        if (!page) continue;
+        pages.push(page);
+
+        // Only follow links if we haven't reached max depth
+        if (current.depth < maxDepth) {
+            const links = extractLinks(page.html, current.url);
+            for (const link of links) {
+                if (!visited.has(link)) {
+                    queue.push({ url: link, depth: current.depth + 1 });
+                }
+            }
+        }
+    }
+
+    checkSpaWarnings(pages, warnings);
+
+    return {
+        pages,
+        discoveryMethod: 'crawl',
+        baseUrl,
+        warnings,
+        failedUrls,
+    };
+}

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -308,10 +308,16 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
     const warnings: string[] = [];
     const visited = new Set<string>();
 
+    // Helper to normalize URLs for consistent dedup (strip trailing slash)
+    function normalizeUrl(u: string): string {
+        return u.replace(/\/$/, '');
+    }
+
     // Helper to fetch and store a page
     async function fetchPage(pageUrl: string): Promise<CrawledPage | null> {
-        if (visited.has(pageUrl) || pages.length >= maxPages) return null;
-        visited.add(pageUrl);
+        const normalized = normalizeUrl(pageUrl);
+        if (visited.has(normalized) || pages.length >= maxPages) return null;
+        visited.add(normalized);
 
         // Check cache first
         if (cacheDir) {
@@ -350,11 +356,23 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
         return { url: pageUrl, html: result.body, contentType: result.contentType, textLength };
     }
 
+    // Fetch robots.txt early so sitemap-discovered URLs can be filtered
+    const robotsResult = await rateLimitedFetch(`${baseUrl}/robots.txt`, rateLimit, maxRetries, lastFetchTime);
+    let robotsTxt = '';
+    if (robotsResult.ok) {
+        robotsTxt = robotsResult.body;
+    }
+
     // Helper to fetch pages from a list of URLs discovered via sitemap
     async function fetchSitemapPages(allPageUrls: string[]): Promise<void> {
         const urlsToFetch = allPageUrls.slice(0, maxPages);
         for (const pageUrl of urlsToFetch) {
             if (pages.length >= maxPages) break;
+            // Enforce robots.txt on sitemap-discovered URLs
+            if (robotsTxt) {
+                const pathname = new URL(pageUrl).pathname;
+                if (!respectsRobotsTxt(robotsTxt, pathname)) continue;
+            }
             const page = await fetchPage(pageUrl);
             if (page) pages.push(page);
         }
@@ -424,11 +442,9 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
     }
 
     // ── Strategy 2: Try robots.txt for Sitemap: directives ──────────────────
+    // (robots.txt already fetched above for filtering)
 
-    const robotsResult = await rateLimitedFetch(`${baseUrl}/robots.txt`, rateLimit, maxRetries, lastFetchTime);
-    let robotsTxt = '';
     if (robotsResult.ok) {
-        robotsTxt = robotsResult.body;
         const sitemapUrls = extractSitemapsFromRobotsTxt(robotsTxt);
 
         if (sitemapUrls.length > 0) {
@@ -469,11 +485,11 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
     // ── Strategy 3: Recursive link crawling ─────────────────────────────────
 
     // BFS crawl from the root URL
-    const queue: { url: string; depth: number }[] = [{ url, depth: 0 }];
+    const queue: { url: string; depth: number }[] = [{ url: normalizeUrl(url), depth: 0 }];
 
     while (queue.length > 0 && pages.length < maxPages) {
         const current = queue.shift()!;
-        if (visited.has(current.url)) continue;
+        if (visited.has(normalizeUrl(current.url))) continue;
 
         // Check robots.txt disallow rules
         const pathname = new URL(current.url).pathname;
@@ -489,8 +505,8 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
         if (current.depth < maxDepth) {
             const links = extractLinks(page.html, current.url);
             for (const link of links) {
-                if (!visited.has(link)) {
-                    queue.push({ url: link, depth: current.depth + 1 });
+                if (!visited.has(normalizeUrl(link))) {
+                    queue.push({ url: normalizeUrl(link), depth: current.depth + 1 });
                 }
             }
         }

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -1,0 +1,250 @@
+import { getPool } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface QueryLogEntry {
+  tool_name: string;
+  query_text: string;
+  result_count: number;
+  top_score: number | null;
+  latency_ms: number;
+  source_name: string | null;
+  session_id: string | null;
+}
+
+export interface AnalyticsSummary {
+  total_queries: number;
+  total_queries_7d: number;
+  empty_result_count_7d: number;
+  empty_result_rate_7d: number;
+  avg_latency_ms_7d: number;
+  p95_latency_ms_7d: number;
+  queries_by_source: Array<{ source_name: string; count: number }>;
+  queries_per_day_7d: Array<{ day: string; count: number }>;
+}
+
+export interface TopQuery {
+  query_text: string;
+  count: number;
+  avg_result_count: number;
+  avg_top_score: number | null;
+}
+
+export interface EmptyQuery {
+  query_text: string;
+  tool_name: string;
+  source_name: string | null;
+  count: number;
+  last_seen: string;
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+/**
+ * Log a query to the query_log table.
+ * When log_queries is false, query_text is stored as '<redacted>'.
+ */
+export async function logQuery(
+  entry: QueryLogEntry,
+  logQueryText: boolean = true,
+): Promise<void> {
+  const pool = getPool();
+  const text = logQueryText ? entry.query_text : "<redacted>";
+  await pool.query(
+    `INSERT INTO query_log (tool_name, query_text, result_count, top_score, latency_ms, source_name, session_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      entry.tool_name,
+      text,
+      entry.result_count,
+      entry.top_score,
+      entry.latency_ms,
+      entry.source_name,
+      entry.session_id,
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute p95 latency in application code instead of SQL.
+ * PGlite does NOT support percentile_cont(), so we fetch all latencies
+ * and compute the percentile in JS.
+ */
+function computeP95(latencies: number[]): number {
+  if (latencies.length === 0) return 0;
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const index = Math.floor(sorted.length * 0.95);
+  return sorted[Math.min(index, sorted.length - 1)] ?? 0;
+}
+
+/**
+ * Get a summary of analytics data.
+ */
+export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
+  const pool = getPool();
+
+  // Note: percentile_cont is NOT used in SQL because PGlite doesn't support it.
+  // Instead, we fetch latencies and compute p95 in application code.
+  const [totalRes, summary7dRes, latencyRes, bySourceRes, perDayRes] =
+    await Promise.all([
+      pool.query("SELECT count(*)::int AS count FROM query_log"),
+      pool.query(`
+            SELECT
+                count(*)::int AS total,
+                count(*) FILTER (WHERE result_count = 0)::int AS empty,
+                COALESCE(avg(latency_ms)::int, 0) AS avg_latency
+            FROM query_log
+            WHERE created_at > NOW() - INTERVAL '7 days'
+        `),
+      pool.query(`
+            SELECT latency_ms FROM query_log
+            WHERE created_at > NOW() - INTERVAL '7 days'
+            ORDER BY latency_ms
+        `),
+      pool.query(`
+            SELECT source_name, count(*)::int AS count
+            FROM query_log
+            WHERE source_name IS NOT NULL
+            GROUP BY source_name
+            ORDER BY count DESC
+        `),
+      pool.query(`
+            SELECT date_trunc('day', created_at)::date::text AS day, count(*)::int AS count
+            FROM query_log
+            WHERE created_at > NOW() - INTERVAL '7 days'
+            GROUP BY day
+            ORDER BY day
+        `),
+    ]);
+
+  const totalQueries = totalRes.rows[0]?.count ?? 0;
+  const s = summary7dRes.rows[0] ?? {};
+  const total7d = s.total ?? 0;
+  const empty7d = s.empty ?? 0;
+
+  // Compute p95 in application code
+  const latencies = latencyRes.rows.map(
+    (r: Record<string, unknown>) => r.latency_ms as number,
+  );
+  const p95Latency = computeP95(latencies);
+
+  return {
+    total_queries: totalQueries,
+    total_queries_7d: total7d,
+    empty_result_count_7d: empty7d,
+    empty_result_rate_7d: total7d > 0 ? empty7d / total7d : 0,
+    avg_latency_ms_7d: s.avg_latency ?? 0,
+    p95_latency_ms_7d: p95Latency,
+    queries_by_source: bySourceRes.rows.map(
+      (r: Record<string, unknown>) => ({
+        source_name: r.source_name as string,
+        count: r.count as number,
+      }),
+    ),
+    queries_per_day_7d: perDayRes.rows.map(
+      (r: Record<string, unknown>) => ({
+        day: r.day as string,
+        count: r.count as number,
+      }),
+    ),
+  };
+}
+
+/**
+ * Get top queries by frequency over the last N days.
+ */
+export async function getTopQueries(
+  days: number = 7,
+  limit: number = 50,
+): Promise<TopQuery[]> {
+  const pool = getPool();
+  const { rows } = await pool.query(
+    `
+        SELECT
+            query_text,
+            count(*)::int AS count,
+            avg(result_count)::real AS avg_result_count,
+            avg(top_score)::real AS avg_top_score
+        FROM query_log
+        WHERE created_at > NOW() - INTERVAL '1 day' * $1
+          AND query_text != '<redacted>'
+        GROUP BY query_text
+        ORDER BY count DESC
+        LIMIT $2
+    `,
+    [days, limit],
+  );
+
+  return rows.map((r: Record<string, unknown>) => ({
+    query_text: r.query_text as string,
+    count: r.count as number,
+    avg_result_count: parseFloat(r.avg_result_count as string) || 0,
+    avg_top_score:
+      r.avg_top_score != null
+        ? parseFloat(r.avg_top_score as string)
+        : null,
+  }));
+}
+
+/**
+ * Get queries that returned zero results, grouped by query text.
+ */
+export async function getEmptyQueries(
+  days: number = 7,
+  limit: number = 50,
+): Promise<EmptyQuery[]> {
+  const pool = getPool();
+  const { rows } = await pool.query(
+    `
+        SELECT
+            query_text,
+            tool_name,
+            source_name,
+            count(*)::int AS count,
+            max(created_at)::text AS last_seen
+        FROM query_log
+        WHERE result_count = 0
+          AND created_at > NOW() - INTERVAL '1 day' * $1
+          AND query_text != '<redacted>'
+        GROUP BY query_text, tool_name, source_name
+        ORDER BY count DESC
+        LIMIT $2
+    `,
+    [days, limit],
+  );
+
+  return rows.map((r: Record<string, unknown>) => ({
+    query_text: r.query_text as string,
+    tool_name: r.tool_name as string,
+    source_name: (r.source_name as string) ?? null,
+    count: r.count as number,
+    last_seen: r.last_seen as string,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete query_log rows older than the specified number of days.
+ * Returns the number of rows deleted.
+ */
+export async function cleanupOldQueryLogs(
+  retentionDays: number,
+): Promise<number> {
+  const pool = getPool();
+  const result = await pool.query(
+    `DELETE FROM query_log WHERE created_at < NOW() - INTERVAL '1 day' * $1`,
+    [retentionDays],
+  );
+  return result.rowCount ?? 0;
+}

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -113,6 +113,7 @@ export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
             SELECT source_name, count(*)::int AS count
             FROM query_log
             WHERE source_name IS NOT NULL
+              AND created_at > NOW() - INTERVAL '7 days'
             GROUP BY source_name
             ORDER BY count DESC
         `),

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -4,6 +4,7 @@ import {
   generateSchema,
   generateMigration,
   generatePostSchemaMigration,
+  generateTsvTriggerDdl,
   generateDimensionCheckQuery,
 } from "./schema.js";
 import { getConfig, getServerConfig } from "../config.js";
@@ -78,6 +79,17 @@ async function initializePGlite(): Promise<void> {
       // ROLLBACK failed — original error is more useful
     }
     throw err;
+  }
+
+  // Attempt tsvector trigger creation — PGlite does not support PL/pgSQL triggers
+  try {
+    await db.exec(generateTsvTriggerDdl());
+  } catch (error: unknown) {
+    console.warn(
+      `[db] tsvector trigger creation skipped (PGlite or unsupported): ` +
+        `${error instanceof Error ? error.message : String(error)}. ` +
+        `tsv column will be populated in application code during upsert.`,
+    );
   }
 
   // Build a wrapper that duck-types as pg.Pool.
@@ -197,6 +209,20 @@ export async function initializeSchema(): Promise<void> {
     throw err;
   } finally {
     migrationClient.release();
+  }
+
+  // Apply tsvector trigger DDL outside the transaction (idempotent)
+  const triggerClient = await p.connect();
+  try {
+    await triggerClient.query(generateTsvTriggerDdl());
+  } catch (error: unknown) {
+    console.warn(
+      `[db] tsvector trigger creation skipped: ` +
+        `${error instanceof Error ? error.message : String(error)}. ` +
+        `tsv column will be populated in application code during upsert.`,
+    );
+  } finally {
+    triggerClient.release();
   }
 }
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -78,8 +78,9 @@ export async function searchChunks(
 }
 
 /**
- * Text search (ILIKE) on the unified chunks table.
- * Optionally filtered by source_name. Returns results ordered by id.
+ * Full-text keyword search using PostgreSQL tsvector/tsquery.
+ * Uses plainto_tsquery for safe query parsing (no operator injection).
+ * Results are ranked by ts_rank (term frequency relevance).
  */
 export async function textSearchChunks(
   pattern: string,
@@ -87,17 +88,44 @@ export async function textSearchChunks(
   sourceName?: string,
 ): Promise<ChunkResult[]> {
   const pool = getPool();
-  const escaped = pattern.replace(/[%_\\]/g, "\\$&");
-  const likePattern = `%${escaped}%`;
-  let sql: string;
-  let params: unknown[];
+
+  const conditions: string[] = [];
+  const params: unknown[] = [];
+  let paramIdx = 1;
+
+  // tsquery from user input — plainto_tsquery handles special chars safely
+  conditions.push(`tsv @@ plainto_tsquery('english', $${paramIdx})`);
+  params.push(pattern);
+  paramIdx++;
+
   if (sourceName) {
-    sql = `SELECT id, source_name, source_url, title, content, repo_url, file_path, start_line, end_line, language, 0.0 AS similarity FROM chunks WHERE source_name = $1 AND content ILIKE $2 ORDER BY id LIMIT $3`;
-    params = [sourceName, likePattern, limit];
-  } else {
-    sql = `SELECT id, source_name, source_url, title, content, repo_url, file_path, start_line, end_line, language, 0.0 AS similarity FROM chunks WHERE content ILIKE $1 ORDER BY id LIMIT $2`;
-    params = [likePattern, limit];
+    conditions.push(`source_name = $${paramIdx}`);
+    params.push(sourceName);
+    paramIdx++;
   }
+
+  const whereClause = conditions.join(" AND ");
+
+  const sql = `
+        SELECT
+            id,
+            source_name,
+            source_url,
+            title,
+            content,
+            repo_url,
+            file_path,
+            start_line,
+            end_line,
+            language,
+            ts_rank(tsv, plainto_tsquery('english', $1)) AS similarity
+        FROM chunks
+        WHERE ${whereClause}
+        ORDER BY ts_rank(tsv, plainto_tsquery('english', $1)) DESC
+        LIMIT $${paramIdx}
+    `;
+  params.push(limit);
+
   const { rows } = await pool.query(sql, params);
   return rows.map((r: Record<string, unknown>) => ({
     id: r.id as number,
@@ -111,6 +139,99 @@ export async function textSearchChunks(
     end_line: (r.end_line as number) ?? null,
     language: (r.language as string) ?? null,
     similarity: parseFloat(r.similarity as string),
+  }));
+}
+
+/**
+ * Hybrid search combining vector similarity and full-text keyword search
+ * using Reciprocal Rank Fusion (RRF) to merge ranked lists.
+ *
+ * Strategy: run two independent indexed queries (vector + keyword),
+ * then merge in application code using RRF scoring.
+ * This is faster than a single SQL query because each query uses its
+ * respective index (HNSW for vector, GIN for tsvector).
+ *
+ * min_score filtering is applied to vector candidates BEFORE merging,
+ * preserving the semantic quality floor per the spec.
+ */
+export async function hybridSearchChunks(
+  embedding: number[],
+  queryText: string,
+  limit: number,
+  sourceName?: string,
+  version?: string,
+  minScore?: number,
+): Promise<ChunkResult[]> {
+  // Fetch 2x candidates from each retriever to ensure good RRF coverage
+  const candidateLimit = limit * 2;
+
+  // Run both searches in parallel
+  const [vectorResults, keywordResults] = await Promise.all([
+    searchChunks(embedding, candidateLimit, sourceName, version),
+    textSearchChunks(queryText, candidateLimit, sourceName),
+  ]);
+
+  // Apply min_score filter to vector candidates before merging
+  const filteredVectorResults =
+    minScore != null
+      ? vectorResults.filter((r) => r.similarity >= minScore)
+      : vectorResults;
+
+  return rrfMerge(filteredVectorResults, keywordResults, limit);
+}
+
+/**
+ * Reciprocal Rank Fusion: merges two ranked lists into one.
+ *
+ * RRF_score(doc) = 1/(k + rank_vector) + 1/(k + rank_keyword)
+ *
+ * where k = 60 (standard constant from the original RRF paper).
+ * Documents appearing in only one list get a single-term score.
+ *
+ * Exported for direct unit testing of the merge logic.
+ */
+export const RRF_K = 60;
+
+export function rrfMerge(
+  vectorResults: ChunkResult[],
+  keywordResults: ChunkResult[],
+  limit: number,
+): ChunkResult[] {
+  // Map chunk ID -> { rrfScore, bestResult }
+  const scores = new Map<number, { rrfScore: number; result: ChunkResult }>();
+
+  // Score vector results by rank position
+  for (let i = 0; i < vectorResults.length; i++) {
+    const r = vectorResults[i];
+    const rank = i + 1; // 1-indexed
+    const rrfScore = 1 / (RRF_K + rank);
+    scores.set(r.id, { rrfScore, result: r });
+  }
+
+  // Score keyword results by rank position, accumulate
+  for (let i = 0; i < keywordResults.length; i++) {
+    const r = keywordResults[i];
+    const rank = i + 1;
+    const rrfContribution = 1 / (RRF_K + rank);
+
+    const existing = scores.get(r.id);
+    if (existing) {
+      existing.rrfScore += rrfContribution;
+      // Keep the vector result (has cosine similarity) as the canonical result
+    } else {
+      scores.set(r.id, { rrfScore: rrfContribution, result: r });
+    }
+  }
+
+  // Sort by RRF score descending, take top N
+  const sorted = Array.from(scores.values())
+    .sort((a, b) => b.rrfScore - a.rrfScore)
+    .slice(0, limit);
+
+  // Return ChunkResult[] with similarity set to the RRF score
+  return sorted.map(({ rrfScore, result }) => ({
+    ...result,
+    similarity: rrfScore,
   }));
 }
 
@@ -135,9 +256,10 @@ export async function upsertChunks(chunks: Chunk[]): Promise<void> {
             INSERT INTO chunks
                 (source_name, source_url, title, content, embedding, repo_url,
                  file_path, start_line, end_line, language, chunk_index,
-                 metadata, commit_sha, version, indexed_at)
+                 metadata, commit_sha, version, indexed_at, tsv)
             VALUES
-                ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW())
+                ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, NOW(),
+                 to_tsvector('english', $4))
             ON CONFLICT (source_name, file_path, chunk_index) DO UPDATE SET
                 source_url = EXCLUDED.source_url,
                 title      = EXCLUDED.title,
@@ -150,7 +272,8 @@ export async function upsertChunks(chunks: Chunk[]): Promise<void> {
                 metadata   = EXCLUDED.metadata,
                 commit_sha = EXCLUDED.commit_sha,
                 version    = EXCLUDED.version,
-                indexed_at = NOW()
+                indexed_at = NOW(),
+                tsv        = EXCLUDED.tsv
         `;
 
     for (const chunk of chunks) {

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -86,7 +86,10 @@ export async function textSearchChunks(
   pattern: string,
   limit: number,
   sourceName?: string,
+  version?: string,
 ): Promise<ChunkResult[]> {
+  if (!pattern.trim()) return [];
+
   const pool = getPool();
 
   const conditions: string[] = [];
@@ -102,6 +105,11 @@ export async function textSearchChunks(
     conditions.push(`source_name = $${paramIdx}`);
     params.push(sourceName);
     paramIdx++;
+  }
+
+  if (version) {
+    conditions.push(`version = $${paramIdx++}`);
+    params.push(version);
   }
 
   const whereClause = conditions.join(" AND ");
@@ -168,7 +176,7 @@ export async function hybridSearchChunks(
   // Run both searches in parallel
   const [vectorResults, keywordResults] = await Promise.all([
     searchChunks(embedding, candidateLimit, sourceName, version),
-    textSearchChunks(queryText, candidateLimit, sourceName),
+    textSearchChunks(queryText, candidateLimit, sourceName, version),
   ]);
 
   // Apply min_score filter to vector candidates before merging
@@ -203,14 +211,18 @@ export function rrfMerge(
   // Score vector results by rank position
   for (let i = 0; i < vectorResults.length; i++) {
     const r = vectorResults[i];
+    if (scores.has(r.id)) continue; // keep first/best-ranked
     const rank = i + 1; // 1-indexed
     const rrfScore = 1 / (RRF_K + rank);
     scores.set(r.id, { rrfScore, result: r });
   }
 
   // Score keyword results by rank position, accumulate
+  const seenKeyword = new Set<number>();
   for (let i = 0; i < keywordResults.length; i++) {
     const r = keywordResults[i];
+    if (seenKeyword.has(r.id)) continue; // keep first/best-ranked
+    seenKeyword.add(r.id);
     const rank = i + 1;
     const rrfContribution = 1 / (RRF_K + rank);
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -86,6 +86,22 @@ UPDATE chunks SET tsv = to_tsvector('english', content) WHERE tsv IS NULL;
 
 -- GIN index for fast full-text search
 CREATE INDEX IF NOT EXISTS idx_chunks_tsv ON chunks USING GIN (tsv);
+
+-- Analytics: query_log table for tracking tool usage
+CREATE TABLE IF NOT EXISTS query_log (
+    id              SERIAL PRIMARY KEY,
+    tool_name       TEXT NOT NULL,
+    query_text      TEXT NOT NULL,
+    result_count    INTEGER NOT NULL,
+    top_score       REAL,
+    latency_ms      INTEGER NOT NULL,
+    source_name     TEXT,
+    session_id      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_log_created_at ON query_log (created_at);
+CREATE INDEX IF NOT EXISTS idx_query_log_tool_name ON query_log (tool_name);
 `;
 
   return coreSql;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -67,11 +67,48 @@ DROP TABLE IF EXISTS code_chunks CASCADE;
 /**
  * Generate post-schema migration SQL for columns added after initial release.
  * Safe to run repeatedly — uses IF NOT EXISTS / ADD COLUMN IF NOT EXISTS.
+ *
+ * Includes tsvector support for hybrid search (v1.8.0):
+ * - Core DDL (column + populate + GIN index) works on both PostgreSQL and PGlite
+ * - Trigger DDL is appended but applied separately via try-catch in initializeSchema
+ *   because PGlite does not support PL/pgSQL triggers
  */
 export function generatePostSchemaMigration(): string {
-  return `
+  const coreSql = `
 ALTER TABLE chunks ADD COLUMN IF NOT EXISTS version TEXT;
 CREATE INDEX IF NOT EXISTS idx_chunks_version ON chunks (version);
+
+-- Hybrid search: tsvector column for full-text search
+ALTER TABLE chunks ADD COLUMN IF NOT EXISTS tsv tsvector;
+
+-- Populate tsvector for any existing rows that don't have it yet
+UPDATE chunks SET tsv = to_tsvector('english', content) WHERE tsv IS NULL;
+
+-- GIN index for fast full-text search
+CREATE INDEX IF NOT EXISTS idx_chunks_tsv ON chunks USING GIN (tsv);
+`;
+
+  return coreSql;
+}
+
+/**
+ * Returns ONLY the trigger DDL, for use in try-catch migration.
+ * Called separately from core DDL so PGlite can skip it gracefully.
+ */
+export function generateTsvTriggerDdl(): string {
+  return `
+-- Trigger to auto-populate tsvector on insert/update of content
+CREATE OR REPLACE FUNCTION chunks_tsv_trigger() RETURNS trigger AS $$
+BEGIN
+    NEW.tsv := to_tsvector('english', NEW.content);
+    RETURN NEW;
+END
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS chunks_tsv_update ON chunks;
+CREATE TRIGGER chunks_tsv_update
+    BEFORE INSERT OR UPDATE OF content ON chunks
+    FOR EACH ROW EXECUTE FUNCTION chunks_tsv_trigger();
 `;
 }
 

--- a/src/indexing/chunking/document.ts
+++ b/src/indexing/chunking/document.ts
@@ -1,0 +1,268 @@
+// Document chunker — page-break and section-aware chunking for PDF/DOCX text.
+
+import { type ChunkOutput, type SourceConfig } from "../../types.js";
+
+const DEFAULT_TARGET_TOKENS = 600;
+const DEFAULT_OVERLAP_TOKENS = 50;
+
+/** Pattern for ALL CAPS section headers (at least 3 uppercase letters, standalone line). */
+const ALL_CAPS_HEADER_RE = /^[A-Z][A-Z\s]{2,}[A-Z]$/;
+
+/** Pattern for numbered section headers: "1.", "1.2", "1.2.3", "Section 1:", etc. */
+const NUMBERED_HEADER_RE = /^(?:\d+\.(?:\d+\.)*\s+\S|Section\s+\d)/i;
+
+/**
+ * Detect if a line is a section header.
+ * Returns the header text if detected, null otherwise.
+ */
+function detectSectionHeader(line: string): string | null {
+  const trimmed = line.trim();
+  if (!trimmed || trimmed.length > 100) return null;
+
+  if (ALL_CAPS_HEADER_RE.test(trimmed)) return trimmed;
+  if (NUMBERED_HEADER_RE.test(trimmed)) return trimmed;
+
+  return null;
+}
+
+/**
+ * Represents a logical section of a document.
+ */
+interface DocumentSection {
+  title: string | null;
+  content: string;
+  pageNumber: number | null;
+}
+
+/**
+ * Split extracted document text into logical sections using:
+ * 1. Form feed characters (\f) as page boundaries
+ * 2. ALL CAPS or numbered section headers as section boundaries
+ * 3. Double newlines as paragraph boundaries (fallback)
+ */
+function splitIntoSections(content: string): DocumentSection[] {
+  // Split on form feeds first to get pages
+  const pages = content.split("\f");
+  const hasPageBreaks = pages.length > 1;
+
+  const sections: DocumentSection[] = [];
+
+  for (let pageIdx = 0; pageIdx < pages.length; pageIdx++) {
+    const pageText = pages[pageIdx].trim();
+    if (!pageText) continue;
+
+    const pageNumber = hasPageBreaks ? pageIdx + 1 : null;
+    const lines = pageText.split("\n");
+
+    let currentTitle: string | null = null;
+    let currentLines: string[] = [];
+
+    function flush() {
+      const text = currentLines.join("\n").trim();
+      if (text) {
+        sections.push({
+          title: currentTitle,
+          content: text,
+          pageNumber,
+        });
+      }
+      currentLines = [];
+    }
+
+    for (const line of lines) {
+      const header = detectSectionHeader(line);
+      if (header) {
+        flush();
+        currentTitle = header;
+        continue;
+      }
+      currentLines.push(line);
+    }
+
+    flush();
+  }
+
+  return sections;
+}
+
+/**
+ * Chunk document text into embedding-friendly chunks.
+ * Follows the ChunkerFn signature: (content, filePath, config) => ChunkOutput[]
+ *
+ * Splitting priority:
+ * 1. Page breaks (form feed \f) — natural boundaries from PDF extraction
+ * 2. Section headers (ALL CAPS, numbered sections) — structural boundaries
+ * 3. Paragraph breaks (double newline) — text-level boundaries
+ * 4. Token-count splitting — fallback for long unstructured blocks
+ */
+export function chunkDocument(
+  content: string,
+  _filePath: string,
+  config: SourceConfig,
+): ChunkOutput[] {
+  if (!content || !content.trim()) {
+    return [];
+  }
+
+  const targetChars =
+    (config.chunk?.target_tokens ?? DEFAULT_TARGET_TOKENS) * 4;
+  const overlapChars =
+    (config.chunk?.overlap_tokens ?? DEFAULT_OVERLAP_TOKENS) * 4;
+
+  const sections = splitIntoSections(content);
+
+  if (sections.length === 0) {
+    return [];
+  }
+
+  // Merge small consecutive sections until target size is reached
+  const merged: {
+    content: string;
+    title: string | null;
+    pageNumber: number | null;
+  }[] = [];
+  let current = "";
+  let currentTitle: string | null = sections[0].title;
+  let currentPage: number | null = sections[0].pageNumber;
+
+  for (const section of sections) {
+    const text = section.content;
+    const separator = current ? "\n\n" : "";
+
+    // Start new chunk when:
+    // - Adding this section would exceed target
+    // - This section has its own title (preserve section boundaries)
+    const sizeExceeded =
+      current &&
+      current.length + separator.length + text.length > targetChars;
+    const hasNewTitle = section.title !== null && current.length > 0;
+
+    if (sizeExceeded || hasNewTitle) {
+      if (current.trim()) {
+        merged.push({
+          content: current,
+          title: currentTitle,
+          pageNumber: currentPage,
+        });
+      }
+      current = text;
+      currentTitle = section.title ?? currentTitle;
+      currentPage = section.pageNumber;
+    } else {
+      if (!current) {
+        currentTitle = section.title;
+        currentPage = section.pageNumber;
+      }
+      current = current ? current + separator + text : text;
+    }
+  }
+  if (current.trim()) {
+    merged.push({
+      content: current,
+      title: currentTitle,
+      pageNumber: currentPage,
+    });
+  }
+
+  // Split any oversized chunks on paragraph boundaries
+  const sized: {
+    content: string;
+    title: string | null;
+    pageNumber: number | null;
+  }[] = [];
+  for (const chunk of merged) {
+    if (chunk.content.length <= targetChars) {
+      sized.push(chunk);
+      continue;
+    }
+
+    const paragraphs = chunk.content
+      .split(/\n\n+/)
+      .filter((p) => p.trim().length > 0);
+    let buf = "";
+    for (const para of paragraphs) {
+      const sep = buf ? "\n\n" : "";
+      if (buf && buf.length + sep.length + para.length > targetChars) {
+        sized.push({
+          content: buf,
+          title: chunk.title,
+          pageNumber: chunk.pageNumber,
+        });
+        buf = para;
+      } else {
+        buf = buf ? buf + sep + para : para;
+      }
+    }
+    if (buf.trim()) {
+      sized.push({
+        content: buf,
+        title: chunk.title,
+        pageNumber: chunk.pageNumber,
+      });
+    }
+  }
+
+  // Split any remaining oversized chunks on word boundaries (fallback for
+  // single long paragraphs with no \n\n breaks)
+  const final: typeof sized = [];
+  for (const chunk of sized) {
+    if (chunk.content.length <= targetChars) {
+      final.push(chunk);
+      continue;
+    }
+    // Split on word boundaries
+    const words = chunk.content.split(/\s+/);
+    let buf = "";
+    for (const word of words) {
+      const sep = buf ? " " : "";
+      if (buf && buf.length + sep.length + word.length > targetChars) {
+        final.push({
+          content: buf,
+          title: chunk.title,
+          pageNumber: chunk.pageNumber,
+        });
+        buf = word;
+      } else {
+        buf = buf ? buf + sep + word : word;
+      }
+    }
+    if (buf.trim()) {
+      final.push({
+        content: buf,
+        title: chunk.title,
+        pageNumber: chunk.pageNumber,
+      });
+    }
+  }
+
+  // Apply overlap
+  const chunks: ChunkOutput[] = [];
+  for (let i = 0; i < final.length; i++) {
+    let chunkContent = final[i].content;
+
+    if (i > 0 && overlapChars > 0) {
+      const prevContent = final[i - 1].content;
+      const overlapText = prevContent.slice(-overlapChars);
+      const breakPoint = overlapText.lastIndexOf("\n");
+      const cleanOverlap =
+        breakPoint > 0 ? overlapText.slice(breakPoint) : overlapText;
+      chunkContent = cleanOverlap + "\n\n" + chunkContent;
+    }
+
+    // Strip form feeds from final output
+    chunkContent = chunkContent
+      .replace(/\f/g, "\n\n")
+      .replace(/\n{3,}/g, "\n\n")
+      .trim();
+
+    chunks.push({
+      content: chunkContent,
+      title: final[i].title ?? undefined,
+      chunkIndex: i,
+      startLine: final[i].pageNumber ?? undefined,
+      endLine: final[i].pageNumber ?? undefined,
+    });
+  }
+
+  return chunks;
+}

--- a/src/indexing/chunking/index.ts
+++ b/src/indexing/chunking/index.ts
@@ -34,6 +34,10 @@ registerChunker("code", chunkCode);
 registerChunker("raw-text", chunkRawText);
 registerChunker("html", chunkHtml);
 
+import { chunkDocument } from "./document.js";
+
+registerChunker("document", chunkDocument);
+
 import { chunkQa } from "./qa.js";
 
 registerChunker("slack", chunkQa);

--- a/src/indexing/content-extractors.ts
+++ b/src/indexing/content-extractors.ts
@@ -64,7 +64,7 @@ async function extractPdf(filePath: string): Promise<ExtractionResult> {
   const result = await pdfParse(buffer);
 
   // Warn about likely scanned PDFs (very little text for multi-page docs)
-  if (result.numpages > 1 && result.text.trim().length < 50) {
+  if (result.numpages >= 1 && result.text.trim().length < 50) {
     console.warn(
       `[content-extractor] ${filePath}: PDF has ${result.numpages} pages but produced very little text ` +
         `(${result.text.trim().length} chars). This may be a scanned document without a text layer.`,
@@ -107,5 +107,13 @@ async function extractDocx(filePath: string): Promise<ExtractionResult> {
   }
 
   const result = await mammoth.extractRawText({ path: filePath });
+
+  if (result.messages && result.messages.length > 0) {
+    console.warn(
+      `[content-extractor] ${filePath}: mammoth reported ${result.messages.length} warning(s):`,
+      result.messages,
+    );
+  }
+
   return { content: result.value };
 }

--- a/src/indexing/content-extractors.ts
+++ b/src/indexing/content-extractors.ts
@@ -1,0 +1,111 @@
+// Content extractors — convert binary document formats to plain text.
+// PDF and DOCX libraries are optional peer dependencies, loaded dynamically.
+
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Extract text content from a file. For non-document source types, reads
+ * the file as UTF-8. For document types, delegates to format-specific
+ * extractors based on file extension.
+ */
+export interface ExtractionResult {
+  content: string;
+  metadata?: Record<string, unknown>;
+}
+
+export async function extractContent(
+  filePath: string,
+  sourceType: string,
+): Promise<ExtractionResult> {
+  if (sourceType !== "document") {
+    const content = await fs.promises.readFile(filePath, "utf-8");
+    return { content };
+  }
+
+  const ext = path.extname(filePath).toLowerCase();
+  switch (ext) {
+    case ".pdf":
+      return extractPdf(filePath);
+    case ".docx":
+      return extractDocx(filePath);
+    default: {
+      const content = await fs.promises.readFile(filePath, "utf-8");
+      return { content };
+    }
+  }
+}
+
+/**
+ * Extract text and metadata from a PDF file using pdf-parse.
+ * Warns if the PDF produces very little text (likely a scanned document).
+ */
+async function extractPdf(filePath: string): Promise<ExtractionResult> {
+  let pdfParse: (
+    buffer: Buffer,
+  ) => Promise<{
+    text: string;
+    numpages: number;
+    info: Record<string, unknown>;
+  }>;
+
+  try {
+    const mod = await import("pdf-parse");
+    pdfParse = mod.default;
+  } catch {
+    throw new Error(
+      `Cannot extract PDF: install pdf-parse to index PDF files.\n` +
+        `  npm install pdf-parse\n` +
+        `  # or: pnpm add pdf-parse`,
+    );
+  }
+
+  const buffer = await fs.promises.readFile(filePath);
+  const result = await pdfParse(buffer);
+
+  // Warn about likely scanned PDFs (very little text for multi-page docs)
+  if (result.numpages > 1 && result.text.trim().length < 50) {
+    console.warn(
+      `[content-extractor] ${filePath}: PDF has ${result.numpages} pages but produced very little text ` +
+        `(${result.text.trim().length} chars). This may be a scanned document without a text layer.`,
+    );
+  }
+
+  // Extract metadata from PDF info dict
+  const metadata: Record<string, unknown> = {};
+  if (result.info?.Title) metadata.title = result.info.Title;
+  if (result.info?.Author) metadata.author = result.info.Author;
+  if (result.info?.CreationDate)
+    metadata.creationDate = result.info.CreationDate;
+  if (result.numpages) metadata.pageCount = result.numpages;
+
+  return {
+    content: result.text,
+    metadata: Object.keys(metadata).length > 0 ? metadata : undefined,
+  };
+}
+
+/**
+ * Extract text from a DOCX file using mammoth.
+ */
+async function extractDocx(filePath: string): Promise<ExtractionResult> {
+  let mammoth: {
+    extractRawText: (options: {
+      path: string;
+    }) => Promise<{ value: string; messages: unknown[] }>;
+  };
+
+  try {
+    const mod = await import("mammoth");
+    mammoth = mod.default;
+  } catch {
+    throw new Error(
+      `Cannot extract DOCX: install mammoth to index DOCX files.\n` +
+        `  npm install mammoth\n` +
+        `  # or: pnpm add mammoth`,
+    );
+  }
+
+  const result = await mammoth.extractRawText({ path: filePath });
+  return { content: result.value };
+}

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -300,25 +300,25 @@ export class IndexingOrchestrator {
           this.lastReindexDate = today;
           console.log("[orchestrator] Starting nightly reindex");
           this.queueFullReindex();
-        }
 
-        // Analytics cleanup — run at the same hour as reindex, once per day
-        const analyticsConfig = getServerConfig().analytics;
-        if (analyticsConfig?.enabled) {
-          const retentionDays = analyticsConfig.retention_days ?? 90;
-          cleanupOldQueryLogs(retentionDays)
-            .then((deleted) => {
-              if (deleted > 0) {
-                console.log(
-                  `[analytics] Cleaned up ${deleted} query_log rows older than ${retentionDays} days`,
+          // Analytics cleanup — run at the same hour as reindex, once per day
+          const analyticsConfig = getServerConfig().analytics;
+          if (analyticsConfig?.enabled) {
+            const retentionDays = analyticsConfig.retention_days ?? 90;
+            cleanupOldQueryLogs(retentionDays)
+              .then((deleted) => {
+                if (deleted > 0) {
+                  console.log(
+                    `[analytics] Cleaned up ${deleted} query_log rows older than ${retentionDays} days`,
+                  );
+                }
+              })
+              .catch((err) => {
+                console.error(
+                  `[analytics] Cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
                 );
-              }
-            })
-            .catch((err) => {
-              console.error(
-                `[analytics] Cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            });
+              });
+          }
         }
       }
     }, 60_000);

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -14,6 +14,7 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { getProvider } from "./providers/index.js";
 import { IndexingPipeline } from "./pipeline.js";
 import { getIndexState, upsertIndexState } from "../db/queries.js";
+import { cleanupOldQueryLogs } from "../db/analytics.js";
 import { isFileSourceConfig } from "../types.js";
 import type { IndexState, IndexStatus, SourceConfig } from "../types.js";
 import type { ProviderOptions } from "./providers/types.js";
@@ -299,6 +300,25 @@ export class IndexingOrchestrator {
           this.lastReindexDate = today;
           console.log("[orchestrator] Starting nightly reindex");
           this.queueFullReindex();
+        }
+
+        // Analytics cleanup — run at the same hour as reindex, once per day
+        const analyticsConfig = getServerConfig().analytics;
+        if (analyticsConfig?.enabled) {
+          const retentionDays = analyticsConfig.retention_days ?? 90;
+          cleanupOldQueryLogs(retentionDays)
+            .then((deleted) => {
+              if (deleted > 0) {
+                console.log(
+                  `[analytics] Cleaned up ${deleted} query_log rows older than ${retentionDays} days`,
+                );
+              }
+            })
+            .catch((err) => {
+              console.error(
+                `[analytics] Cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
         }
       }
     }, 60_000);

--- a/src/indexing/providers/file.ts
+++ b/src/indexing/providers/file.ts
@@ -6,6 +6,7 @@ import path from "node:path";
 import { createHash } from "node:crypto";
 import { simpleGit, type SimpleGit } from "simple-git";
 import { matchesPatterns, hasLowSemanticValue } from "../utils.js";
+import { extractContent } from "../content-extractors.js";
 import { isFileSourceConfig } from "../../types.js";
 import type { SourceConfig, FileSourceConfig } from "../../types.js";
 import type {
@@ -17,6 +18,7 @@ import type {
 
 const DEFAULT_SKIP_DIRS = new Set(["node_modules", "dist", "build", ".git"]);
 const DEFAULT_MAX_FILE_SIZE = 102400; // 100KB
+const DEFAULT_DOCUMENT_MAX_FILE_SIZE = 10485760; // 10MB
 
 function repoNameFromUrl(repoUrl: string): string {
   const last = repoUrl.split("/").pop() ?? "";
@@ -51,7 +53,11 @@ export class FileDataProvider implements DataProvider {
       ...DEFAULT_SKIP_DIRS,
       ...(config.skip_dirs ?? []),
     ]);
-    this.maxFileSize = config.max_file_size ?? DEFAULT_MAX_FILE_SIZE;
+    this.maxFileSize =
+      config.max_file_size ??
+      (config.type === "document"
+        ? DEFAULT_DOCUMENT_MAX_FILE_SIZE
+        : DEFAULT_MAX_FILE_SIZE);
   }
 
   private isLocal(): boolean {
@@ -102,9 +108,12 @@ export class FileDataProvider implements DataProvider {
     for (const absPath of matchingFiles) {
       const relPath = path.relative(repoDir, absPath);
       try {
-        const content = await fs.promises.readFile(absPath, "utf-8");
+        const { content, metadata } = await extractContent(
+          absPath,
+          this.config.type,
+        );
         if (hasLowSemanticValue(content)) continue;
-        items.push({ id: relPath, content });
+        items.push({ id: relPath, content, metadata });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`${this.logPrefix} Failed to read ${relPath}: ${msg}`);
@@ -192,9 +201,12 @@ export class FileDataProvider implements DataProvider {
       try {
         const stat = await fs.promises.stat(absPath);
         if (stat.size > this.maxFileSize) continue;
-        const content = await fs.promises.readFile(absPath, "utf-8");
+        const { content, metadata } = await extractContent(
+          absPath,
+          this.config.type,
+        );
         if (hasLowSemanticValue(content)) continue;
-        items.push({ id: relPath, content });
+        items.push({ id: relPath, content, metadata });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`${this.logPrefix} Failed to read ${relPath}: ${msg}`);

--- a/src/indexing/providers/index.ts
+++ b/src/indexing/providers/index.ts
@@ -32,7 +32,7 @@ export type {
 // Register built-in providers
 import { FileDataProvider } from "./file.js";
 
-for (const type of ["markdown", "code", "raw-text", "html"]) {
+for (const type of ["markdown", "code", "raw-text", "html", "document"]) {
   registerProvider(
     type,
     (config, options) => new FileDataProvider(config, options),

--- a/src/mammoth.d.ts
+++ b/src/mammoth.d.ts
@@ -1,0 +1,11 @@
+// Type declarations for optional peer dependency mammoth
+declare module "mammoth" {
+  interface ExtractionResult {
+    value: string;
+    messages: Array<{ type: string; message: string }>;
+  }
+  const mammoth: {
+    extractRawText(options: { path: string }): Promise<ExtractionResult>;
+  };
+  export default mammoth;
+}

--- a/src/mcp/tools/knowledge.ts
+++ b/src/mcp/tools/knowledge.ts
@@ -7,6 +7,8 @@ import type {
   ChunkResult,
 } from "../../types.js";
 import { getFaqChunks, searchChunks } from "../../db/queries.js";
+import { logQuery } from "../../db/analytics.js";
+import { getServerConfig } from "../../config.js";
 
 /**
  * Format FAQ results in the standard QUESTION/ANSWER/SOURCE/CONFIDENCE format.
@@ -76,6 +78,7 @@ export function registerKnowledgeTool(
     async ({ query, limit, min_confidence }) => {
       const effectiveLimit = limit ?? toolConfig.default_limit;
       const effectiveConfidence = min_confidence ?? toolConfig.min_confidence;
+      const startMs = Date.now();
 
       try {
         if (!query || query.trim() === "") {
@@ -85,6 +88,28 @@ export function registerKnowledgeTool(
             effectiveConfidence,
             effectiveLimit,
           );
+
+          // Fire-and-forget analytics logging
+          const analyticsConfig = getServerConfig().analytics;
+          if (analyticsConfig?.enabled) {
+            logQuery(
+              {
+                tool_name: toolConfig.name,
+                query_text: "<browse>",
+                result_count: chunks.length,
+                top_score: null,
+                latency_ms: Date.now() - startMs,
+                source_name: toolConfig.sources.join(","),
+                session_id: null,
+              },
+              analyticsConfig.log_queries,
+            ).catch((err) => {
+              console.error(
+                `[analytics] Failed to log query: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
+          }
+
           return {
             content: [
               { type: "text" as const, text: formatFaqResults(chunks) },
@@ -128,6 +153,31 @@ export function registerKnowledgeTool(
                 similarity: result.similarity,
               });
             }
+          }
+
+          // Fire-and-forget analytics logging
+          const analyticsConfig = getServerConfig().analytics;
+          if (analyticsConfig?.enabled) {
+            const topScore =
+              mergedResults.length > 0
+                ? Math.max(...mergedResults.map((r) => r.similarity))
+                : null;
+            logQuery(
+              {
+                tool_name: toolConfig.name,
+                query_text: query,
+                result_count: mergedResults.length,
+                top_score: topScore,
+                latency_ms: Date.now() - startMs,
+                source_name: toolConfig.sources.join(","),
+                session_id: null,
+              },
+              analyticsConfig.log_queries,
+            ).catch((err) => {
+              console.error(
+                `[analytics] Failed to log query: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
           }
 
           return {

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -2,7 +2,11 @@ import { z } from "zod";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import type { EmbeddingProvider } from "../../indexing/embeddings.js";
 import type { SearchToolConfig, ChunkResult } from "../../types.js";
-import { searchChunks } from "../../db/queries.js";
+import {
+  searchChunks,
+  textSearchChunks,
+  hybridSearchChunks,
+} from "../../db/queries.js";
 
 function formatDocsResults(results: ChunkResult[]): string {
   if (results.length === 0) return "No results found.";
@@ -95,24 +99,57 @@ export function registerSearchTool(
     inputSchema,
     async ({ query, limit, min_score, version }) => {
       const effectiveLimit = limit ?? toolConfig.default_limit;
+      const searchMode = toolConfig.search_mode ?? "vector";
       try {
-        const embedding = await embeddingClient.embed(query);
-        const results = await searchChunks(
-          embedding,
-          effectiveLimit,
-          toolConfig.source,
-          version,
-        );
+        let results: ChunkResult[];
         const minScore = min_score ?? toolConfig.min_score;
-        const filtered =
-          minScore != null
-            ? results.filter((r) => r.similarity >= minScore)
-            : results;
+
+        switch (searchMode) {
+          case "keyword": {
+            results = await textSearchChunks(
+              query,
+              effectiveLimit,
+              toolConfig.source,
+            );
+            // ts_rank scores are not on the cosine similarity scale,
+            // so min_score filtering is not applied in keyword mode.
+            break;
+          }
+          case "hybrid": {
+            const embedding = await embeddingClient.embed(query);
+            // hybridSearchChunks applies min_score to vector candidates
+            // before RRF merge, preserving semantic quality floor.
+            results = await hybridSearchChunks(
+              embedding,
+              query,
+              effectiveLimit,
+              toolConfig.source,
+              version,
+              minScore,
+            );
+            break;
+          }
+          case "vector":
+          default: {
+            const embedding = await embeddingClient.embed(query);
+            results = await searchChunks(
+              embedding,
+              effectiveLimit,
+              toolConfig.source,
+              version,
+            );
+            if (minScore != null) {
+              results = results.filter((r) => r.similarity >= minScore);
+            }
+            break;
+          }
+        }
+
         return {
           content: [
             {
               type: "text" as const,
-              text: formatResults(filtered, toolConfig.result_format),
+              text: formatResults(results, toolConfig.result_format),
             },
           ],
         };

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -7,6 +7,8 @@ import {
   textSearchChunks,
   hybridSearchChunks,
 } from "../../db/queries.js";
+import { logQuery } from "../../db/analytics.js";
+import { getServerConfig } from "../../config.js";
 
 function formatDocsResults(results: ChunkResult[]): string {
   if (results.length === 0) return "No results found.";
@@ -100,6 +102,7 @@ export function registerSearchTool(
     async ({ query, limit, min_score, version }) => {
       const effectiveLimit = limit ?? toolConfig.default_limit;
       const searchMode = toolConfig.search_mode ?? "vector";
+      const startMs = Date.now();
       try {
         let results: ChunkResult[];
         const minScore = min_score ?? toolConfig.min_score;
@@ -144,6 +147,32 @@ export function registerSearchTool(
             }
             break;
           }
+        }
+
+        // Fire-and-forget analytics logging
+        const analyticsConfig = getServerConfig().analytics;
+        if (analyticsConfig?.enabled) {
+          const latencyMs = Date.now() - startMs;
+          const topScore =
+            results.length > 0
+              ? Math.max(...results.map((r) => r.similarity))
+              : null;
+          logQuery(
+            {
+              tool_name: toolConfig.name,
+              query_text: query,
+              result_count: results.length,
+              top_score: topScore,
+              latency_ms: latencyMs,
+              source_name: toolConfig.source,
+              session_id: null,
+            },
+            analyticsConfig.log_queries,
+          ).catch((err) => {
+            console.error(
+              `[analytics] Failed to log query: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
         }
 
         return {

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -110,6 +110,7 @@ export function registerSearchTool(
               query,
               effectiveLimit,
               toolConfig.source,
+              version,
             );
             // ts_rank scores are not on the cosine similarity scale,
             // so min_score filtering is not applied in keyword mode.

--- a/src/pdf-parse.d.ts
+++ b/src/pdf-parse.d.ts
@@ -1,0 +1,10 @@
+// Type declarations for optional peer dependency pdf-parse
+declare module "pdf-parse" {
+  interface PdfData {
+    text: string;
+    numpages: number;
+    info: Record<string, unknown>;
+  }
+  function pdfParse(buffer: Buffer): Promise<PdfData>;
+  export default pdfParse;
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,15 @@ import { WorkspaceManager } from "./workspace.js";
 import { generateLlmsTxt, generateLlmsFullTxt } from "./llms-txt.js";
 import { generateFaqTxt } from "./faq-txt.js";
 import { generateSkillMd } from "./skill-md.js";
+import {
+  getAnalyticsSummary,
+  getTopQueries,
+  getEmptyQueries,
+} from "./db/analytics.js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export interface ServerOptions {
   port?: number;
@@ -588,6 +597,102 @@ app.get(
     }
   },
 );
+
+// ---------------------------------------------------------------------------
+// Analytics API — protected by token auth
+// ---------------------------------------------------------------------------
+
+/**
+ * Analytics auth middleware — exported so tests can import and test the real
+ * code instead of reimplementing the logic in test doubles.
+ */
+export function analyticsAuth(
+  req: Request,
+  res: Response,
+  next: express.NextFunction,
+): void {
+  const serverCfg = getServerConfig();
+  const token =
+    serverCfg.analytics?.token || process.env.ANALYTICS_TOKEN;
+
+  if (!serverCfg.analytics?.enabled) {
+    res.status(404).json({ error: "Analytics not enabled" });
+    return;
+  }
+
+  if (!token) {
+    // No token configured = no auth required (but analytics must still be enabled)
+    next();
+    return;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({
+      error:
+        "Missing or invalid Authorization header. Use: Bearer <token>",
+    });
+    return;
+  }
+
+  const provided = authHeader.slice(7);
+  if (provided !== token) {
+    res.status(403).json({ error: "Invalid analytics token" });
+    return;
+  }
+
+  next();
+}
+
+app.get(
+  "/api/analytics/summary",
+  analyticsAuth,
+  async (_req: Request, res: Response) => {
+    try {
+      const summary = await getAnalyticsSummary();
+      res.json(summary);
+    } catch (err) {
+      console.error("[analytics] Summary query failed:", err);
+      res.status(500).json({ error: "Failed to fetch analytics summary" });
+    }
+  },
+);
+
+app.get(
+  "/api/analytics/queries",
+  analyticsAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const days = parseInt(req.query.days as string) || 7;
+      const limit = parseInt(req.query.limit as string) || 50;
+      const queries = await getTopQueries(days, Math.min(limit, 200));
+      res.json(queries);
+    } catch (err) {
+      console.error("[analytics] Top queries failed:", err);
+      res.status(500).json({ error: "Failed to fetch top queries" });
+    }
+  },
+);
+
+app.get(
+  "/api/analytics/empty-queries",
+  analyticsAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const days = parseInt(req.query.days as string) || 7;
+      const limit = parseInt(req.query.limit as string) || 50;
+      const queries = await getEmptyQueries(days, Math.min(limit, 200));
+      res.json(queries);
+    } catch (err) {
+      console.error("[analytics] Empty queries failed:", err);
+      res.status(500).json({ error: "Failed to fetch empty queries" });
+    }
+  },
+);
+
+app.get("/analytics", analyticsAuth, (_req: Request, res: Response) => {
+  res.sendFile(path.resolve(__dirname, "../docs/analytics.html"));
+});
 
 // ---------------------------------------------------------------------------
 // Startup

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,7 +33,7 @@ const BaseSourceFields = {
 // File-based source schema (markdown, code, raw-text, html) — unchanged fields from today
 export const FileSourceConfigSchema = z.object({
   ...BaseSourceFields,
-  type: z.enum(["markdown", "code", "raw-text", "html"]),
+  type: z.enum(["markdown", "code", "raw-text", "html", "document"]),
   repo: z.string().url().optional(),
   branch: z.string().optional(),
   path: z.string().min(1),
@@ -338,7 +338,7 @@ export type BashOptions = z.infer<typeof BashOptionsSchema>;
 
 // ── Source config type guards ────────────────────────────────────────────────
 
-const FILE_SOURCE_TYPES = new Set(["markdown", "code", "raw-text", "html"]);
+const FILE_SOURCE_TYPES = new Set(["markdown", "code", "raw-text", "html", "document"]);
 export function isFileSourceConfig(
   config: SourceConfig,
 ): config is FileSourceConfig {

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,6 +221,15 @@ export const WebhookConfigSchema = z.object({
   path_triggers: z.record(z.string(), z.array(z.string())),
 });
 
+// ── Analytics configuration schemas ──────────────────────────────────────────
+
+export const AnalyticsConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  log_queries: z.boolean().default(true),
+  token: z.string().min(1).optional(),
+  retention_days: z.number().int().positive().default(90),
+});
+
 // ── Top-level server configuration schema ─────────────────────────────────────
 
 export const ServerConfigSchema = z
@@ -236,6 +245,7 @@ export const ServerConfigSchema = z
     embedding: EmbeddingConfigSchema.optional(),
     indexing: IndexingConfigSchema.optional(),
     webhook: WebhookConfigSchema.optional(),
+    analytics: AnalyticsConfigSchema.optional(),
   })
   .superRefine((cfg, ctx) => {
     const hasRag = cfg.tools.some(
@@ -332,6 +342,7 @@ export type OllamaEmbeddingConfig = z.infer<
 export type LocalEmbeddingConfig = z.infer<typeof LocalEmbeddingConfigSchema>;
 export type IndexingConfig = z.infer<typeof IndexingConfigSchema>;
 export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
+export type AnalyticsConfig = z.infer<typeof AnalyticsConfigSchema>;
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
 export type BashCacheConfig = z.infer<typeof BashCacheConfigSchema>;
 export type BashOptions = z.infer<typeof BashOptionsSchema>;

--- a/src/types.ts
+++ b/src/types.ts
@@ -102,6 +102,7 @@ const SearchToolConfigObjectSchema = z.object({
   max_limit: z.number().int().positive(),
   result_format: z.enum(["docs", "code", "raw"]),
   min_score: z.number().min(0).max(1).optional(),
+  search_mode: z.enum(["vector", "keyword", "hybrid"]).default("vector"),
 });
 
 // SearchToolConfig type is inferred from the object schema directly.


### PR DESCRIPTION
## Summary

Combine semantic vector search with keyword search using Reciprocal Rank Fusion (RRF). Three modes: `vector` (default, unchanged), `keyword` (tsvector + ts_rank), `hybrid` (both merged via RRF).

- `tsvector` column + GIN index on chunks table (auto-populated via trigger on PostgreSQL, inline on PGlite)
- `search_mode: 'vector' | 'keyword' | 'hybrid'` per search tool (default: vector)
- Two-query + RRF merge (k=60) — indexes used properly, not a single full-table scan
- PGlite-safe: trigger DDL in try-catch, tsv always set inline in INSERT

## Stacked on
- PR #21 (v1.7.0 Local Embeddings)

## CR loop
- Round 1: 0 critical, 2 important (version filter on keyword leg, rrfMerge dedup) — both fixed
- Round 1 fixes applied, converged

## New tests: 82 (1844 total)

## Test plan
- [x] 1844 tests pass
- [x] Build clean
- [x] CR converged