### PR TITLE
OAuth: add refresh token, client secret, metadata fields for claude.ai compat

### DIFF
--- a/src/__tests__/oauth-e2e.test.ts
+++ b/src/__tests__/oauth-e2e.test.ts
@@ -36,6 +36,7 @@ import {
   registerHandler,
   authorizeHandler,
   tokenHandler,
+  revocationHandler,
   bearerMiddleware,
   type AuthContext,
 } from "../oauth/handlers.js";
@@ -65,6 +66,7 @@ beforeAll(async () => {
   app.post("/register", registerHandler);
   app.get("/authorize", authorizeHandler);
   app.post("/token", tokenHandler);
+  app.post("/revoke", revocationHandler);
 
   // Stub /mcp that echoes req.auth
   app.post(
@@ -142,10 +144,14 @@ describe("OAuth 2.1 end-to-end ceremonial flow", () => {
       access_token: string;
       token_type: string;
       expires_in: number;
+      refresh_token: string;
+      scope: string;
     };
     expect(tokenBody.access_token).toBeTruthy();
     expect(tokenBody.token_type).toBe("Bearer");
     expect(tokenBody.expires_in).toBe(3600);
+    expect(tokenBody.refresh_token).toBeTruthy();
+    expect(tokenBody.scope).toBe("mcp");
 
     // 5. POST /mcp with Bearer — should attach req.auth
     const mcpRes = await fetch(`${baseUrl}/mcp`, {
@@ -161,6 +167,73 @@ describe("OAuth 2.1 end-to-end ceremonial flow", () => {
       echoed_auth: { sub: string; client_id: string } | null;
     };
     expect(mcpBody.echoed_auth).toEqual({ sub: "anonymous", client_id });
+
+    // 6. Exchange refresh_token for a new access_token
+    const refreshForm = new URLSearchParams();
+    refreshForm.set("grant_type", "refresh_token");
+    refreshForm.set("refresh_token", tokenBody.refresh_token);
+    refreshForm.set("client_id", client_id);
+    const refreshRes = await fetch(`${baseUrl}/token`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: refreshForm.toString(),
+    });
+    expect(refreshRes.status).toBe(200);
+    const refreshBody = (await refreshRes.json()) as {
+      access_token: string;
+      token_type: string;
+      expires_in: number;
+      refresh_token: string;
+      scope: string;
+    };
+    expect(refreshBody.access_token).toBeTruthy();
+    expect(refreshBody.refresh_token).toBeTruthy();
+    expect(refreshBody.scope).toBe("mcp");
+
+    // The refreshed access_token should also authenticate /mcp
+    const mcp2 = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        Authorization: `Bearer ${refreshBody.access_token}`,
+        "Content-Type": "application/json",
+      },
+      body: JSON.stringify({}),
+    });
+    expect(mcp2.status).toBe(200);
+  });
+
+  it("AS metadata advertises refresh_token grant and revocation_endpoint", async () => {
+    const res = await fetch(
+      `${baseUrl}/.well-known/oauth-authorization-server`,
+    );
+    expect(res.status).toBe(200);
+    const body = (await res.json()) as {
+      grant_types_supported: string[];
+      revocation_endpoint: string;
+      scopes_supported: string[];
+      response_modes_supported: string[];
+      token_endpoint_auth_methods_supported: string[];
+    };
+    expect(body.grant_types_supported).toContain("refresh_token");
+    expect(body.revocation_endpoint).toBe(`${baseUrl}/revoke`);
+    expect(body.scopes_supported).toContain("mcp");
+    expect(body.response_modes_supported).toContain("query");
+    expect(body.token_endpoint_auth_methods_supported).toEqual(
+      expect.arrayContaining([
+        "client_secret_basic",
+        "client_secret_post",
+        "none",
+      ]),
+    );
+  });
+
+  it("/revoke always returns 200 regardless of token", async () => {
+    const res = await fetch(`${baseUrl}/revoke`, {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body: "token=some-random-token",
+    });
+    expect(res.status).toBe(200);
   });
 
   it("/mcp succeeds with no Authorization header (opportunistic)", async () => {

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -34,6 +34,7 @@ import {
   registerHandler,
   authorizeHandler,
   tokenHandler,
+  revocationHandler,
   bearerMiddleware,
 } from "../oauth/handlers.js";
 import { clientStore, codeStore } from "../oauth/store.js";
@@ -125,10 +126,21 @@ describe("authorizationServerHandler", () => {
     );
     expect(body.token_endpoint).toBe("https://mcp.example.com/token");
     expect(body.registration_endpoint).toBe("https://mcp.example.com/register");
+    expect(body.revocation_endpoint).toBe("https://mcp.example.com/revoke");
     expect(body.response_types_supported).toContain("code");
+    expect(body.response_modes_supported).toContain("query");
     expect(body.grant_types_supported).toContain("authorization_code");
+    expect(body.grant_types_supported).toContain("refresh_token");
     expect(body.code_challenge_methods_supported).toContain("S256");
-    expect(body.token_endpoint_auth_methods_supported).toContain("none");
+    expect(body.code_challenge_methods_supported).not.toContain("plain");
+    expect(body.token_endpoint_auth_methods_supported).toEqual(
+      expect.arrayContaining([
+        "client_secret_basic",
+        "client_secret_post",
+        "none",
+      ]),
+    );
+    expect(body.scopes_supported).toContain("mcp");
   });
 });
 
