### PR TITLE
Fix analytics-server test path resolution

### DIFF
--- a/src/__tests__/analytics-server.test.ts
+++ b/src/__tests__/analytics-server.test.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import express, { Request, Response } from "express";
 import http from "node:http";
 import path from "node:path";
-import { fileURLToPath } from "node:url";
 
 const mockGetAnalyticsSummary = vi.fn();
 const mockGetTopQueries = vi.fn();
@@ -53,7 +52,10 @@ function buildTestApp() {
   const app = express();
   app.use(express.json());
 
-  const __dirname = path.dirname(fileURLToPath(import.meta.url));
+  // Resolve docs/analytics.html from the repo root. Vitest runs from the
+  // repo root, so process.cwd() is stable regardless of whether __dirname
+  // points into src/__tests__ (source tree) or dist/__tests__ (built).
+  const analyticsHtmlPath = path.join(process.cwd(), "docs", "analytics.html");
 
   // Dashboard HTML route — mirrors server.ts /analytics
   app.get("/analytics", (_req: Request, res: Response) => {
@@ -61,7 +63,11 @@ function buildTestApp() {
       res.status(404).json({ error: "Analytics not enabled" });
       return;
     }
-    res.sendFile(path.resolve(__dirname, "../../docs/analytics.html"));
+    // `dotfiles: "allow"` is required so the file serves from paths that
+    // contain a dot-prefixed segment (e.g. git worktrees under `.claude/`).
+    // Without it, Express's `send` returns 404 for any path containing a
+    // dotfile component, which is unrelated to the actual file's existence.
+    res.sendFile(analyticsHtmlPath, { dotfiles: "allow" });
   });
 
   // API routes with analyticsAuth middleware


### PR DESCRIPTION
## Summary

Two tests in `src/__tests__/analytics-server.test.ts` were failing pre-existing:

- `GET /analytics (dashboard HTML) > returns HTML when analytics is enabled`
- `GET /analytics (dashboard HTML) > serves HTML without requiring a token (auth is client-side)`

Both expected status 200 but got 404.

## Root cause

Two distinct issues, both in the test's local Express app's `/analytics` route:

1. **`__dirname` vs `cwd` mismatch.** The test resolved the HTML path via `path.resolve(__dirname, "../../docs/analytics.html")`. That assumes `__dirname` is `dist/__tests__/`, but vitest runs tests directly from `src/__tests__/`, making the path one level too shallow (`src/docs/analytics.html`, which doesn't exist).

2. **Express `send` dotfile denial.** When the repo sits in a path containing a dot-prefixed segment (e.g. `/.claude/worktrees/agent-.../`), Express's underlying `send` module returns 404 by default (`dotfiles: "ignore"`) regardless of whether the file exists. This affects anyone running tests from a worktree under `.claude/`.

## Fix

- Resolve the HTML path from `process.cwd()` (vitest's project root) rather than `__dirname`. Stable across source and built layouts.
- Pass `{ dotfiles: "allow" }` to `res.sendFile` so the route serves files whose absolute path contains dot-prefixed segments.

## Test plan

- [x] `npx vitest run src/__tests__/analytics-server.test.ts` — 11/11 pass (was 9/11)
- [x] `npm test` — 2368/2368 pass
- [x] `npm run build` — clean
- [x] `npx prettier --check "src/**/*.ts"` — clean