### PR TITLE
Enable analytics in deployed config

### DIFF
--- a/deploy/copilotkit-docs.yaml
+++ b/deploy/copilotkit-docs.yaml
@@ -173,6 +173,9 @@ indexing:
   reindex_hour_utc: 3
   stale_threshold_hours: 24
 
+analytics:
+  enabled: true
+
 webhook:
   repo_sources:
     "CopilotKit/CopilotKit":


### PR DESCRIPTION
## Summary

- Add `analytics.enabled: true` to `deploy/copilotkit-docs.yaml`
- Token provided via `ANALYTICS_TOKEN` env var on Railway (already set)

## Test plan
- [x] ANALYTICS_TOKEN env var set on Railway
- [x] Config only adds `enabled: true` — no secrets in config