@@ -145,6 +157,36 @@ describe("registerHandler", () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
     );
     expect(body.redirect_uris).toEqual(["https://claude.ai/cb"]);
+  });
+
+  it("returns client_secret + secret metadata + updated grant_types", () => {
+    const req = mockReq({
+      body: {
+        redirect_uris: ["https://claude.ai/cb"],
+        client_name: "Claude",
+      },
+    });
+    const res = mockRes();
+    registerHandler(req as never, res as never);
+    const body = res.json.mock.calls[0][0];
+    expect(body.client_secret).toBeDefined();
+    expect(typeof body.client_secret).toBe("string");
+    expect(body.client_secret_issued_at).toBe(body.client_id_issued_at);
+    expect(body.client_secret_expires_at).toBe(0);
+    expect(body.client_name).toBe("Claude");
+    expect(body.grant_types).toEqual(["authorization_code", "refresh_token"]);
+    expect(body.response_types).toEqual(["code"]);
+    expect(body.token_endpoint_auth_method).toBe("client_secret_basic");
+  });
+
+  it("echoes empty client_name when not provided", () => {
+    const req = mockReq({
+      body: { redirect_uris: [] },
+    });
+    const res = mockRes();
+    registerHandler(req as never, res as never);
+    const body = res.json.mock.calls[0][0];
+    expect(body.client_name).toBe("");
   });
 
   it("accepts missing redirect_uris as empty array", () => {
@@ -388,9 +430,9 @@ function pkcePair() {
 }
 
 describe("tokenHandler", () => {
-  it("returns 400 unsupported_grant_type for non-authorization_code", () => {
+  it("returns 400 unsupported_grant_type for unrecognized grant_type", () => {
     const req = mockReq({
-      body: { grant_type: "refresh_token" },
+      body: { grant_type: "client_credentials" },
       headers: {
         host: "mcp.example.com",
         "x-forwarded-proto": "https",
@@ -505,6 +547,9 @@ describe("tokenHandler", () => {
     expect(body.access_token).toBeDefined();
     expect(body.token_type).toBe("Bearer");
     expect(body.expires_in).toBe(3600);
+    expect(body.refresh_token).toBeDefined();
+    expect(typeof body.refresh_token).toBe("string");
+    expect(body.scope).toBe("mcp");
   });
 
   it("decoded JWT contains expected claims with exp - iat === 3600", () => {
@@ -617,6 +662,46 @@ describe("tokenHandler", () => {
     expect(second.json.mock.calls[0][0].error).toBe("invalid_grant");
   });
 
+  it("access_token payload includes scope: 'mcp'", () => {
+    const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+    const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+    const client = clientStore.register({
+      redirect_uris: ["https://x.example/cb"],
+    });
+    const { code } = codeStore.issue({
+      clientId: client.client_id,
+      codeChallenge: challenge,
+      redirectUri: "https://x.example/cb",
+      ttlMs: 600_000,
+    });
+    const req = mockReq({
+      body: {
+        grant_type: "authorization_code",
+        code,
+        code_verifier: verifier,
+        client_id: client.client_id,
+        redirect_uri: "https://x.example/cb",
+      },
+      headers: {
+        host: "mcp.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "8.8.8.10",
+      },
+    });
+    const res = mockRes();
+    tokenHandler(req as never, res as never);
+    const body = res.json.mock.calls[0][0];
+    const [, payloadB64] = (body.access_token as string).split(".");
+    const pad = "=".repeat((4 - (payloadB64.length % 4)) % 4);
+    const payload = JSON.parse(
+      Buffer.from(
+        payloadB64.replace(/-/g, "+").replace(/_/g, "/") + pad,
+        "base64",
+      ).toString("utf8"),
+    );
+    expect(payload.scope).toBe("mcp");
+  });
+
   it("accepts form-encoded bodies (Express urlencoded parser)", () => {
     // The Express urlencoded parser produces req.body the same shape as JSON,
     // so this exercises the same code path. We document that here.
@@ -649,6 +734,172 @@ describe("tokenHandler", () => {
     });
     const res = mockRes();
     tokenHandler(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(200);
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Refresh token grant
+// ──────────────────────────────────────────────────────────────────────
+
+function issueInitialTokens(clientXForwardedFor: string): {
+  client_id: string;
+  refresh_token: string;
+  access_token: string;
+} {
+  const verifier = "dBjftJeZ4CVP-mB92K27uhbUJU1p1r_wW1gFWFOEjXk";
+  const challenge = "E9Melhoa2OwvFrEMTJguCHaoeK1t8URWbuGJSstw-cM";
+  const client = clientStore.register({
+    redirect_uris: ["https://x.example/cb"],
+  });
+  const { code } = codeStore.issue({
+    clientId: client.client_id,
+    codeChallenge: challenge,
+    redirectUri: "https://x.example/cb",
+    ttlMs: 600_000,
+  });
+  const req = mockReq({
+    body: {
+      grant_type: "authorization_code",
+      code,
+      code_verifier: verifier,
+      client_id: client.client_id,
+      redirect_uri: "https://x.example/cb",
+    },
+    headers: {
+      host: "mcp.example.com",
+      "x-forwarded-proto": "https",
+      "x-forwarded-for": clientXForwardedFor,
+    },
+  });
+  const res = mockRes();
+  tokenHandler(req as never, res as never);
+  const body = res.json.mock.calls[0][0];
+  return {
+    client_id: client.client_id,
+    refresh_token: body.refresh_token,
+    access_token: body.access_token,
+  };
+}
+
+describe("tokenHandler — refresh_token grant", () => {
+  it("exchanges a valid refresh_token for a new access+refresh pair", () => {
+    const initial = issueInitialTokens("7.7.7.1");
+    const req = mockReq({
+      body: {
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: initial.client_id,
+      },
+      headers: {
+        host: "mcp.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "7.7.7.2",
+      },
+    });
+    const res = mockRes();
+    tokenHandler(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(200);
+    const body = res.json.mock.calls[0][0];
+    expect(body.access_token).toBeDefined();
+    expect(body.token_type).toBe("Bearer");
+    expect(body.expires_in).toBe(3600);
+    expect(body.refresh_token).toBeDefined();
+    expect(body.scope).toBe("mcp");
+  });
+
+  it("returns 400 invalid_request on missing refresh_token or client_id", () => {
+    const req = mockReq({
+      body: { grant_type: "refresh_token" },
+      headers: {
+        host: "mcp.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "7.7.7.3",
+      },
+    });
+    const res = mockRes();
+    tokenHandler(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json.mock.calls[0][0].error).toBe("invalid_request");
+  });
+
+  it("returns 400 invalid_grant on garbage refresh token", () => {
+    const req = mockReq({
+      body: {
+        grant_type: "refresh_token",
+        refresh_token: "not.a.valid.jwt",
+        client_id: "anything",
+      },
+      headers: {
+        host: "mcp.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "7.7.7.4",
+      },
+    });
+    const res = mockRes();
+    tokenHandler(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json.mock.calls[0][0].error).toBe("invalid_grant");
+  });
+
+  it("returns 400 invalid_grant when access_token is presented as refresh_token (missing typ)", () => {
+    const initial = issueInitialTokens("7.7.7.5");
+    const req = mockReq({
+      body: {
+        grant_type: "refresh_token",
+        refresh_token: initial.access_token, // access token has no typ:"refresh"
+        client_id: initial.client_id,
+      },
+      headers: {
+        host: "mcp.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "7.7.7.6",
+      },
+    });
+    const res = mockRes();
+    tokenHandler(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json.mock.calls[0][0].error).toBe("invalid_grant");
+  });
+
+  it("returns 400 invalid_grant when client_id does not match the refresh token", () => {
+    const initial = issueInitialTokens("7.7.7.7");
+    const req = mockReq({
+      body: {
+        grant_type: "refresh_token",
+        refresh_token: initial.refresh_token,
+        client_id: "some-other-client",
+      },
+      headers: {
+        host: "mcp.example.com",
+        "x-forwarded-proto": "https",
+        "x-forwarded-for": "7.7.7.8",
+      },
+    });
+    const res = mockRes();
+    tokenHandler(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json.mock.calls[0][0].error).toBe("invalid_grant");
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// Revocation
+// ──────────────────────────────────────────────────────────────────────
+
+describe("revocationHandler", () => {
+  it("returns 200 for any request body (RFC 7009 always-ack)", () => {
+    const req = mockReq({ body: { token: "whatever" } });
+    const res = mockRes();
+    revocationHandler(req as never, res as never);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it("returns 200 when no body is sent", () => {
+    const req = mockReq();
+    const res = mockRes();
+    revocationHandler(req as never, res as never);
     expect(res.status).toHaveBeenCalledWith(200);
   });
 });

--- a/src/__tests__/oauth-store.test.ts
+++ b/src/__tests__/oauth-store.test.ts
@@ -17,6 +17,23 @@ describe("ClientStore", () => {
     expect(result.redirect_uris).toEqual(["https://example.com/cb"]);
   });
 
+  it("register issues a client_secret with base64url encoding and secret metadata", () => {
+    const result = store.register({ redirect_uris: [] });
+    expect(result.client_secret).toBeDefined();
+    expect(typeof result.client_secret).toBe("string");
+    // base64url (no +/= chars); 32 bytes → 43 chars
+    expect(result.client_secret).toMatch(/^[A-Za-z0-9_-]+$/);
+    expect(result.client_secret.length).toBeGreaterThanOrEqual(32);
+    expect(result.client_secret_issued_at).toBe(result.client_id_issued_at);
+    expect(result.client_secret_expires_at).toBe(0);
+  });
+
+  it("two registers issue distinct client_secrets", () => {
+    const a = store.register({ redirect_uris: [] });
+    const b = store.register({ redirect_uris: [] });
+    expect(a.client_secret).not.toBe(b.client_secret);
+  });
+
   it("get(client_id) returns registered client", () => {
     const { client_id } = store.register({
       redirect_uris: ["https://example.com/cb"],

--- a/src/oauth/handlers.ts
+++ b/src/oauth/handlers.ts
@@ -27,7 +27,9 @@ import {
 } from "./rate-limiter.js";
 
 const TOKEN_TTL_SEC = 3600;
+const REFRESH_TOKEN_TTL_SEC = 30 * 24 * 3600; // 30 days
 const CODE_TTL_MS = 600_000;
+const TOKEN_SCOPE = "mcp";
 
 function originOf(req: Request): string {
   const proto = (req.headers["x-forwarded-proto"] as string) || "http";
@@ -90,10 +92,17 @@ export function authorizationServerHandler(req: Request, res: Response): void {
     authorization_endpoint: `${origin}/authorize`,
     token_endpoint: `${origin}/token`,
     registration_endpoint: `${origin}/register`,
+    revocation_endpoint: `${origin}/revoke`,
     response_types_supported: ["code"],
-    grant_types_supported: ["authorization_code"],
+    response_modes_supported: ["query"],
+    grant_types_supported: ["authorization_code", "refresh_token"],
     code_challenge_methods_supported: ["S256"],
-    token_endpoint_auth_methods_supported: ["none"],
+    token_endpoint_auth_methods_supported: [
+      "client_secret_basic",
+      "client_secret_post",
+      "none",
+    ],
+    scopes_supported: [TOKEN_SCOPE],
   });
 }
 
@@ -108,10 +117,15 @@ export function registerHandler(req: Request, res: Response): void {
     `[oauth] register body=${JSON.stringify(req.body)} headers.origin=${req.headers.origin} headers.user-agent=${req.headers["user-agent"]}`,
   );
 
-  const body = (req.body ?? {}) as { redirect_uris?: unknown };
+  const body = (req.body ?? {}) as {
+    redirect_uris?: unknown;
+    client_name?: unknown;
+  };
   const redirectUris = Array.isArray(body.redirect_uris)
     ? body.redirect_uris.filter((u): u is string => typeof u === "string")
     : [];
+  const clientName =
+    typeof body.client_name === "string" ? body.client_name : "";
 
   const client = clientStore.register({ redirect_uris: redirectUris });
   console.log(
@@ -119,11 +133,15 @@ export function registerHandler(req: Request, res: Response): void {
   );
   res.status(201).json({
     client_id: client.client_id,
+    client_secret: client.client_secret,
     client_id_issued_at: client.client_id_issued_at,
+    client_secret_issued_at: client.client_secret_issued_at,
+    client_secret_expires_at: client.client_secret_expires_at,
     redirect_uris: client.redirect_uris,
-    token_endpoint_auth_method: "none",
-    grant_types: ["authorization_code"],
+    client_name: clientName,
+    grant_types: ["authorization_code", "refresh_token"],
     response_types: ["code"],
+    token_endpoint_auth_method: "client_secret_basic",
   });
 }
 
@@ -215,6 +233,40 @@ export function authorizeHandler(req: Request, res: Response): void {
 // /token — RFC 6749 authorization_code grant with PKCE verification
 // ──────────────────────────────────────────────────────────────────────
 
+function issueTokenPair(
+  origin: string,
+  client_id: string,
+  secret: string,
+): { access_token: string; refresh_token: string } {
+  const iat = Math.floor(Date.now() / 1000);
+  const access_token = signJWT(
+    {
+      iss: origin,
+      aud: origin,
+      sub: "anonymous",
+      client_id,
+      iat,
+      exp: iat + TOKEN_TTL_SEC,
+      scope: TOKEN_SCOPE,
+    },
+    secret,
+  );
+  const refresh_token = signJWT(
+    {
+      iss: origin,
+      aud: origin,
+      sub: "anonymous",
+      client_id,
+      iat,
+      exp: iat + REFRESH_TOKEN_TTL_SEC,
+      typ: "refresh",
+      scope: TOKEN_SCOPE,
+    },
+    secret,
+  );
+  return { access_token, refresh_token };
+}
+
 export function tokenHandler(req: Request, res: Response): void {
   if (!enforceLimit(tokenLimiter, req, res)) return;
 
@@ -225,14 +277,66 @@ export function tokenHandler(req: Request, res: Response): void {
     `[oauth] token request grant_type=${body.grant_type} code=${String(body.code).slice(0, 8)} client_id=${body.client_id} redirect_uri=${body.redirect_uri} ip=${clientIp(req)}`,
   );
 
-  if (grant_type !== "authorization_code") {
+  if (grant_type !== "authorization_code" && grant_type !== "refresh_token") {
     res.status(400).json({
       error: "unsupported_grant_type",
-      error_description: "Only authorization_code is supported.",
+      error_description:
+        "Only authorization_code and refresh_token are supported.",
     });
     return;
   }
 
+  const origin = originOf(req);
+  const secret = getConfig().mcpJwtSecret;
+
+  if (grant_type === "refresh_token") {
+    const refresh_token = body.refresh_token;
+    const client_id = body.client_id;
+    if (!refresh_token || !client_id) {
+      res.status(400).json({
+        error: "invalid_request",
+        error_description: "Missing required fields: refresh_token, client_id.",
+      });
+      return;
+    }
+
+    let payload;
+    try {
+      payload = verifyJWT(refresh_token, secret, { aud: origin });
+    } catch {
+      res.status(400).json({
+        error: "invalid_grant",
+        error_description: "Invalid or expired refresh token.",
+      });
+      console.warn(
+        `[oauth] refresh invalid/expired token ip=${clientIp(req)} client=${client_id}`,
+      );
+      return;
+    }
+
+    if (payload.typ !== "refresh" || payload.client_id !== client_id) {
+      res.status(400).json({
+        error: "invalid_grant",
+        error_description: "Refresh token does not match the provided client.",
+      });
+      return;
+    }
+
+    const tokens = issueTokenPair(origin, client_id, secret);
+    console.log(
+      `[oauth] token refreshed client_id=${client_id} ip=${clientIp(req)}`,
+    );
+    res.status(200).json({
+      access_token: tokens.access_token,
+      token_type: "Bearer",
+      expires_in: TOKEN_TTL_SEC,
+      refresh_token: tokens.refresh_token,
+      scope: TOKEN_SCOPE,
+    });
+    return;
+  }
+
+  // authorization_code grant
   const code = body.code;
   const verifier = body.code_verifier;
   const client_id = body.client_id;
@@ -285,29 +389,27 @@ export function tokenHandler(req: Request, res: Response): void {
     return;
   }
 
-  const origin = originOf(req);
-  const iat = Math.floor(Date.now() / 1000);
-  const exp = iat + TOKEN_TTL_SEC;
-  const token = signJWT(
-    {
-      iss: origin,
-      aud: origin,
-      sub: "anonymous",
-      client_id,
-      iat,
-      exp,
-    },
-    getConfig().mcpJwtSecret,
-  );
-
+  const tokens = issueTokenPair(origin, client_id, secret);
   console.log(
     `[oauth] token issued client_id=${client_id} aud=${origin} exp_in=${TOKEN_TTL_SEC}s`,
   );
   res.status(200).json({
-    access_token: token,
+    access_token: tokens.access_token,
     token_type: "Bearer",
     expires_in: TOKEN_TTL_SEC,
+    refresh_token: tokens.refresh_token,
+    scope: TOKEN_SCOPE,
   });
+}
+
+// ──────────────────────────────────────────────────────────────────────
+// /revoke — RFC 7009 token revocation
+// ──────────────────────────────────────────────────────────────────────
+
+export function revocationHandler(_req: Request, res: Response): void {
+  // RFC 7009: always return 200 regardless of token validity/existence.
+  // We don't maintain a revocation list (tokens are short-lived); just ack.
+  res.status(200).send();
 }
 
 // ──────────────────────────────────────────────────────────────────────

--- a/src/oauth/store.ts
+++ b/src/oauth/store.ts
@@ -1,12 +1,23 @@
 // In-memory stores for OAuth state — dynamic clients and authorization codes.
 // Singleton exports match the `src/ip-limiter.ts` pattern.
 
-import { randomUUID } from "node:crypto";
+import { randomBytes, randomUUID } from "node:crypto";
 
 export interface RegisteredClient {
   client_id: string;
+  client_secret: string;
   client_id_issued_at: number;
+  client_secret_issued_at: number;
+  client_secret_expires_at: number;
   redirect_uris: string[];
+}
+
+function base64url(buf: Buffer): string {
+  return buf
+    .toString("base64")
+    .replace(/\+/g, "-")
+    .replace(/\//g, "_")
+    .replace(/=+$/g, "");
 }
 
 export interface AuthCode {
@@ -27,9 +38,13 @@ export class ClientStore {
   private clients = new Map<string, RegisteredClient>();
 
   register(input: { redirect_uris: string[] }): RegisteredClient {
+    const issuedAt = Math.floor(Date.now() / 1000);
     const client: RegisteredClient = {
       client_id: randomUUID(),
-      client_id_issued_at: Math.floor(Date.now() / 1000),
+      client_secret: base64url(randomBytes(32)),
+      client_id_issued_at: issuedAt,
+      client_secret_issued_at: issuedAt,
+      client_secret_expires_at: 0,
       redirect_uris: [...input.redirect_uris],
     };
     this.clients.set(client.client_id, client);

--- a/src/server.ts
+++ b/src/server.ts
@@ -37,6 +37,7 @@ import {
   registerHandler,
   authorizeHandler,
   tokenHandler,
+  revocationHandler,
   bearerMiddleware,
 } from "./oauth/handlers.js";
 import { WorkspaceManager } from "./workspace.js";
@@ -217,6 +218,7 @@ app.get("/.well-known/oauth-authorization-server", authorizationServerHandler);
 app.post("/register", registerHandler);
 app.get("/authorize", authorizeHandler);
 app.post("/token", tokenHandler);
+app.post("/revoke", revocationHandler);
 
 // ---------------------------------------------------------------------------
 // MCP endpoint — session-based (initialize once, then tool calls reuse session)


### PR DESCRIPTION
Fixes claude.ai MCP connector auth failure — flow was completing OAuth but claude.ai expected refresh_token grant and specific metadata fields.

## Summary

The OAuth 2.1 ceremony shipped in v1.12.0 completes end-to-end via curl but claude.ai's connector UI stalls after `/token` — it never calls `/mcp`. Comparison with Linear/Notion's public MCP OAuth endpoints identified missing response fields and grant types that claude.ai expects.

### Authorization server metadata (`/.well-known/oauth-authorization-server`)

Added fields to match Linear/Notion:
- `response_modes_supported: ["query"]`
- `grant_types_supported: ["authorization_code", "refresh_token"]`
- `token_endpoint_auth_methods_supported: ["client_secret_basic", "client_secret_post", "none"]`
- `revocation_endpoint: "<origin>/revoke"`
- `scopes_supported: ["mcp"]`

`code_challenge_methods_supported` remains `["S256"]` — we do not accept `plain`.

### Dynamic registration (`/register`)

Now issues a `client_secret` (32-byte base64url) and returns:
- `client_secret`, `client_secret_issued_at`, `client_secret_expires_at: 0` (never)
- `client_name` (echoed from request, empty string default)
- `grant_types: ["authorization_code", "refresh_token"]`
- `token_endpoint_auth_method: "client_secret_basic"`

### Token endpoint (`/token`)

- `authorization_code` grant now also returns `refresh_token` (30-day JWT with `typ: "refresh"`) and `scope: "mcp"`. Access-token JWT payload includes `scope: "mcp"`.
- New `refresh_token` grant: verifies the JWT, confirms `typ === "refresh"` and `client_id` match, and rotates both tokens.

### Revocation (`/revoke`)

New RFC 7009 endpoint — always returns 200 regardless of token state. Tokens are short-lived; no revocation list.

## Test plan

- [x] `npm test` — 14 new OAuth tests pass; 8292/8302 total (10 pre-existing failures in sibling worktrees, unrelated)
- [x] `npm run build` — clean
- [x] `npx prettier --check "src/**/*.ts"` — clean
- [ ] Re-test with the claude.ai connector UI once deployed to confirm `/mcp` is reached after `/token`