### PR TITLE
v1.11.0: Analytics Dashboard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,23 +1,15 @@
 # @copilotkit/pathfinder
 
-## 1.10.0
+## 1.11.0
 
 ### Minor Changes
 
-- **Auto-Generate from URL**: New `pathfinder init --from <url>` command that crawls a documentation site and generates a working `pathfinder.yaml`. Three-tier discovery: sitemap.xml, robots.txt Sitemap directives, recursive link following
-- **Site Crawler**: Rate-limited crawler with retry/backoff for 429/5xx, page caching, SPA detection warnings, and robots.txt compliance
-- **Config Generator**: Auto-detects source type (HTML/markdown), derives base URL from common path prefix, detects content selectors, and supports GitHub/GitLab repo detection
-- **CLI Flags**: `--rate-limit <ms>`, `--max-pages <n>`, `--force` flags for controlling crawl behavior
-
-## 1.9.0
-
-### Minor Changes
-
-- **PDF/DOCX Ingestion**: New `document` source type for indexing PDF and DOCX files. Format detected from file extension, with page-break and section-aware chunking
-- **Content Extractors**: Dynamic import of `pdf-parse` (PDF) and `mammoth` (DOCX) as optional peer dependencies — only loaded when a `document` source is configured
-- **Document Chunker**: Intelligent splitting on page breaks (form feed), ALL CAPS section headers, numbered section headers, and paragraph boundaries with configurable overlap
-- **Scanned PDF Detection**: Warns when a multi-page PDF produces very little text, indicating a scanned document without a text layer
-- **10MB Default File Size**: Document sources default to 10MB max file size (vs 100KB for text sources)
+- **Analytics Dashboard**: Built-in query analytics with embedded Chart.js dashboard at `/analytics`. Track query volume, latency (avg + p95), empty result rates, top queries, and queries by source
+- **Query Logging**: Fire-and-forget instrumentation in search and knowledge tool handlers. Logs query text, result count, top similarity score, latency, source, and session ID
+- **Analytics REST API**: Three endpoints (`/api/analytics/summary`, `/queries`, `/empty-queries`) with Bearer token authentication via config or `ANALYTICS_TOKEN` env var
+- **Analytics Config**: New `analytics` section in pathfinder.yaml with `enabled`, `log_queries`, `token`, and `retention_days` fields. Fully optional and backwards compatible
+- **Auto-Cleanup**: Old query_log rows automatically pruned during nightly reindex cycle based on `retention_days` (default 90)
+- **PGlite Compatible**: p95 latency computed in application code (not SQL `percentile_cont`) for PGlite compatibility
 
 ## 1.8.0
 

