### PR TITLE
Fix broken Slack webhook curl in all CI workflows

### DIFF
--- a/.github/workflows/deploy-health-check.yml
+++ b/.github/workflows/deploy-health-check.yml
@@ -21,16 +21,20 @@ jobs:
       - name: Notify Slack — success
         if: success()
         run: |
-          curl -sf -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d '{"text":"Pathfinder production deploy healthy — both services OK"}'
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -sf -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d '{"text":"Pathfinder production deploy healthy — both services OK"}' || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Notify Slack — failure
         if: failure()
         run: |
-          curl -s -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"Pathfinder production health check FAILED after deploy\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -s -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\":\"Pathfinder production health check FAILED after deploy\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -29,6 +29,8 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         run: |
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \ || true
-            -H "Content-Type: application/json" \
-            -d "{\"text\":\"❌ *Pathfinder GitHub Pages deploy failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
+            curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"❌ *Pathfinder GitHub Pages deploy failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+          fi

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -9,8 +9,10 @@ jobs:
       - name: Notify Slack
         if: github.actor != 'github-actions[bot]'
         run: |
-          curl -sf -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"New PR on pathfinder: *${{ github.event.pull_request.title }}* by ${{ github.actor }}\n<${{ github.event.pull_request.html_url }}|View PR #${{ github.event.pull_request.number }}>\"}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -sf -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\":\"New PR on pathfinder: *${{ github.event.pull_request.title }}* by ${{ github.actor }}\n<${{ github.event.pull_request.html_url }}|View PR #${{ github.event.pull_request.number }}>\"}" || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -29,16 +29,20 @@ jobs:
       - name: Notify Slack — success
         if: success()
         run: |
-          curl -sf -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"Docker image published: ghcr.io/copilotkit/pathfinder:${{ github.ref_name }}\"}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -sf -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\":\"Docker image published: ghcr.io/copilotkit/pathfinder:${{ github.ref_name }}\"}" || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Notify Slack — failure
         if: failure()
         run: |
-          curl -sf -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"Docker publish failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -sf -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\":\"Docker publish failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -66,13 +66,17 @@ jobs:
         if: steps.check.outputs.published == 'false'
         run: |
           VERSION="v${{ steps.check.outputs.version }}"
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \ || true
-            -H "Content-Type: application/json" \
-            -d "{\"text\":\"📦 *@copilotkit/pathfinder ${VERSION} published*\nnpm: https://www.npmjs.com/package/@copilotkit/pathfinder/v/${{ steps.check.outputs.version }}\nRelease: https://github.com/${{ github.repository }}/releases/tag/${VERSION}\"}"
+          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
+            curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"📦 *@copilotkit/pathfinder ${VERSION} published*\nnpm: https://www.npmjs.com/package/@copilotkit/pathfinder/v/${{ steps.check.outputs.version }}\nRelease: https://github.com/${{ github.repository }}/releases/tag/${VERSION}\"}" || true
+          fi
 
       - name: Notify Slack on failure
         if: failure()
         run: |
-          curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \ || true
-            -H "Content-Type: application/json" \
-            -d "{\"text\":\"❌ *Pathfinder release failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
+            curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+              -H "Content-Type: application/json" \
+              -d "{\"text\":\"❌ *Pathfinder release failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+          fi

--- a/.github/workflows/unreleased-check.yml
+++ b/.github/workflows/unreleased-check.yml
@@ -41,8 +41,10 @@ jobs:
       - name: Notify Slack — unreleased changes
         if: steps.unreleased.outputs.count
         run: |
-          curl -sf -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"Unreleased changes on main — ${{ steps.unreleased.outputs.count }} commits since ${{ steps.unreleased.outputs.tag }}\n<https://github.com/${{ github.repository }}/compare/${{ steps.unreleased.outputs.tag }}...main|View compare>\"}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -sf -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\":\"Unreleased changes on main — ${{ steps.unreleased.outputs.count }} commits since ${{ steps.unreleased.outputs.tag }}\n<https://github.com/${{ github.repository }}/compare/${{ steps.unreleased.outputs.tag }}...main|View compare>\"}" || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -35,16 +35,20 @@ jobs:
       - name: Notify Slack — changes detected
         if: steps.changes.outputs.changed == 'true'
         run: |
-          curl -sf -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"Competitive matrix updated — PR created\n<${{ steps.pr.outputs.url }}|View PR>\"}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -sf -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\":\"Competitive matrix updated — PR created\n<${{ steps.pr.outputs.url }}|View PR>\"}" || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Notify Slack — failure
         if: failure()
         run: |
-          curl -sf -X POST "$SLACK_WEBHOOK" \ || true
-            -H 'Content-Type: application/json' \
-            -d "{\"text\":\"Competitive matrix scan failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -sf -X POST "$SLACK_WEBHOOK" \
+              -H 'Content-Type: application/json' \
+              -d "{\"text\":\"Competitive matrix scan failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+          fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary

- Multiline curl with `\ || true` on the first line caused `-H` to be interpreted as a shell command when `SLACK_WEBHOOK` was empty
- Wrap each curl block in `if [ -n "$SLACK_WEBHOOK" ]` guard and move `|| true` to the end
- Fixes all 7 workflow files (10 curl blocks total)

## Test plan
- [x] Verified `unreleased-check.yml` was failing with `exit code 127` due to this exact bug
- [x] All curl blocks now guarded against empty webhook