### PR TITLE
Include analytics.html in Docker prod image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN npm ci --omit=dev
 # RUN npm install pdf-parse mammoth        # For type: document (PDF/DOCX)
 # RUN npm install @xenova/transformers     # For embedding.provider: local
 COPY --from=build /app/dist/ ./dist/
+COPY docs/analytics.html ./docs/analytics.html
 COPY deploy/copilotkit-docs.yaml ./copilotkit-docs.yaml
 COPY deploy/pathfinder-docs.yaml ./pathfinder-docs.yaml
 COPY pathfinder.example.yaml ./pathfinder.example.yaml


### PR DESCRIPTION
## Summary

- The `/analytics` route serves `docs/analytics.html` but the Dockerfile only copied `dist/` into the prod stage
- Adds `COPY docs/analytics.html ./docs/analytics.html` to the prod image
- Fixes `ENOENT: no such file or directory, stat '/app/docs/analytics.html'` in Railway logs

## Test plan
- [x] Confirmed error in Railway logs: `ENOENT: no such file or directory`
- [x] API endpoints work (`/api/analytics/summary` returns data)
- [x] Only the HTML serving is broken due to missing file