--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Pathfinder indexes your GitHub repos — docs (Markdown, MDX, HTML) and source c
 
 - **[Semantic Search](https://pathfinder.copilotkit.dev/search)** — pgvector RAG with configurable chunk sizes, overlap, and score thresholds
 - **[Filesystem Exploration](https://pathfinder.copilotkit.dev/search)** — QuickJS WASM sandbox with session state, `qmd` semantic grep, `related` files
-- **[7 Source Types](https://pathfinder.copilotkit.dev/config)** — Markdown, code, raw-text, HTML, Slack, Discord, Notion — with pluggable chunker registry
+- **[8 Source Types](https://pathfinder.copilotkit.dev/config)** — Markdown, code, raw-text, HTML, document (PDF/DOCX), Slack, Discord, Notion — with pluggable chunker registry
 - **[Multiple Embedding Providers](https://pathfinder.copilotkit.dev/config)** — OpenAI, Ollama (local HTTP), or transformers.js (zero external deps, CPU-only)
 - **[Config-Driven](https://pathfinder.copilotkit.dev/config)** — Everything in one `pathfinder.yaml`: sources, tools, embedding, indexing, webhooks
 - **[Client Setup](https://pathfinder.copilotkit.dev/clients)** — Claude Desktop, Claude Code, Cursor, Codex, VS Code, any Streamable HTTP client

--- a/README.md
+++ b/README.md
@@ -72,12 +72,16 @@ Pathfinder indexes your GitHub repos — docs (Markdown, MDX, HTML) and source c
 - **[Auto-Generated Endpoints](https://pathfinder.copilotkit.dev/usage)** — `/llms.txt`, `/llms-full.txt`, `/faq.txt`, `/.well-known/skills/default/skill.md`
 - **[Webhook Reindexing](https://pathfinder.copilotkit.dev/deploy)** — GitHub push triggers incremental reindex
 - **[IP Rate Limiting](https://pathfinder.copilotkit.dev/config)** — Per-IP session caps and configurable TTL
+- **[Analytics](https://pathfinder.copilotkit.dev/analytics)** — Query logging, top queries, empty results, latency metrics at `/analytics`
 
 ## CLI
 
 ```bash
 # Scaffold config
 npx @copilotkit/pathfinder init
+
+# Auto-generate config from an existing docs site
+npx @copilotkit/pathfinder init --from <url>
 
 # Start server (uses PGlite if no DATABASE_URL)
 npx @copilotkit/pathfinder serve

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -1,0 +1,139 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Pathfinder Analytics</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4"></script>
+    <style>
+        * { box-sizing: border-box; margin: 0; padding: 0; }
+        body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; background: #0f172a; color: #e2e8f0; padding: 24px; }
+        h1 { font-size: 1.5rem; margin-bottom: 24px; }
+        .stats { display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 16px; margin-bottom: 32px; }
+        .stat-card { background: #1e293b; border-radius: 8px; padding: 16px; }
+        .stat-card .label { font-size: 0.75rem; text-transform: uppercase; color: #94a3b8; margin-bottom: 4px; }
+        .stat-card .value { font-size: 1.5rem; font-weight: 700; }
+        .chart-row { display: grid; grid-template-columns: 1fr 1fr; gap: 24px; margin-bottom: 32px; }
+        .chart-box { background: #1e293b; border-radius: 8px; padding: 16px; }
+        .chart-box h2 { font-size: 1rem; margin-bottom: 12px; }
+        table { width: 100%; border-collapse: collapse; background: #1e293b; border-radius: 8px; overflow: hidden; margin-bottom: 32px; }
+        th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid #334155; }
+        th { background: #0f172a; font-size: 0.75rem; text-transform: uppercase; color: #94a3b8; }
+        .empty { color: #f87171; }
+        .error { color: #f87171; padding: 24px; text-align: center; }
+        @media (max-width: 768px) { .chart-row { grid-template-columns: 1fr; } }
+    </style>
+</head>
+<body>
+    <h1>Pathfinder Analytics</h1>
+    <div id="error" class="error" style="display:none"></div>
+
+    <div class="stats" id="stats"></div>
+
+    <div class="chart-row">
+        <div class="chart-box">
+            <h2>Queries per Day (7d)</h2>
+            <canvas id="dailyChart"></canvas>
+        </div>
+        <div class="chart-box">
+            <h2>Queries by Source</h2>
+            <canvas id="sourceChart"></canvas>
+        </div>
+    </div>
+
+    <h2 style="margin-bottom: 12px;">Top Queries (7d)</h2>
+    <table id="topQueriesTable">
+        <thead><tr><th>Query</th><th>Count</th><th>Avg Results</th><th>Avg Score</th></tr></thead>
+        <tbody></tbody>
+    </table>
+
+    <h2 style="margin-bottom: 12px;">Empty Result Queries (7d) <span class="empty">&#x26a0;</span></h2>
+    <table id="emptyQueriesTable">
+        <thead><tr><th>Query</th><th>Tool</th><th>Source</th><th>Count</th><th>Last Seen</th></tr></thead>
+        <tbody></tbody>
+    </table>
+
+    <script>
+        const TOKEN = new URLSearchParams(window.location.search).get('token') || '';
+        const headers = TOKEN ? { 'Authorization': 'Bearer ' + TOKEN } : {};
+
+        async function fetchJson(url) {
+            var res = await fetch(url, { headers: headers });
+            if (!res.ok) {
+                var body = await res.json().catch(function() { return {}; });
+                throw new Error(body.error || 'HTTP ' + res.status);
+            }
+            return res.json();
+        }
+
+        async function load() {
+            try {
+                var results = await Promise.all([
+                    fetchJson('/api/analytics/summary'),
+                    fetchJson('/api/analytics/queries?days=7&limit=50'),
+                    fetchJson('/api/analytics/empty-queries?days=7&limit=50'),
+                ]);
+                var summary = results[0];
+                var topQueries = results[1];
+                var emptyQueries = results[2];
+
+                // Stats cards
+                document.getElementById('stats').innerHTML = [
+                    { label: 'Total Queries', value: summary.total_queries.toLocaleString() },
+                    { label: 'Queries (7d)', value: summary.total_queries_7d.toLocaleString() },
+                    { label: 'Empty Result Rate (7d)', value: (summary.empty_result_rate_7d * 100).toFixed(1) + '%' },
+                    { label: 'Avg Latency (7d)', value: summary.avg_latency_ms_7d + 'ms' },
+                    { label: 'P95 Latency (7d)', value: summary.p95_latency_ms_7d + 'ms' },
+                    { label: 'Empty Queries (7d)', value: summary.empty_result_count_7d.toLocaleString() },
+                ].map(function(s) { return '<div class="stat-card"><div class="label">' + s.label + '</div><div class="value">' + s.value + '</div></div>'; }).join('');
+
+                // Daily chart
+                new Chart(document.getElementById('dailyChart'), {
+                    type: 'bar',
+                    data: {
+                        labels: summary.queries_per_day_7d.map(function(d) { return d.day; }),
+                        datasets: [{ label: 'Queries', data: summary.queries_per_day_7d.map(function(d) { return d.count; }), backgroundColor: '#3b82f6' }],
+                    },
+                    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } },
+                });
+
+                // Source chart
+                if (summary.queries_by_source.length > 0) {
+                    new Chart(document.getElementById('sourceChart'), {
+                        type: 'doughnut',
+                        data: {
+                            labels: summary.queries_by_source.map(function(s) { return s.source_name; }),
+                            datasets: [{ data: summary.queries_by_source.map(function(s) { return s.count; }), backgroundColor: ['#3b82f6', '#10b981', '#f59e0b', '#ef4444', '#8b5cf6', '#ec4899'] }],
+                        },
+                        options: { responsive: true },
+                    });
+                }
+
+                // Top queries table
+                var topBody = document.querySelector('#topQueriesTable tbody');
+                topBody.innerHTML = topQueries.map(function(q) {
+                    return '<tr><td>' + esc(q.query_text) + '</td><td>' + q.count + '</td><td>' + q.avg_result_count.toFixed(1) + '</td><td>' + (q.avg_top_score != null ? q.avg_top_score.toFixed(2) : '-') + '</td></tr>';
+                }).join('') || '<tr><td colspan="4">No queries logged yet.</td></tr>';
+
+                // Empty queries table
+                var emptyBody = document.querySelector('#emptyQueriesTable tbody');
+                emptyBody.innerHTML = emptyQueries.map(function(q) {
+                    return '<tr class="empty"><td>' + esc(q.query_text) + '</td><td>' + esc(q.tool_name) + '</td><td>' + esc(q.source_name || '-') + '</td><td>' + q.count + '</td><td>' + new Date(q.last_seen).toLocaleString() + '</td></tr>';
+                }).join('') || '<tr><td colspan="5">No empty-result queries.</td></tr>';
+
+            } catch (err) {
+                document.getElementById('error').style.display = 'block';
+                document.getElementById('error').textContent = 'Failed to load analytics: ' + err.message;
+            }
+        }
+
+        function esc(s) {
+            var d = document.createElement('div');
+            d.textContent = s;
+            return d.innerHTML;
+        }
+
+        load();
+    </script>
+</body>
+</html>

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -235,6 +235,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
             <li><a href="#source-slack">Slack</a></li>
             <li><a href="#source-discord">Discord</a></li>
             <li><a href="#source-notion">Notion</a></li>
+            <li><a href="#source-document">Document</a></li>
             <li><a href="#tools">Tools</a></li>
             <li><a href="#tool-search">Search</a></li>
             <li><a href="#tool-bash">Bash</a></li>
@@ -243,6 +244,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
             <li><a href="#embedding">Embedding</a></li>
             <li><a href="#indexing">Indexing</a></li>
             <li><a href="#webhook">Webhook</a></li>
+            <li><a href="#analytics">Analytics</a></li>
         </ul>
     </div>
 
@@ -269,7 +271,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
     <div class="code-block"><span class="key">sources:</span>
   - <span class="key">name:</span> <span class="value">docs</span>                        <span class="comment"># Unique name, referenced by tools</span>
-    <span class="key">type:</span> <span class="value">markdown</span>                    <span class="comment"># markdown | code | raw-text | html | slack | discord | notion</span>
+    <span class="key">type:</span> <span class="value">markdown</span>                    <span class="comment"># markdown | code | raw-text | html | document | slack | discord | notion</span>
     <span class="key">repo:</span> <span class="value">https://github.com/org/repo.git</span>  <span class="comment"># Git repo URL (optional for local paths)</span>
     <span class="key">branch:</span> <span class="value">main</span>                      <span class="comment"># Git branch to track (default: default branch)</span>
     <span class="key">path:</span> <span class="value">docs/</span>                       <span class="comment"># Directory within the repo to index</span>
@@ -298,7 +300,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
       <span class="key">overlap_lines:</span> <span class="value">10</span>              <span class="comment"># Line overlap between chunks</span></div>
 
     <ul>
-        <li><strong>type</strong> — Determines chunking strategy. <code>markdown</code> splits on headings and uses token-based chunks. <code>code</code> splits on function boundaries and uses line-based chunks. <code>raw-text</code> treats content as plain text with token-based chunks. <code>html</code> parses HTML structure and extracts text content with token-based chunks.</li>
+        <li><strong>type</strong> — Determines chunking strategy. <code>markdown</code> splits on headings and uses token-based chunks. <code>code</code> splits on function boundaries and uses line-based chunks. <code>raw-text</code> treats content as plain text with token-based chunks. <code>html</code> parses HTML structure and extracts text content with token-based chunks. <code>document</code> extracts text from PDF and DOCX files with token-based chunks.</li>
         <li><strong>category</strong> — Optional tag applied to all chunks from this source. Sources with <code>category: faq</code> contribute to the <code>/faq.txt</code> endpoint and can be queried via knowledge tools.</li>
         <li><strong>repo</strong> — If provided, Pathfinder clones and updates from this repo. Omit for local directories.</li>
         <li><strong>version</strong> — Tags all indexed chunks with this version string. Used for version-filtered search queries.</li>
@@ -416,6 +418,28 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     <p>By default, Notion sources are indexed as documents and referenced by <code>search</code> tools. To also make them available via <code>knowledge</code> tools and the <code>/faq.txt</code> endpoint, add <code>category: faq</code> to the source config — useful for Notion databases structured as Q&amp;A or FAQ collections.</p>
 
     <p><em>Note: The <code>chunk</code> config is available on all source types. For Slack and Discord, the Q&amp;A chunker produces one chunk per Q&amp;A pair (chunk settings have no effect). For Notion, the markdown chunker respects <code>target_tokens</code> and <code>overlap_tokens</code>.</em></p>
+
+    <h3 id="source-document">Source type: document</h3>
+
+    <p>Index PDF and DOCX files. Requires optional peer dependencies: <code>npm install pdf-parse</code> for PDF support and <code>npm install mammoth</code> for DOCX support. Uses token-based chunks like markdown sources.</p>
+
+    <div class="code-block"><span class="key">sources:</span>
+  - <span class="key">name:</span> <span class="value">manuals</span>
+    <span class="key">type:</span> <span class="value">document</span>
+    <span class="key">path:</span> <span class="value">./documents</span>
+    <span class="key">file_patterns:</span>
+      - <span class="value">"**/*.pdf"</span>
+      - <span class="value">"**/*.docx"</span>
+    <span class="key">max_file_size:</span> <span class="value">10485760</span>              <span class="comment"># 10MB default limit</span>
+    <span class="key">chunk:</span>
+      <span class="key">target_tokens:</span> <span class="value">600</span>
+      <span class="key">overlap_tokens:</span> <span class="value">50</span></div>
+
+    <ul>
+        <li><strong>PDF support</strong> — Requires <code>pdf-parse</code> peer dependency. Text is extracted page-by-page. Scanned PDFs (image-only pages with no extractable text) are detected and skipped with a warning.</li>
+        <li><strong>DOCX support</strong> — Requires <code>mammoth</code> peer dependency. Document content is converted to plain text for chunking.</li>
+        <li><strong>max_file_size</strong> — Defaults to 10MB (10485760 bytes) for document sources. Large files are skipped with a warning.</li>
+    </ul>
 
     <h3>url_derivation example</h3>
 
@@ -603,6 +627,25 @@ https://docs.example.com/getting-started</div>
     <span class="key">docs:</span> [<span class="value">"docs/"</span>]</div>
 
     <p>Point a GitHub webhook at <code>https://your-server/webhooks/github</code> with the <code>push</code> event. Set <code>GITHUB_WEBHOOK_SECRET</code> to match the webhook secret.</p>
+
+    <h2 id="analytics">analytics</h2>
+
+    <p>Optional. Enables query logging and the built-in analytics dashboard at <code>/analytics</code>.</p>
+
+    <div class="code-block"><span class="key">analytics:</span>
+  <span class="key">enabled:</span> <span class="value">false</span>                       <span class="comment"># Enable analytics (default: false)</span>
+  <span class="key">log_queries:</span> <span class="value">true</span>                    <span class="comment"># Log all search queries (default: true)</span>
+  <span class="key">token:</span> <span class="value">${ANALYTICS_TOKEN}</span>             <span class="comment"># Bearer token for the /api/analytics endpoints</span>
+  <span class="key">retention_days:</span> <span class="value">90</span>                  <span class="comment"># Days to retain analytics data (default: 90)</span></div>
+
+    <ul>
+        <li><strong>enabled</strong> — When <code>true</code>, Pathfinder logs queries and serves the analytics dashboard at <code>/analytics</code>. Default <code>false</code>.</li>
+        <li><strong>log_queries</strong> — When <code>true</code>, all search queries are logged with latency and result counts. Default <code>true</code> (when analytics is enabled).</li>
+        <li><strong>token</strong> — Bearer token for authenticating requests to <code>/api/analytics/*</code> endpoints. Use the <code>ANALYTICS_TOKEN</code> environment variable. Required when analytics is enabled.</li>
+        <li><strong>retention_days</strong> — How long to keep analytics data before automatic cleanup. Default 90 days.</li>
+    </ul>
+
+    <p>The analytics dashboard provides top queries, empty result tracking, and latency metrics. API endpoints: <code>/api/analytics/summary</code>, <code>/api/analytics/queries</code>, <code>/api/analytics/empty-queries</code>.</p>
 
     <h2>Example Configs</h2>
 

--- a/docs/deploy/index.html
+++ b/docs/deploy/index.html
@@ -382,6 +382,7 @@ server {
             <tr><td><code>NODE_ENV</code></td><td>No</td><td><code>development</code></td><td>Set to <code>production</code> for deployed instances</td></tr>
             <tr><td><code>LOG_LEVEL</code></td><td>No</td><td><code>info</code></td><td>Logging verbosity (debug, info, warn, error)</td></tr>
             <tr><td><code>CLONE_DIR</code></td><td>No</td><td><code>/tmp/mcp-repos</code></td><td>Directory for git repo clones</td></tr>
+            <tr><td><code>ANALYTICS_TOKEN</code></td><td>When analytics enabled</td><td>-</td><td>Bearer token for authenticating <code>/api/analytics/*</code> endpoints</td></tr>
         </tbody>
     </table>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -429,6 +429,30 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
                 <td><span class="no">&#10007;</span></td>
             </tr>
             <tr>
+                <td>Local embeddings (no API key)</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="yes">&#10003;</span> <span class="partial">uses local models</span></td>
+            </tr>
+            <tr>
+                <td>Hybrid search (vector + keyword)</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+            </tr>
+            <tr>
+                <td>PDF/DOCX support</td>
+                <td class="col-pathfinder"><span class="yes">&#10003;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="no">&#10007;</span></td>
+                <td><span class="partial">&#10003; partial — PDF via ingest</span></td>
+            </tr>
+            <tr>
                 <td>Hosted option</td>
                 <td class="col-pathfinder"><span class="no">&#10007;</span></td>
                 <td><span class="yes">&#10003;</span></td>

--- a/docs/migrate-from-gitbook/index.html
+++ b/docs/migrate-from-gitbook/index.html
@@ -438,8 +438,8 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
         <p>GitBook's browser-based editor is a key feature. Pathfinder reads your existing Markdown/HTML files &mdash; you edit them however you already do (VS Code, Obsidian, vim, etc.).</p>
     </div>
     <div class="gap-card">
-        <h4>No built-in analytics</h4>
-        <p>Telemetry data (file access patterns, search queries) goes to the database but there's no built-in visualization yet. Query it directly or build your own dashboard.</p>
+        <h4>Analytics dashboard included</h4>
+        <p>Pathfinder includes a built-in analytics dashboard at <code>/analytics</code> with query logging, top queries, empty result tracking, and latency metrics. Enable it with <code>analytics.enabled: true</code> in your config.</p>
     </div>
 
     <a href="/" class="back-link">&larr; Back to Pathfinder</a>

--- a/docs/migrate-from-local-rag/index.html
+++ b/docs/migrate-from-local-rag/index.html
@@ -263,7 +263,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     </div>
     <div class="stay-card">
         <h4>Fully offline operation</h4>
-        <p>mcp-local-rag uses local embedding models — no API keys, no network calls. Pathfinder requires an OpenAI API key for embeddings (local embedding support is on the roadmap).</p>
+        <p>mcp-local-rag uses local embedding models — no API keys, no network calls. Pathfinder supports local embeddings via Ollama and @xenova/transformers — no API keys needed — but requires a running server process.</p>
     </div>
     <div class="stay-card">
         <h4>Zero dependencies</h4>
@@ -406,8 +406,8 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     <p>Pathfinder is more capable, but it's also more involved. Here's what changes:</p>
 
     <div class="gap-card">
-        <h4>Requires an OpenAI API key for embeddings</h4>
-        <p>mcp-local-rag uses local embedding models with zero API dependencies. Pathfinder uses OpenAI embeddings by default. Local embedding support is on the roadmap. If you only use bash tools (no semantic search), you can skip the API key entirely.</p>
+        <h4>OpenAI embeddings are the default, but local options are available</h4>
+        <p>mcp-local-rag uses local embedding models with zero API dependencies. Pathfinder uses OpenAI embeddings by default, but also supports Ollama and @xenova/transformers for fully local, API-key-free embeddings. If you only use bash tools (no semantic search), you can skip the embedding provider entirely.</p>
     </div>
     <div class="gap-card">
         <h4>Server process stays running</h4>

--- a/docs/migrate-from-mintlify/index.html
+++ b/docs/migrate-from-mintlify/index.html
@@ -444,8 +444,8 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
         <p>You run the infrastructure. Docker Compose makes this straightforward, but there's no managed cloud offering (yet). You need PostgreSQL and optionally an OpenAI API key.</p>
     </div>
     <div class="gap-card">
-        <h4>No analytics dashboard</h4>
-        <p>Telemetry data (file access patterns, grep misses) goes to the database but there's no built-in visualization. Query it directly or build your own dashboard.</p>
+        <h4>Analytics dashboard included</h4>
+        <p>Pathfinder includes a built-in analytics dashboard at <code>/analytics</code> with query logging, top queries, empty result tracking, and latency metrics. Enable it with <code>analytics.enabled: true</code> in your config.</p>
     </div>
 
     <a href="/" class="back-link">&larr; Back to Pathfinder</a>

--- a/docs/usage/index.html
+++ b/docs/usage/index.html
@@ -285,6 +285,17 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
         <li><strong><code>/.well-known/skills/default/skill.md</code></strong> — A dynamic agent capability description that reflects your current tool configuration. Agents can read this to understand what Pathfinder can do.</li>
         <li><strong><code>/faq.txt</code></strong> — Q&amp;A pairs from FAQ-category sources (Slack threads, Discord forums), filtered by confidence. Only generated when sources with <code>category: faq</code> are configured.</li>
         <li><strong><code>/health</code></strong> — JSON health check with uptime, indexing status, and chunk counts per source.</li>
+        <li><strong><code>/analytics</code></strong> — Built-in analytics dashboard with query logging, top queries, empty result tracking, and latency metrics. Requires <code>analytics.enabled: true</code> in config.</li>
+    </ul>
+
+    <h3>Analytics API Endpoints</h3>
+
+    <p>When analytics is enabled, the following API endpoints are available (authenticated via <code>ANALYTICS_TOKEN</code> bearer token):</p>
+
+    <ul>
+        <li><strong><code>/api/analytics/summary</code></strong> — Overview of query volume, average latency, and top queries.</li>
+        <li><strong><code>/api/analytics/queries</code></strong> — Paginated list of all logged search queries with timestamps, latency, and result counts.</li>
+        <li><strong><code>/api/analytics/empty-queries</code></strong> — Queries that returned zero results, useful for identifying content gaps.</li>
     </ul>
 
     <p>All HTTP responses include <code>Link</code> headers pointing to <code>/llms.txt</code> and, when available, <code>&lt;/faq.txt&gt;; rel="faq"</code>, so clients can discover these endpoints automatically.</p>
@@ -293,6 +304,13 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
 
     <ul>
         <li><strong><code>pathfinder init</code></strong> — Scaffold a new <code>pathfinder.yaml</code> config file interactively.</li>
+        <li><strong><code>pathfinder init --from &lt;url&gt;</code></strong> — Crawl a documentation site and auto-generate a <code>pathfinder.yaml</code> config. Options:
+            <ul>
+                <li><code>--rate-limit &lt;ms&gt;</code> — Milliseconds between requests (default: 500)</li>
+                <li><code>--max-pages &lt;n&gt;</code> — Maximum pages to crawl (default: 500)</li>
+                <li><code>--force</code> — Overwrite existing <code>pathfinder.yaml</code></li>
+            </ul>
+        </li>
         <li><strong><code>pathfinder serve</code></strong> — Start the MCP server. Uses PGlite if no <code>DATABASE_URL</code> is set. Options:
             <ul>
                 <li><code>-p, --port &lt;number&gt;</code> — Override the default port (3001)</li>

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.10.0",
-    "description": "The knowledge server for AI agents — index docs, code, PDF, DOCX, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
+    "version": "1.11.0",
+    "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
     "type": "module",
     "repository": {
         "type": "git",
@@ -67,18 +67,10 @@
         "zod": "^3.23.8"
     },
     "peerDependencies": {
-        "@xenova/transformers": "^2.17.0",
-        "pdf-parse": "^1.1.1",
-        "mammoth": "^1.8.0"
+        "@xenova/transformers": "^2.17.0"
     },
     "peerDependenciesMeta": {
         "@xenova/transformers": {
-            "optional": true
-        },
-        "pdf-parse": {
-            "optional": true
-        },
-        "mammoth": {
             "optional": true
         }
     },

--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -94,3 +94,9 @@ indexing:
   auto_reindex: true
   reindex_hour_utc: 3
   stale_threshold_hours: 24
+
+# ── Analytics (query logging and dashboard) ──
+# analytics:
+#   enabled: true
+#   log_queries: true
+#   retention_days: 90

--- a/plugin/SKILL.md
+++ b/plugin/SKILL.md
@@ -19,6 +19,8 @@ Finds content by meaning, not just keywords. Use this when you need to understan
 - "Error handling middleware"
 - "Database migration workflow"
 
+> **Note:** Some search tools may be configured for hybrid mode (combining vector and keyword search) or keyword-only mode. The tool handles this internally — always provide a natural language query regardless of mode.
+
 ### explore (bash/filesystem)
 
 A sandboxed bash shell for browsing the indexed filesystem. Files are read-only (except `/workspace/`). Use this for precise lookups, structural exploration, and when you need exact file contents.

--- a/src/__tests__/analytics-config.test.ts
+++ b/src/__tests__/analytics-config.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect } from "vitest";
+import { AnalyticsConfigSchema, ServerConfigSchema } from "../types.js";
+
+describe("AnalyticsConfigSchema", () => {
+  it("accepts a fully specified config", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      enabled: true,
+      log_queries: true,
+      token: "secret-token-123",
+      retention_days: 30,
+    });
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      enabled: true,
+      log_queries: true,
+      token: "secret-token-123",
+      retention_days: 30,
+    });
+  });
+
+  it("applies defaults for missing optional fields", () => {
+    const result = AnalyticsConfigSchema.safeParse({});
+    expect(result.success).toBe(true);
+    expect(result.data).toEqual({
+      enabled: false,
+      log_queries: true,
+      retention_days: 90,
+    });
+  });
+
+  it("rejects empty token string", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      enabled: true,
+      token: "",
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-positive retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 0,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects non-integer retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 30.5,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects negative retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: -1,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("rejects retention_days of fractional value", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 30.7,
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it("accepts very large retention_days", () => {
+    const result = AnalyticsConfigSchema.safeParse({
+      retention_days: 3650, // 10 years
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe("ServerConfigSchema with analytics", () => {
+  const minimalServerConfig = {
+    server: { name: "test", version: "1.0.0" },
+    sources: [
+      {
+        name: "s",
+        type: "markdown",
+        path: ".",
+        file_patterns: ["**/*.md"],
+        chunk: {},
+      },
+    ],
+    tools: [
+      { name: "bash", type: "bash", description: "bash", sources: ["s"] },
+    ],
+  };
+
+  it("accepts config without analytics section", () => {
+    const result = ServerConfigSchema.safeParse(minimalServerConfig);
+    expect(result.success).toBe(true);
+    expect(result.data!.analytics).toBeUndefined();
+  });
+
+  it("accepts config with analytics section", () => {
+    const result = ServerConfigSchema.safeParse({
+      ...minimalServerConfig,
+      analytics: { enabled: true, token: "abc123" },
+    });
+    expect(result.success).toBe(true);
+    expect(result.data!.analytics?.enabled).toBe(true);
+    expect(result.data!.analytics?.token).toBe("abc123");
+  });
+});

--- a/src/__tests__/analytics-endpoints.test.ts
+++ b/src/__tests__/analytics-endpoints.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// These tests verify the auth middleware logic and endpoint parameter parsing.
+// They mock the analytics DB functions and test the Express handler logic.
+
+const mockGetAnalyticsSummary = vi.fn();
+const mockGetTopQueries = vi.fn();
+const mockGetEmptyQueries = vi.fn();
+
+vi.mock("../db/analytics.js", () => ({
+  getAnalyticsSummary: (...args: unknown[]) =>
+    mockGetAnalyticsSummary(...args),
+  getTopQueries: (...args: unknown[]) => mockGetTopQueries(...args),
+  getEmptyQueries: (...args: unknown[]) => mockGetEmptyQueries(...args),
+}));
+
+// Mock getServerConfig to control analytics config in tests
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn(),
+  getConfig: vi.fn().mockReturnValue({
+    port: 3001,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+  }),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import { getServerConfig } from "../config.js";
+import { analyticsAuth } from "../server.js";
+
+const mockGetServerConfigFn = vi.mocked(getServerConfig);
+
+function mockRes() {
+  const json = vi.fn();
+  const status = vi.fn().mockReturnValue({ json });
+  return { status, json };
+}
+
+describe("analyticsAuth middleware", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    delete process.env.ANALYTICS_TOKEN;
+  });
+
+  afterEach(() => {
+    delete process.env.ANALYTICS_TOKEN;
+  });
+
+  it("returns 404 when analytics not enabled", () => {
+    mockGetServerConfigFn.mockReturnValue({} as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth({ headers: {} } as never, res as never, next);
+
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when enabled and no token configured", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth({ headers: {} } as never, res as never, next);
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("returns 401 when token required but no auth header", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth({ headers: {} } as never, res as never, next);
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 when token does not match", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer wrong" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("calls next when token matches", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer secret" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("returns 401 for malformed auth header (no space after Bearer)", () => {
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true, token: "secret" },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearersecret" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it("uses ANALYTICS_TOKEN env var as fallback when config has no token", () => {
+    process.env.ANALYTICS_TOKEN = "env-secret";
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer env-secret" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(next).toHaveBeenCalled();
+  });
+
+  it("rejects when ANALYTICS_TOKEN env var is set but wrong token provided", () => {
+    process.env.ANALYTICS_TOKEN = "env-secret";
+    mockGetServerConfigFn.mockReturnValue({
+      analytics: { enabled: true },
+    } as never);
+    const res = mockRes();
+    const next = vi.fn();
+
+    analyticsAuth(
+      { headers: { authorization: "Bearer wrong" } } as never,
+      res as never,
+      next,
+    );
+
+    expect(res.status).toHaveBeenCalledWith(403);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Endpoint parameter parsing
+// ---------------------------------------------------------------------------
+
+describe("endpoint parameter parsing", () => {
+  it("/api/analytics/queries with non-numeric days defaults to 7", () => {
+    const days = parseInt("abc") || 7;
+    const limit = parseInt("") || 50;
+    expect(days).toBe(7);
+    expect(limit).toBe(50);
+  });
+
+  it("/api/analytics/queries caps limit at 200", () => {
+    const limit = Math.min(parseInt("999"), 200);
+    expect(limit).toBe(200);
+  });
+});

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -1,0 +1,386 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the pool before importing analytics module
+const mockQuery = vi.fn();
+vi.mock("../db/client.js", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+import {
+  logQuery,
+  getAnalyticsSummary,
+  getTopQueries,
+  getEmptyQueries,
+  cleanupOldQueryLogs,
+} from "../db/analytics.js";
+import type { QueryLogEntry } from "../db/analytics.js";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// ---------------------------------------------------------------------------
+// logQuery
+// ---------------------------------------------------------------------------
+
+describe("logQuery", () => {
+  const baseEntry: QueryLogEntry = {
+    tool_name: "search-docs",
+    query_text: "how to install",
+    result_count: 5,
+    top_score: 0.92,
+    latency_ms: 42,
+    source_name: "docs",
+    session_id: "sess-123",
+  };
+
+  it("inserts a row with all fields", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await logQuery(baseEntry);
+
+    expect(mockQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("INSERT INTO query_log");
+    expect(params).toEqual([
+      "search-docs",
+      "how to install",
+      5,
+      0.92,
+      42,
+      "docs",
+      "sess-123",
+    ]);
+  });
+
+  it("redacts query_text when logQueryText is false", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await logQuery(baseEntry, false);
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[1]).toBe("<redacted>");
+  });
+
+  it("passes null for nullable fields", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await logQuery({
+      ...baseEntry,
+      top_score: null,
+      source_name: null,
+      session_id: null,
+    });
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[3]).toBeNull(); // top_score
+    expect(params[5]).toBeNull(); // source_name
+    expect(params[6]).toBeNull(); // session_id
+  });
+});
+
+// ---------------------------------------------------------------------------
+// logQuery error handling
+// ---------------------------------------------------------------------------
+
+describe("logQuery error handling", () => {
+  it("propagates DB connection error to caller", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("connection refused"));
+    await expect(
+      logQuery({
+        tool_name: "search",
+        query_text: "test",
+        result_count: 0,
+        top_score: null,
+        latency_ms: 10,
+        source_name: null,
+        session_id: null,
+      }),
+    ).rejects.toThrow("connection refused");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getAnalyticsSummary
+// ---------------------------------------------------------------------------
+
+describe("getAnalyticsSummary", () => {
+  it("returns aggregated summary data", async () => {
+    // Mock order: total, summary7d, latency rows, bySource, perDay
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 1000 }] }) // total
+      .mockResolvedValueOnce({
+        rows: [{ total: 200, empty: 10, avg_latency: 45 }],
+      }) // 7d summary
+      .mockResolvedValueOnce({
+        rows: Array.from({ length: 200 }, (_, i) => ({
+          latency_ms: i + 1,
+        })),
+      }) // latency rows for p95 computation
+      .mockResolvedValueOnce({
+        rows: [{ source_name: "docs", count: 150 }],
+      }) // by source
+      .mockResolvedValueOnce({
+        rows: [
+          { day: "2026-04-10", count: 30 },
+          { day: "2026-04-11", count: 25 },
+        ],
+      }); // per day
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.total_queries).toBe(1000);
+    expect(result.total_queries_7d).toBe(200);
+    expect(result.empty_result_count_7d).toBe(10);
+    expect(result.empty_result_rate_7d).toBeCloseTo(0.05);
+    expect(result.avg_latency_ms_7d).toBe(45);
+    // p95 of [1..200] sorted: index = floor(200 * 0.95) = 190, value = 191
+    expect(result.p95_latency_ms_7d).toBe(191);
+    expect(result.queries_by_source).toEqual([
+      { source_name: "docs", count: 150 },
+    ]);
+    expect(result.queries_per_day_7d).toHaveLength(2);
+  });
+
+  it("handles zero queries gracefully", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 0, empty: 0, avg_latency: 0 }],
+      })
+      .mockResolvedValueOnce({ rows: [] }) // empty latency rows
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.total_queries).toBe(0);
+    expect(result.empty_result_rate_7d).toBe(0);
+    expect(result.p95_latency_ms_7d).toBe(0);
+    expect(result.queries_by_source).toEqual([]);
+    expect(result.queries_per_day_7d).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// p95 computation edge cases (tested indirectly via getAnalyticsSummary)
+// ---------------------------------------------------------------------------
+
+describe("p95 computation edge cases", () => {
+  it("p95 of single latency value returns that value", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 1 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 1, empty: 0, avg_latency: 42 }],
+      })
+      .mockResolvedValueOnce({ rows: [{ latency_ms: 42 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+    expect(result.p95_latency_ms_7d).toBe(42);
+  });
+
+  it("p95 of all identical values returns that value", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 100 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 100, empty: 0, avg_latency: 50 }],
+      })
+      .mockResolvedValueOnce({
+        rows: Array.from({ length: 100 }, () => ({ latency_ms: 50 })),
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+    expect(result.p95_latency_ms_7d).toBe(50);
+  });
+
+  it("p95 of two values returns the higher one", async () => {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 2 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 2, empty: 0, avg_latency: 75 }],
+      })
+      .mockResolvedValueOnce({
+        rows: [{ latency_ms: 50 }, { latency_ms: 100 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await getAnalyticsSummary();
+    // floor(2 * 0.95) = 1, sorted[1] = 100
+    expect(result.p95_latency_ms_7d).toBe(100);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTopQueries
+// ---------------------------------------------------------------------------
+
+describe("getTopQueries", () => {
+  it("returns top queries with frequency and avg stats", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: "install guide",
+          count: 42,
+          avg_result_count: "3.5",
+          avg_top_score: "0.88",
+        },
+        {
+          query_text: "api reference",
+          count: 30,
+          avg_result_count: "5.0",
+          avg_top_score: null,
+        },
+      ],
+    });
+
+    const result = await getTopQueries(7, 50);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].query_text).toBe("install guide");
+    expect(result[0].count).toBe(42);
+    expect(result[0].avg_result_count).toBeCloseTo(3.5);
+    expect(result[0].avg_top_score).toBeCloseTo(0.88);
+    expect(result[1].avg_top_score).toBeNull();
+  });
+
+  it("passes days and limit to query params", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getTopQueries(30, 10);
+
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params).toEqual([30, 10]);
+  });
+
+  it("excludes redacted queries", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getTopQueries();
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("query_text != '<redacted>'");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getTopQueries edge cases
+// ---------------------------------------------------------------------------
+
+describe("getTopQueries edge cases", () => {
+  it("handles days=0 gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getTopQueries(0, 50);
+    expect(result).toEqual([]);
+    const [, params] = mockQuery.mock.calls[0];
+    expect(params[0]).toBe(0);
+  });
+
+  it("handles limit=0 gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getTopQueries(7, 0);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEmptyQueries
+// ---------------------------------------------------------------------------
+
+describe("getEmptyQueries", () => {
+  it("returns empty-result queries grouped by text+tool+source", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: "nonexistent thing",
+          tool_name: "search-docs",
+          source_name: "docs",
+          count: 15,
+          last_seen: "2026-04-11T10:00:00Z",
+        },
+      ],
+    });
+
+    const result = await getEmptyQueries(7, 50);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].query_text).toBe("nonexistent thing");
+    expect(result[0].count).toBe(15);
+    expect(result[0].source_name).toBe("docs");
+  });
+
+  it("filters on result_count = 0", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getEmptyQueries();
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("result_count = 0");
+  });
+
+  it("returns null for missing source_name", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          query_text: "q",
+          tool_name: "t",
+          source_name: null,
+          count: 1,
+          last_seen: "2026-04-11",
+        },
+      ],
+    });
+
+    const result = await getEmptyQueries();
+    expect(result[0].source_name).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEmptyQueries edge cases
+// ---------------------------------------------------------------------------
+
+describe("getEmptyQueries edge cases", () => {
+  it("handles limit=0 gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const result = await getEmptyQueries(7, 0);
+    expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOldQueryLogs
+// ---------------------------------------------------------------------------
+
+describe("cleanupOldQueryLogs", () => {
+  it("deletes rows older than retention period and returns count", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 150 });
+    const deleted = await cleanupOldQueryLogs(90);
+    expect(deleted).toBe(150);
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("DELETE FROM query_log");
+    expect(params).toEqual([90]);
+  });
+
+  it("returns 0 when no rows match", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: 0 });
+    const deleted = await cleanupOldQueryLogs(90);
+    expect(deleted).toBe(0);
+  });
+
+  it("handles null rowCount gracefully", async () => {
+    mockQuery.mockResolvedValueOnce({ rowCount: null });
+    const deleted = await cleanupOldQueryLogs(90);
+    expect(deleted).toBe(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// cleanupOldQueryLogs error handling
+// ---------------------------------------------------------------------------
+
+describe("cleanupOldQueryLogs error handling", () => {
+  it("propagates DB error to caller", async () => {
+    mockQuery.mockRejectedValueOnce(new Error("disk full"));
+    await expect(cleanupOldQueryLogs(90)).rejects.toThrow("disk full");
+  });
+});

--- a/src/__tests__/config-generator.test.ts
+++ b/src/__tests__/config-generator.test.ts
@@ -192,7 +192,7 @@ describe('generateConfig edge cases', () => {
         expect(config.sources[0].repo).toContain('gitlab.com');
     });
 
-    it('wires detected content_selector into source config', () => {
+    it('does not include content_selector in config (emitted as YAML comment instead)', () => {
         const crawlResult: CrawlResult = {
             pages: [
                 { url: 'https://docs.example.com/page', html: '<html><body><main><h1>Title</h1><p>Content</p></main></body></html>', contentType: 'text/html', textLength: 200 },
@@ -204,8 +204,25 @@ describe('generateConfig edge cases', () => {
         };
 
         const config = generateConfig(crawlResult, 'https://docs.example.com');
-        // Fix I2: detectContentSelector should find <main> and include it
-        expect((config.sources[0] as any).content_selector).toBe('main');
+        // content_selector must NOT be in the config object (would fail Zod validation)
+        expect((config.sources[0] as any).content_selector).toBeUndefined();
+    });
+
+    it('emits content_selector as YAML comment when detected', async () => {
+        const { generateConfigYaml } = await import('../config-generator.js');
+
+        const crawlResult: CrawlResult = {
+            pages: [
+                { url: 'https://docs.example.com/page', html: '<html><body><main><h1>Title</h1><p>Content</p></main></body></html>', contentType: 'text/html', textLength: 200 },
+            ],
+            discoveryMethod: 'sitemap',
+            baseUrl: 'https://docs.example.com',
+            warnings: [],
+            failedUrls: [],
+        };
+
+        const yaml = generateConfigYaml(crawlResult, 'https://docs.example.com');
+        expect(yaml).toContain('# content_selector: "main"');
     });
 });
 

--- a/src/__tests__/knowledge-analytics.test.ts
+++ b/src/__tests__/knowledge-analytics.test.ts
@@ -1,0 +1,118 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { KnowledgeToolConfig } from "../types.js";
+
+vi.mock("../db/queries.js", () => ({
+  getFaqChunks: vi.fn(),
+  searchChunks: vi.fn(),
+}));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn(),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn(),
+}));
+
+import { registerKnowledgeTool } from "../mcp/tools/knowledge.js";
+import { getFaqChunks, searchChunks } from "../db/queries.js";
+import { logQuery } from "../db/analytics.js";
+import { getServerConfig } from "../config.js";
+
+const mockGetFaqChunks = vi.mocked(getFaqChunks);
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockLogQuery = vi.mocked(logQuery);
+const mockGetServerConfig = vi.mocked(getServerConfig);
+const mockEmbed = vi.fn();
+
+const toolConfig: KnowledgeToolConfig = {
+  name: "faq",
+  type: "knowledge",
+  description: "FAQ",
+  sources: ["slack-faq"],
+  min_confidence: 0.7,
+  default_limit: 20,
+  max_limit: 100,
+};
+
+describe("knowledge tool analytics instrumentation", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "test", version: "1.0.0" });
+    registerKnowledgeTool(
+      server as never,
+      { embed: mockEmbed } as never,
+      toolConfig,
+    );
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    client = new Client({ name: "tc", version: "1.0.0" });
+    await client.connect(ct);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("logs browse-mode query when analytics enabled", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockGetFaqChunks.mockResolvedValueOnce([]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({ name: "faq", arguments: {} });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.query_text).toBe("<browse>");
+    expect(entry.tool_name).toBe("faq");
+  });
+
+  it("logs search-mode query with actual query text", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+    mockGetFaqChunks.mockResolvedValueOnce([]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "faq",
+      arguments: { query: "how to deploy" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.query_text).toBe("how to deploy");
+  });
+
+  it("does not log when analytics disabled", async () => {
+    mockGetServerConfig.mockReturnValue({} as never);
+    mockGetFaqChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({ name: "faq", arguments: {} });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/knowledge-mcp.test.ts
+++ b/src/__tests__/knowledge-mcp.test.ts
@@ -20,6 +20,12 @@ vi.mock("../db/queries.js", () => ({
   getFaqChunks: vi.fn(),
   searchChunks: vi.fn(),
 }));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({}),
+}));
 
 import { registerKnowledgeTool } from "../mcp/tools/knowledge.js";
 import { getFaqChunks, searchChunks } from "../db/queries.js";

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -171,4 +171,35 @@ describe("generatePostSchemaMigration", () => {
       "CREATE INDEX IF NOT EXISTS idx_chunks_version ON chunks (version)",
     );
   });
+
+  it("creates query_log table", () => {
+    const sql = generatePostSchemaMigration();
+    expect(sql).toContain("CREATE TABLE IF NOT EXISTS query_log");
+  });
+
+  it("includes query_log required columns", () => {
+    const sql = generatePostSchemaMigration();
+    for (const col of [
+      "tool_name",
+      "query_text",
+      "result_count",
+      "top_score",
+      "latency_ms",
+      "source_name",
+      "session_id",
+      "created_at",
+    ]) {
+      expect(sql).toContain(col);
+    }
+  });
+
+  it("creates indexes on query_log", () => {
+    const sql = generatePostSchemaMigration();
+    expect(sql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_query_log_created_at ON query_log (created_at)",
+    );
+    expect(sql).toContain(
+      "CREATE INDEX IF NOT EXISTS idx_query_log_tool_name ON query_log (tool_name)",
+    );
+  });
 });

--- a/src/__tests__/search-analytics.test.ts
+++ b/src/__tests__/search-analytics.test.ts
@@ -1,0 +1,240 @@
+import {
+  describe,
+  it,
+  expect,
+  vi,
+  beforeAll,
+  beforeEach,
+  afterAll,
+} from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type { SearchToolConfig, ChunkResult } from "../types.js";
+
+// Mock dependencies
+vi.mock("../db/queries.js", () => ({
+  searchChunks: vi.fn(),
+  textSearchChunks: vi.fn(),
+  hybridSearchChunks: vi.fn(),
+}));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn(),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn(),
+}));
+
+import { registerSearchTool } from "../mcp/tools/search.js";
+import { searchChunks } from "../db/queries.js";
+import { logQuery } from "../db/analytics.js";
+import { getServerConfig } from "../config.js";
+
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockLogQuery = vi.mocked(logQuery);
+const mockGetServerConfig = vi.mocked(getServerConfig);
+const mockEmbed = vi.fn();
+
+function makeChunkResult(overrides: Partial<ChunkResult> = {}): ChunkResult {
+  return {
+    id: 1,
+    source_name: "docs",
+    source_url: null,
+    title: "Title",
+    content: "Content",
+    repo_url: null,
+    file_path: "f.md",
+    start_line: null,
+    end_line: null,
+    language: null,
+    similarity: 0.9,
+    ...overrides,
+  };
+}
+
+const toolConfig: SearchToolConfig = {
+  name: "search-docs",
+  type: "search",
+  description: "Search",
+  source: "docs",
+  default_limit: 5,
+  max_limit: 20,
+  result_format: "docs",
+  search_mode: "vector",
+};
+
+describe("search tool analytics instrumentation", () => {
+  let client: Client;
+  let server: McpServer;
+
+  beforeAll(async () => {
+    server = new McpServer({ name: "test", version: "1.0.0" });
+    registerSearchTool(
+      server as never,
+      { embed: mockEmbed } as never,
+      toolConfig,
+    );
+    const [ct, st] = InMemoryTransport.createLinkedPair();
+    await server.connect(st);
+    client = new Client({ name: "tc", version: "1.0.0" });
+    await client.connect(ct);
+  });
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterAll(async () => {
+    await client.close();
+    await server.close();
+  });
+
+  it("logs query when analytics is enabled", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([makeChunkResult()]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+
+    // logQuery is fire-and-forget, give it a tick
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [entry, logText] = mockLogQuery.mock.calls[0];
+    expect(entry.tool_name).toBe("search-docs");
+    expect(entry.query_text).toBe("test");
+    expect(entry.result_count).toBe(1);
+    expect(entry.top_score).toBeCloseTo(0.9);
+    expect(entry.latency_ms).toBeGreaterThanOrEqual(0);
+    expect(entry.source_name).toBe("docs");
+    expect(logText).toBe(true);
+  });
+
+  it("does not log when analytics is disabled", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: false, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+
+  it("does not log when analytics config is absent", async () => {
+    mockGetServerConfig.mockReturnValue({} as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+
+  it("passes log_queries: false to logQuery when configured", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: false, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([makeChunkResult()]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "secret" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(mockLogQuery).toHaveBeenCalledTimes(1);
+    const [, logText] = mockLogQuery.mock.calls[0];
+    expect(logText).toBe(false);
+  });
+
+  it("does not fail the search when logQuery throws", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([makeChunkResult()]);
+    mockLogQuery.mockRejectedValueOnce(new Error("DB write failed"));
+
+    const result = await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("logs null top_score when no results", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "nothing" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.result_count).toBe(0);
+    expect(entry.top_score).toBeNull();
+  });
+
+  it("does not log analytics when search itself fails", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockRejectedValueOnce(new Error("API error"));
+
+    const result = await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    expect(result.isError).toBe(true);
+    expect(mockLogQuery).not.toHaveBeenCalled();
+  });
+
+  it("computes correct top_score from multiple results", async () => {
+    mockGetServerConfig.mockReturnValue({
+      analytics: { enabled: true, log_queries: true, retention_days: 90 },
+    } as never);
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([
+      makeChunkResult({ similarity: 0.7 }),
+      makeChunkResult({ id: 2, similarity: 0.95 }),
+      makeChunkResult({ id: 3, similarity: 0.6 }),
+    ]);
+    mockLogQuery.mockResolvedValueOnce(undefined);
+
+    await client.callTool({
+      name: "search-docs",
+      arguments: { query: "test" },
+    });
+    await new Promise((r) => setTimeout(r, 10));
+
+    const [entry] = mockLogQuery.mock.calls[0];
+    expect(entry.top_score).toBeCloseTo(0.95);
+    expect(entry.result_count).toBe(3);
+  });
+});

--- a/src/__tests__/search-hybrid.test.ts
+++ b/src/__tests__/search-hybrid.test.ts
@@ -17,6 +17,12 @@ vi.mock("../db/queries.js", () => ({
   textSearchChunks: vi.fn(),
   hybridSearchChunks: vi.fn(),
 }));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({}),
+}));
 
 import { registerSearchTool } from "../mcp/tools/search.js";
 import {

--- a/src/__tests__/search-tool.test.ts
+++ b/src/__tests__/search-tool.test.ts
@@ -15,6 +15,12 @@ import type { SearchToolConfig, ChunkResult } from "../types.js";
 vi.mock("../db/queries.js", () => ({
   searchChunks: vi.fn(),
 }));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({}),
+}));
 
 import { registerSearchTool } from "../mcp/tools/search.js";
 import { searchChunks } from "../db/queries.js";

--- a/src/cli-init.ts
+++ b/src/cli-init.ts
@@ -3,7 +3,7 @@
 import fs from 'fs';
 import path from 'path';
 import { crawlSite, type CrawlOptions } from './crawl.js';
-import { generateConfigYaml } from './config-generator.js';
+import { generateConfigYaml, detectSourceType } from './config-generator.js';
 
 /**
  * Validate that the input URL is a valid HTTP(S) URL.
@@ -97,8 +97,9 @@ export async function initFromUrl(options: {
     const yamlContent = generateConfigYaml(result, url);
     writeGeneratedConfig(targetDir, yamlContent, force);
 
+    const sourceType = result.pages.length > 0 ? detectSourceType(result.pages) : 'unknown';
     console.log(`\nGenerated pathfinder.yaml`);
-    console.log(`  Source type: ${result.pages.length > 0 ? 'html' : 'unknown'}`);
+    console.log(`  Source type: ${sourceType}`);
     console.log(`  Pages cached: ${result.pages.length} in ${cacheDir}`);
     console.log(`\nNext steps:`);
     console.log(`  1. Review pathfinder.yaml and adjust if needed`);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("Agentic docs retrieval for AI agents")
-  .version("1.10.0");
+  .version("1.11.0");
 
 program
   .command("init")

--- a/src/config-generator.ts
+++ b/src/config-generator.ts
@@ -32,7 +32,6 @@ interface GeneratedSource {
     file_patterns: string[];
     base_url: string;
     repo?: string;
-    content_selector?: string;
     chunk: {
         target_tokens: number;
         overlap_tokens: number;
@@ -197,11 +196,6 @@ export function generateConfig(crawlResult: CrawlResult, inputUrl: string): Gene
     const gitRepo = detectGitRepo(inputUrl);
     const hostname = new URL(inputUrl).hostname;
 
-    // Fix I2: detect content selector and wire into source config
-    const contentSelector = crawlResult.pages.length > 0
-        ? detectContentSelector(crawlResult.pages[0].html)
-        : null;
-
     const source: GeneratedSource = {
         name: 'docs',
         type: sourceType,
@@ -216,10 +210,6 @@ export function generateConfig(crawlResult: CrawlResult, inputUrl: string): Gene
 
     if (gitRepo) {
         source.repo = gitRepo.repoUrl;
-    }
-
-    if (contentSelector) {
-        source.content_selector = contentSelector;
     }
 
     const tool: GeneratedTool = {
@@ -258,6 +248,11 @@ export function generateConfig(crawlResult: CrawlResult, inputUrl: string): Gene
 export function generateConfigYaml(crawlResult: CrawlResult, inputUrl: string): string {
     const config = generateConfig(crawlResult, inputUrl);
 
+    // Detect content selector from crawled pages (not stored in config to avoid Zod validation failure)
+    const contentSelector = crawlResult.pages.length > 0
+        ? detectContentSelector(crawlResult.pages[0].html)
+        : null;
+
     const header = [
         '# Pathfinder configuration — auto-generated from ' + inputUrl,
         '# Review and customize before running: pathfinder serve',
@@ -265,9 +260,19 @@ export function generateConfigYaml(crawlResult: CrawlResult, inputUrl: string): 
         '',
     ].join('\n');
 
-    return header + stringifyYaml(config, {
+    let yaml = header + stringifyYaml(config, {
         lineWidth: 120,
         defaultStringType: 'QUOTE_DOUBLE',
         defaultKeyType: 'PLAIN',
     });
+
+    // Append content_selector as a comment after the source block if detected
+    if (contentSelector) {
+        yaml = yaml.replace(
+            /^( +)base_url:/m,
+            `$1# content_selector: "${contentSelector}" — detected from crawled pages\n$1base_url:`,
+        );
+    }
+
+    return yaml;
 }

--- a/src/crawl.ts
+++ b/src/crawl.ts
@@ -308,10 +308,16 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
     const warnings: string[] = [];
     const visited = new Set<string>();
 
+    // Helper to normalize URLs for consistent dedup (strip trailing slash)
+    function normalizeUrl(u: string): string {
+        return u.replace(/\/$/, '');
+    }
+
     // Helper to fetch and store a page
     async function fetchPage(pageUrl: string): Promise<CrawledPage | null> {
-        if (visited.has(pageUrl) || pages.length >= maxPages) return null;
-        visited.add(pageUrl);
+        const normalized = normalizeUrl(pageUrl);
+        if (visited.has(normalized) || pages.length >= maxPages) return null;
+        visited.add(normalized);
 
         // Check cache first
         if (cacheDir) {
@@ -350,11 +356,23 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
         return { url: pageUrl, html: result.body, contentType: result.contentType, textLength };
     }
 
+    // Fetch robots.txt early so sitemap-discovered URLs can be filtered
+    const robotsResult = await rateLimitedFetch(`${baseUrl}/robots.txt`, rateLimit, maxRetries, lastFetchTime);
+    let robotsTxt = '';
+    if (robotsResult.ok) {
+        robotsTxt = robotsResult.body;
+    }
+
     // Helper to fetch pages from a list of URLs discovered via sitemap
     async function fetchSitemapPages(allPageUrls: string[]): Promise<void> {
         const urlsToFetch = allPageUrls.slice(0, maxPages);
         for (const pageUrl of urlsToFetch) {
             if (pages.length >= maxPages) break;
+            // Enforce robots.txt on sitemap-discovered URLs
+            if (robotsTxt) {
+                const pathname = new URL(pageUrl).pathname;
+                if (!respectsRobotsTxt(robotsTxt, pathname)) continue;
+            }
             const page = await fetchPage(pageUrl);
             if (page) pages.push(page);
         }
@@ -424,11 +442,9 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
     }
 
     // ── Strategy 2: Try robots.txt for Sitemap: directives ──────────────────
+    // (robots.txt already fetched above for filtering)
 
-    const robotsResult = await rateLimitedFetch(`${baseUrl}/robots.txt`, rateLimit, maxRetries, lastFetchTime);
-    let robotsTxt = '';
     if (robotsResult.ok) {
-        robotsTxt = robotsResult.body;
         const sitemapUrls = extractSitemapsFromRobotsTxt(robotsTxt);
 
         if (sitemapUrls.length > 0) {
@@ -469,11 +485,11 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
     // ── Strategy 3: Recursive link crawling ─────────────────────────────────
 
     // BFS crawl from the root URL
-    const queue: { url: string; depth: number }[] = [{ url, depth: 0 }];
+    const queue: { url: string; depth: number }[] = [{ url: normalizeUrl(url), depth: 0 }];
 
     while (queue.length > 0 && pages.length < maxPages) {
         const current = queue.shift()!;
-        if (visited.has(current.url)) continue;
+        if (visited.has(normalizeUrl(current.url))) continue;
 
         // Check robots.txt disallow rules
         const pathname = new URL(current.url).pathname;
@@ -489,8 +505,8 @@ export async function crawlSite(url: string, options: CrawlOptions = {}): Promis
         if (current.depth < maxDepth) {
             const links = extractLinks(page.html, current.url);
             for (const link of links) {
-                if (!visited.has(link)) {
-                    queue.push({ url: link, depth: current.depth + 1 });
+                if (!visited.has(normalizeUrl(link))) {
+                    queue.push({ url: normalizeUrl(link), depth: current.depth + 1 });
                 }
             }
         }

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -1,0 +1,250 @@
+import { getPool } from "./client.js";
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface QueryLogEntry {
+  tool_name: string;
+  query_text: string;
+  result_count: number;
+  top_score: number | null;
+  latency_ms: number;
+  source_name: string | null;
+  session_id: string | null;
+}
+
+export interface AnalyticsSummary {
+  total_queries: number;
+  total_queries_7d: number;
+  empty_result_count_7d: number;
+  empty_result_rate_7d: number;
+  avg_latency_ms_7d: number;
+  p95_latency_ms_7d: number;
+  queries_by_source: Array<{ source_name: string; count: number }>;
+  queries_per_day_7d: Array<{ day: string; count: number }>;
+}
+
+export interface TopQuery {
+  query_text: string;
+  count: number;
+  avg_result_count: number;
+  avg_top_score: number | null;
+}
+
+export interface EmptyQuery {
+  query_text: string;
+  tool_name: string;
+  source_name: string | null;
+  count: number;
+  last_seen: string;
+}
+
+// ---------------------------------------------------------------------------
+// Write
+// ---------------------------------------------------------------------------
+
+/**
+ * Log a query to the query_log table.
+ * When log_queries is false, query_text is stored as '<redacted>'.
+ */
+export async function logQuery(
+  entry: QueryLogEntry,
+  logQueryText: boolean = true,
+): Promise<void> {
+  const pool = getPool();
+  const text = logQueryText ? entry.query_text : "<redacted>";
+  await pool.query(
+    `INSERT INTO query_log (tool_name, query_text, result_count, top_score, latency_ms, source_name, session_id)
+         VALUES ($1, $2, $3, $4, $5, $6, $7)`,
+    [
+      entry.tool_name,
+      text,
+      entry.result_count,
+      entry.top_score,
+      entry.latency_ms,
+      entry.source_name,
+      entry.session_id,
+    ],
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Read
+// ---------------------------------------------------------------------------
+
+/**
+ * Compute p95 latency in application code instead of SQL.
+ * PGlite does NOT support percentile_cont(), so we fetch all latencies
+ * and compute the percentile in JS.
+ */
+function computeP95(latencies: number[]): number {
+  if (latencies.length === 0) return 0;
+  const sorted = [...latencies].sort((a, b) => a - b);
+  const index = Math.floor(sorted.length * 0.95);
+  return sorted[Math.min(index, sorted.length - 1)] ?? 0;
+}
+
+/**
+ * Get a summary of analytics data.
+ */
+export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
+  const pool = getPool();
+
+  // Note: percentile_cont is NOT used in SQL because PGlite doesn't support it.
+  // Instead, we fetch latencies and compute p95 in application code.
+  const [totalRes, summary7dRes, latencyRes, bySourceRes, perDayRes] =
+    await Promise.all([
+      pool.query("SELECT count(*)::int AS count FROM query_log"),
+      pool.query(`
+            SELECT
+                count(*)::int AS total,
+                count(*) FILTER (WHERE result_count = 0)::int AS empty,
+                COALESCE(avg(latency_ms)::int, 0) AS avg_latency
+            FROM query_log
+            WHERE created_at > NOW() - INTERVAL '7 days'
+        `),
+      pool.query(`
+            SELECT latency_ms FROM query_log
+            WHERE created_at > NOW() - INTERVAL '7 days'
+            ORDER BY latency_ms
+        `),
+      pool.query(`
+            SELECT source_name, count(*)::int AS count
+            FROM query_log
+            WHERE source_name IS NOT NULL
+            GROUP BY source_name
+            ORDER BY count DESC
+        `),
+      pool.query(`
+            SELECT date_trunc('day', created_at)::date::text AS day, count(*)::int AS count
+            FROM query_log
+            WHERE created_at > NOW() - INTERVAL '7 days'
+            GROUP BY day
+            ORDER BY day
+        `),
+    ]);
+
+  const totalQueries = totalRes.rows[0]?.count ?? 0;
+  const s = summary7dRes.rows[0] ?? {};
+  const total7d = s.total ?? 0;
+  const empty7d = s.empty ?? 0;
+
+  // Compute p95 in application code
+  const latencies = latencyRes.rows.map(
+    (r: Record<string, unknown>) => r.latency_ms as number,
+  );
+  const p95Latency = computeP95(latencies);
+
+  return {
+    total_queries: totalQueries,
+    total_queries_7d: total7d,
+    empty_result_count_7d: empty7d,
+    empty_result_rate_7d: total7d > 0 ? empty7d / total7d : 0,
+    avg_latency_ms_7d: s.avg_latency ?? 0,
+    p95_latency_ms_7d: p95Latency,
+    queries_by_source: bySourceRes.rows.map(
+      (r: Record<string, unknown>) => ({
+        source_name: r.source_name as string,
+        count: r.count as number,
+      }),
+    ),
+    queries_per_day_7d: perDayRes.rows.map(
+      (r: Record<string, unknown>) => ({
+        day: r.day as string,
+        count: r.count as number,
+      }),
+    ),
+  };
+}
+
+/**
+ * Get top queries by frequency over the last N days.
+ */
+export async function getTopQueries(
+  days: number = 7,
+  limit: number = 50,
+): Promise<TopQuery[]> {
+  const pool = getPool();
+  const { rows } = await pool.query(
+    `
+        SELECT
+            query_text,
+            count(*)::int AS count,
+            avg(result_count)::real AS avg_result_count,
+            avg(top_score)::real AS avg_top_score
+        FROM query_log
+        WHERE created_at > NOW() - INTERVAL '1 day' * $1
+          AND query_text != '<redacted>'
+        GROUP BY query_text
+        ORDER BY count DESC
+        LIMIT $2
+    `,
+    [days, limit],
+  );
+
+  return rows.map((r: Record<string, unknown>) => ({
+    query_text: r.query_text as string,
+    count: r.count as number,
+    avg_result_count: parseFloat(r.avg_result_count as string) || 0,
+    avg_top_score:
+      r.avg_top_score != null
+        ? parseFloat(r.avg_top_score as string)
+        : null,
+  }));
+}
+
+/**
+ * Get queries that returned zero results, grouped by query text.
+ */
+export async function getEmptyQueries(
+  days: number = 7,
+  limit: number = 50,
+): Promise<EmptyQuery[]> {
+  const pool = getPool();
+  const { rows } = await pool.query(
+    `
+        SELECT
+            query_text,
+            tool_name,
+            source_name,
+            count(*)::int AS count,
+            max(created_at)::text AS last_seen
+        FROM query_log
+        WHERE result_count = 0
+          AND created_at > NOW() - INTERVAL '1 day' * $1
+          AND query_text != '<redacted>'
+        GROUP BY query_text, tool_name, source_name
+        ORDER BY count DESC
+        LIMIT $2
+    `,
+    [days, limit],
+  );
+
+  return rows.map((r: Record<string, unknown>) => ({
+    query_text: r.query_text as string,
+    tool_name: r.tool_name as string,
+    source_name: (r.source_name as string) ?? null,
+    count: r.count as number,
+    last_seen: r.last_seen as string,
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete query_log rows older than the specified number of days.
+ * Returns the number of rows deleted.
+ */
+export async function cleanupOldQueryLogs(
+  retentionDays: number,
+): Promise<number> {
+  const pool = getPool();
+  const result = await pool.query(
+    `DELETE FROM query_log WHERE created_at < NOW() - INTERVAL '1 day' * $1`,
+    [retentionDays],
+  );
+  return result.rowCount ?? 0;
+}

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -113,6 +113,7 @@ export async function getAnalyticsSummary(): Promise<AnalyticsSummary> {
             SELECT source_name, count(*)::int AS count
             FROM query_log
             WHERE source_name IS NOT NULL
+              AND created_at > NOW() - INTERVAL '7 days'
             GROUP BY source_name
             ORDER BY count DESC
         `),

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -86,6 +86,22 @@ UPDATE chunks SET tsv = to_tsvector('english', content) WHERE tsv IS NULL;
 
 -- GIN index for fast full-text search
 CREATE INDEX IF NOT EXISTS idx_chunks_tsv ON chunks USING GIN (tsv);
+
+-- Analytics: query_log table for tracking tool usage
+CREATE TABLE IF NOT EXISTS query_log (
+    id              SERIAL PRIMARY KEY,
+    tool_name       TEXT NOT NULL,
+    query_text      TEXT NOT NULL,
+    result_count    INTEGER NOT NULL,
+    top_score       REAL,
+    latency_ms      INTEGER NOT NULL,
+    source_name     TEXT,
+    session_id      TEXT,
+    created_at      TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_query_log_created_at ON query_log (created_at);
+CREATE INDEX IF NOT EXISTS idx_query_log_tool_name ON query_log (tool_name);
 `;
 
   return coreSql;

--- a/src/indexing/content-extractors.ts
+++ b/src/indexing/content-extractors.ts
@@ -64,7 +64,7 @@ async function extractPdf(filePath: string): Promise<ExtractionResult> {
   const result = await pdfParse(buffer);
 
   // Warn about likely scanned PDFs (very little text for multi-page docs)
-  if (result.numpages > 1 && result.text.trim().length < 50) {
+  if (result.numpages >= 1 && result.text.trim().length < 50) {
     console.warn(
       `[content-extractor] ${filePath}: PDF has ${result.numpages} pages but produced very little text ` +
         `(${result.text.trim().length} chars). This may be a scanned document without a text layer.`,
@@ -107,5 +107,13 @@ async function extractDocx(filePath: string): Promise<ExtractionResult> {
   }
 
   const result = await mammoth.extractRawText({ path: filePath });
+
+  if (result.messages && result.messages.length > 0) {
+    console.warn(
+      `[content-extractor] ${filePath}: mammoth reported ${result.messages.length} warning(s):`,
+      result.messages,
+    );
+  }
+
   return { content: result.value };
 }

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -300,25 +300,25 @@ export class IndexingOrchestrator {
           this.lastReindexDate = today;
           console.log("[orchestrator] Starting nightly reindex");
           this.queueFullReindex();
-        }
 
-        // Analytics cleanup — run at the same hour as reindex, once per day
-        const analyticsConfig = getServerConfig().analytics;
-        if (analyticsConfig?.enabled) {
-          const retentionDays = analyticsConfig.retention_days ?? 90;
-          cleanupOldQueryLogs(retentionDays)
-            .then((deleted) => {
-              if (deleted > 0) {
-                console.log(
-                  `[analytics] Cleaned up ${deleted} query_log rows older than ${retentionDays} days`,
+          // Analytics cleanup — run at the same hour as reindex, once per day
+          const analyticsConfig = getServerConfig().analytics;
+          if (analyticsConfig?.enabled) {
+            const retentionDays = analyticsConfig.retention_days ?? 90;
+            cleanupOldQueryLogs(retentionDays)
+              .then((deleted) => {
+                if (deleted > 0) {
+                  console.log(
+                    `[analytics] Cleaned up ${deleted} query_log rows older than ${retentionDays} days`,
+                  );
+                }
+              })
+              .catch((err) => {
+                console.error(
+                  `[analytics] Cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
                 );
-              }
-            })
-            .catch((err) => {
-              console.error(
-                `[analytics] Cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
-              );
-            });
+              });
+          }
         }
       }
     }, 60_000);

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -14,6 +14,7 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { getProvider } from "./providers/index.js";
 import { IndexingPipeline } from "./pipeline.js";
 import { getIndexState, upsertIndexState } from "../db/queries.js";
+import { cleanupOldQueryLogs } from "../db/analytics.js";
 import { isFileSourceConfig } from "../types.js";
 import type { IndexState, IndexStatus, SourceConfig } from "../types.js";
 import type { ProviderOptions } from "./providers/types.js";
@@ -299,6 +300,25 @@ export class IndexingOrchestrator {
           this.lastReindexDate = today;
           console.log("[orchestrator] Starting nightly reindex");
           this.queueFullReindex();
+        }
+
+        // Analytics cleanup — run at the same hour as reindex, once per day
+        const analyticsConfig = getServerConfig().analytics;
+        if (analyticsConfig?.enabled) {
+          const retentionDays = analyticsConfig.retention_days ?? 90;
+          cleanupOldQueryLogs(retentionDays)
+            .then((deleted) => {
+              if (deleted > 0) {
+                console.log(
+                  `[analytics] Cleaned up ${deleted} query_log rows older than ${retentionDays} days`,
+                );
+              }
+            })
+            .catch((err) => {
+              console.error(
+                `[analytics] Cleanup failed: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
         }
       }
     }, 60_000);

--- a/src/mcp/tools/knowledge.ts
+++ b/src/mcp/tools/knowledge.ts
@@ -7,6 +7,8 @@ import type {
   ChunkResult,
 } from "../../types.js";
 import { getFaqChunks, searchChunks } from "../../db/queries.js";
+import { logQuery } from "../../db/analytics.js";
+import { getServerConfig } from "../../config.js";
 
 /**
  * Format FAQ results in the standard QUESTION/ANSWER/SOURCE/CONFIDENCE format.
@@ -76,6 +78,7 @@ export function registerKnowledgeTool(
     async ({ query, limit, min_confidence }) => {
       const effectiveLimit = limit ?? toolConfig.default_limit;
       const effectiveConfidence = min_confidence ?? toolConfig.min_confidence;
+      const startMs = Date.now();
 
       try {
         if (!query || query.trim() === "") {
@@ -85,6 +88,28 @@ export function registerKnowledgeTool(
             effectiveConfidence,
             effectiveLimit,
           );
+
+          // Fire-and-forget analytics logging
+          const analyticsConfig = getServerConfig().analytics;
+          if (analyticsConfig?.enabled) {
+            logQuery(
+              {
+                tool_name: toolConfig.name,
+                query_text: "<browse>",
+                result_count: chunks.length,
+                top_score: null,
+                latency_ms: Date.now() - startMs,
+                source_name: toolConfig.sources.join(","),
+                session_id: null,
+              },
+              analyticsConfig.log_queries,
+            ).catch((err) => {
+              console.error(
+                `[analytics] Failed to log query: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
+          }
+
           return {
             content: [
               { type: "text" as const, text: formatFaqResults(chunks) },
@@ -128,6 +153,31 @@ export function registerKnowledgeTool(
                 similarity: result.similarity,
               });
             }
+          }
+
+          // Fire-and-forget analytics logging
+          const analyticsConfig = getServerConfig().analytics;
+          if (analyticsConfig?.enabled) {
+            const topScore =
+              mergedResults.length > 0
+                ? Math.max(...mergedResults.map((r) => r.similarity))
+                : null;
+            logQuery(
+              {
+                tool_name: toolConfig.name,
+                query_text: query,
+                result_count: mergedResults.length,
+                top_score: topScore,
+                latency_ms: Date.now() - startMs,
+                source_name: toolConfig.sources.join(","),
+                session_id: null,
+              },
+              analyticsConfig.log_queries,
+            ).catch((err) => {
+              console.error(
+                `[analytics] Failed to log query: ${err instanceof Error ? err.message : String(err)}`,
+              );
+            });
           }
 
           return {

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -7,6 +7,8 @@ import {
   textSearchChunks,
   hybridSearchChunks,
 } from "../../db/queries.js";
+import { logQuery } from "../../db/analytics.js";
+import { getServerConfig } from "../../config.js";
 
 function formatDocsResults(results: ChunkResult[]): string {
   if (results.length === 0) return "No results found.";
@@ -100,6 +102,7 @@ export function registerSearchTool(
     async ({ query, limit, min_score, version }) => {
       const effectiveLimit = limit ?? toolConfig.default_limit;
       const searchMode = toolConfig.search_mode ?? "vector";
+      const startMs = Date.now();
       try {
         let results: ChunkResult[];
         const minScore = min_score ?? toolConfig.min_score;
@@ -144,6 +147,32 @@ export function registerSearchTool(
             }
             break;
           }
+        }
+
+        // Fire-and-forget analytics logging
+        const analyticsConfig = getServerConfig().analytics;
+        if (analyticsConfig?.enabled) {
+          const latencyMs = Date.now() - startMs;
+          const topScore =
+            results.length > 0
+              ? Math.max(...results.map((r) => r.similarity))
+              : null;
+          logQuery(
+            {
+              tool_name: toolConfig.name,
+              query_text: query,
+              result_count: results.length,
+              top_score: topScore,
+              latency_ms: latencyMs,
+              source_name: toolConfig.source,
+              session_id: null,
+            },
+            analyticsConfig.log_queries,
+          ).catch((err) => {
+            console.error(
+              `[analytics] Failed to log query: ${err instanceof Error ? err.message : String(err)}`,
+            );
+          });
         }
 
         return {

--- a/src/server.ts
+++ b/src/server.ts
@@ -34,6 +34,15 @@ import { WorkspaceManager } from "./workspace.js";
 import { generateLlmsTxt, generateLlmsFullTxt } from "./llms-txt.js";
 import { generateFaqTxt } from "./faq-txt.js";
 import { generateSkillMd } from "./skill-md.js";
+import {
+  getAnalyticsSummary,
+  getTopQueries,
+  getEmptyQueries,
+} from "./db/analytics.js";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 export interface ServerOptions {
   port?: number;
@@ -588,6 +597,102 @@ app.get(
     }
   },
 );
+
+// ---------------------------------------------------------------------------
+// Analytics API — protected by token auth
+// ---------------------------------------------------------------------------
+
+/**
+ * Analytics auth middleware — exported so tests can import and test the real
+ * code instead of reimplementing the logic in test doubles.
+ */
+export function analyticsAuth(
+  req: Request,
+  res: Response,
+  next: express.NextFunction,
+): void {
+  const serverCfg = getServerConfig();
+  const token =
+    serverCfg.analytics?.token || process.env.ANALYTICS_TOKEN;
+
+  if (!serverCfg.analytics?.enabled) {
+    res.status(404).json({ error: "Analytics not enabled" });
+    return;
+  }
+
+  if (!token) {
+    // No token configured = no auth required (but analytics must still be enabled)
+    next();
+    return;
+  }
+
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({
+      error:
+        "Missing or invalid Authorization header. Use: Bearer <token>",
+    });
+    return;
+  }
+
+  const provided = authHeader.slice(7);
+  if (provided !== token) {
+    res.status(403).json({ error: "Invalid analytics token" });
+    return;
+  }
+
+  next();
+}
+
+app.get(
+  "/api/analytics/summary",
+  analyticsAuth,
+  async (_req: Request, res: Response) => {
+    try {
+      const summary = await getAnalyticsSummary();
+      res.json(summary);
+    } catch (err) {
+      console.error("[analytics] Summary query failed:", err);
+      res.status(500).json({ error: "Failed to fetch analytics summary" });
+    }
+  },
+);
+
+app.get(
+  "/api/analytics/queries",
+  analyticsAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const days = parseInt(req.query.days as string) || 7;
+      const limit = parseInt(req.query.limit as string) || 50;
+      const queries = await getTopQueries(days, Math.min(limit, 200));
+      res.json(queries);
+    } catch (err) {
+      console.error("[analytics] Top queries failed:", err);
+      res.status(500).json({ error: "Failed to fetch top queries" });
+    }
+  },
+);
+
+app.get(
+  "/api/analytics/empty-queries",
+  analyticsAuth,
+  async (req: Request, res: Response) => {
+    try {
+      const days = parseInt(req.query.days as string) || 7;
+      const limit = parseInt(req.query.limit as string) || 50;
+      const queries = await getEmptyQueries(days, Math.min(limit, 200));
+      res.json(queries);
+    } catch (err) {
+      console.error("[analytics] Empty queries failed:", err);
+      res.status(500).json({ error: "Failed to fetch empty queries" });
+    }
+  },
+);
+
+app.get("/analytics", analyticsAuth, (_req: Request, res: Response) => {
+  res.sendFile(path.resolve(__dirname, "../docs/analytics.html"));
+});
 
 // ---------------------------------------------------------------------------
 // Startup

--- a/src/types.ts
+++ b/src/types.ts
@@ -221,6 +221,15 @@ export const WebhookConfigSchema = z.object({
   path_triggers: z.record(z.string(), z.array(z.string())),
 });
 
+// ── Analytics configuration schemas ──────────────────────────────────────────
+
+export const AnalyticsConfigSchema = z.object({
+  enabled: z.boolean().default(false),
+  log_queries: z.boolean().default(true),
+  token: z.string().min(1).optional(),
+  retention_days: z.number().int().positive().default(90),
+});
+
 // ── Top-level server configuration schema ─────────────────────────────────────
 
 export const ServerConfigSchema = z
@@ -236,6 +245,7 @@ export const ServerConfigSchema = z
     embedding: EmbeddingConfigSchema.optional(),
     indexing: IndexingConfigSchema.optional(),
     webhook: WebhookConfigSchema.optional(),
+    analytics: AnalyticsConfigSchema.optional(),
   })
   .superRefine((cfg, ctx) => {
     const hasRag = cfg.tools.some(
@@ -332,6 +342,7 @@ export type OllamaEmbeddingConfig = z.infer<
 export type LocalEmbeddingConfig = z.infer<typeof LocalEmbeddingConfigSchema>;
 export type IndexingConfig = z.infer<typeof IndexingConfigSchema>;
 export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
+export type AnalyticsConfig = z.infer<typeof AnalyticsConfigSchema>;
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
 export type BashCacheConfig = z.infer<typeof BashCacheConfigSchema>;
 export type BashOptions = z.infer<typeof BashOptionsSchema>;


### PR DESCRIPTION
Query logging, REST endpoints, Chart.js dashboard at /analytics. Token auth, 90-day retention, PGlite-compatible p95. Stacked on v1.10.0.