### PR TITLE
Add legacy SSE transport at /sse for claude.ai web connector

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.11.1",
+    "version": "1.12.0",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@copilotkit/pathfinder",
-            "version": "1.11.1",
+            "version": "1.12.0",
             "license": "Elastic-2.0",
             "dependencies": {
                 "@discordjs/rest": "^2.6.1",

--- a/src/__tests__/oauth-handlers.test.ts
+++ b/src/__tests__/oauth-handlers.test.ts
@@ -164,6 +164,7 @@ describe("registerHandler", () => {
       body: {
         redirect_uris: ["https://claude.ai/cb"],
         client_name: "Claude",
+        token_endpoint_auth_method: "client_secret_basic",
       },
     });
     const res = mockRes();
@@ -176,6 +177,7 @@ describe("registerHandler", () => {
     expect(body.client_name).toBe("Claude");
     expect(body.grant_types).toEqual(["authorization_code", "refresh_token"]);
     expect(body.response_types).toEqual(["code"]);
+    // Handler echoes the requested auth method (was previously hardcoded to client_secret_basic)
     expect(body.token_endpoint_auth_method).toBe("client_secret_basic");
   });
 

--- a/src/__tests__/sse-e2e.test.ts
+++ b/src/__tests__/sse-e2e.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+// Stable JWT secret so bearerMiddleware doesn't explode at import time.
+vi.mock("../config.js", () => ({
+  getConfig: vi.fn().mockReturnValue({
+    port: 0,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "e".repeat(64),
+  }),
+  getServerConfig: vi.fn().mockReturnValue({
+    server: { name: "pathfinder-e2e", version: "0.0.0" },
+    sources: [],
+    tools: [],
+  }),
+  getAnalyticsConfig: vi.fn(),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import { IpSessionLimiter } from "../ip-limiter.js";
+import { createSseHandlers } from "../sse-handlers.js";
+import { createMcpServer } from "../mcp/server.js";
+
+describe("SSE transport e2e (initialize handshake over /sse + /messages)", () => {
+  let server: Server | undefined;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleSpy.mockRestore();
+    if (server?.listening) {
+      await new Promise<void>((resolve, reject) =>
+        server!.close((err) => (err ? reject(err) : resolve())),
+      );
+    }
+    server = undefined;
+  });
+
+  it("completes MCP initialize handshake over /sse + /messages", async () => {
+    const app = express();
+    app.use(express.json());
+    const { getHandler, postHandler } = createSseHandlers({
+      sseTransports: {},
+      sessionLastActivity: {},
+      ipLimiter: new IpSessionLimiter(20),
+      createMcpServer: () => createMcpServer(),
+      workspaceManager: undefined,
+    });
+    app.get("/sse", getHandler);
+    app.post("/messages", postHandler);
+
+    server = await new Promise<Server>((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+    const addr = server.address() as AddressInfo;
+    const baseUrl = `http://127.0.0.1:${addr.port}`;
+
+    // 1. Open /sse and read the "endpoint" event to extract messages URL.
+    const sseRes = await fetch(`${baseUrl}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    expect(sseRes.status).toBe(200);
+    const reader = sseRes.body!.getReader();
+    const decoder = new TextDecoder();
+
+    let buffer = "";
+    async function readUntil(pred: (buf: string) => boolean): Promise<void> {
+      while (!pred(buffer)) {
+        const { value, done } = await reader.read();
+        if (done) throw new Error("SSE stream closed prematurely");
+        buffer += decoder.decode(value, { stream: true });
+      }
+    }
+
+    await readUntil((b) => b.includes("event: endpoint"));
+    const endpointMatch = buffer.match(
+      /data: (\/messages\?sessionId=[0-9a-f-]+)/,
+    );
+    expect(endpointMatch).not.toBeNull();
+    const endpoint = endpointMatch![1];
+
+    // 2. POST initialize via /messages.
+    const initRes = await fetch(`${baseUrl}${endpoint}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        id: 1,
+        method: "initialize",
+        params: {
+          protocolVersion: "2024-11-05",
+          capabilities: {},
+          clientInfo: { name: "test-client", version: "0.0.0" },
+        },
+      }),
+    });
+    expect(initRes.status).toBe(202);
+
+    // 3. Read the initialize response from the SSE stream.
+    await readUntil(
+      (b) => b.includes("event: message") && b.includes('"id":1'),
+    );
+    // Extract the JSON-RPC response from the SSE frame.
+    const msgMatch = buffer.match(/event: message\s*\ndata: (.+)/);
+    expect(msgMatch).not.toBeNull();
+    const response = JSON.parse(msgMatch![1]);
+    expect(response.jsonrpc).toBe("2.0");
+    expect(response.id).toBe(1);
+    expect(response.result).toBeDefined();
+    expect(response.result.protocolVersion).toBeDefined();
+    expect(response.result.serverInfo?.name).toBe("pathfinder-e2e");
+
+    await reader.cancel();
+  });
+});

--- a/src/__tests__/sse-transport.test.ts
+++ b/src/__tests__/sse-transport.test.ts
@@ -1,0 +1,361 @@
+import {
+  describe,
+  it,
+  expect,
+  beforeAll,
+  afterAll,
+  beforeEach,
+  afterEach,
+  vi,
+} from "vitest";
+import express from "express";
+import type { Server } from "node:http";
+import type { AddressInfo } from "node:net";
+import { randomUUID } from "node:crypto";
+
+// Stable JWT secret for bearer middleware tests.
+vi.mock("../config.js", () => ({
+  getConfig: vi.fn().mockReturnValue({
+    port: 0,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "e".repeat(64),
+  }),
+  getServerConfig: vi.fn().mockReturnValue({
+    server: { name: "pathfinder-test", version: "0.0.0" },
+    sources: [],
+    tools: [],
+  }),
+  getAnalyticsConfig: vi.fn(),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import { IpSessionLimiter } from "../ip-limiter.js";
+import { createSseHandlers, type SseHandlerDeps } from "../sse-handlers.js";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function buildApp(overrides: Partial<SseHandlerDeps> = {}): {
+  app: express.Express;
+  deps: SseHandlerDeps;
+} {
+  const sseTransports: SseHandlerDeps["sseTransports"] = {};
+  const sessionLastActivity: SseHandlerDeps["sessionLastActivity"] = {};
+  const deps: SseHandlerDeps = {
+    sseTransports,
+    sessionLastActivity,
+    ipLimiter: new IpSessionLimiter(20),
+    createMcpServer: () => {
+      // Minimal stub: a "server" with a connect() that registers transport handlers.
+      return {
+        connect: vi.fn(async (transport: unknown) => {
+          // Mimic SDK behavior: invoke transport.start() if present.
+          const t = transport as { start?: () => Promise<void> };
+          if (t.start) await t.start();
+        }),
+      } as unknown as ReturnType<SseHandlerDeps["createMcpServer"]>;
+    },
+    workspaceManager: undefined,
+    ...overrides,
+  };
+
+  const app = express();
+  app.use(express.json());
+  const { getHandler, postHandler } = createSseHandlers(deps);
+  app.get("/sse", getHandler);
+  app.post("/messages", postHandler);
+  return { app, deps };
+}
+
+function startServer(app: express.Express): Promise<Server> {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+function closeServer(server: Server | undefined): Promise<void> {
+  if (!server) return Promise.resolve();
+  return new Promise((resolve, reject) => {
+    server.close((err) => (err ? reject(err) : resolve()));
+  });
+}
+
+function baseUrlOf(server: Server): string {
+  const addr = server.address() as AddressInfo;
+  return `http://127.0.0.1:${addr.port}`;
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe("SSE transport routes", () => {
+  let server: Server | undefined;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    await closeServer(server);
+    server = undefined;
+  });
+
+  it("GET /sse returns 200 with text/event-stream Content-Type and writes an endpoint event", async () => {
+    const { app } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+
+    expect(res.status).toBe(200);
+    expect(res.headers.get("content-type")).toMatch(/text\/event-stream/);
+
+    // Read a small portion of the stream to confirm the SDK emitted the
+    // "event: endpoint" line, then close the connection.
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    for (let i = 0; i < 5; i++) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+      if (buffer.includes("event: endpoint")) break;
+    }
+    await reader.cancel();
+
+    expect(buffer).toContain("event: endpoint");
+    expect(buffer).toMatch(/data: \/messages\?sessionId=[0-9a-f-]+/);
+  });
+
+  it("GET /sse registers the session in sseTransports and sessionLastActivity", async () => {
+    const { app, deps } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    // Wait until we see the endpoint event so session is registered.
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+
+    const match = buffer.match(/sessionId=([0-9a-f-]+)/);
+    expect(match).not.toBeNull();
+    const sid = match![1];
+
+    expect(deps.sseTransports[sid]).toBeDefined();
+    expect(deps.sessionLastActivity[sid]).toBeGreaterThan(0);
+
+    await reader.cancel();
+  });
+
+  it("GET /sse returns 401 with an invalid Bearer token (via bearerMiddleware)", async () => {
+    const { app } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: {
+        Accept: "text/event-stream",
+        Authorization: "Bearer this.is.not.a.jwt",
+      },
+    });
+
+    expect(res.status).toBe(401);
+  });
+
+  it("GET /sse returns 200 with no Authorization header (opportunistic auth)", async () => {
+    const { app } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`);
+    expect(res.status).toBe(200);
+    await res.body?.cancel();
+  });
+
+  it("POST /messages with bogus sessionId returns 404", async () => {
+    const { app } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/messages?sessionId=${randomUUID()}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("POST /messages without a sessionId query param returns 404", async () => {
+    const { app } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+
+    expect(res.status).toBe(404);
+  });
+
+  it("GET /sse then POST /messages forwards the message to the session transport", async () => {
+    const { app, deps } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const sseRes = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = sseRes.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+
+    // Spy on the transport's handlePostMessage.
+    const transport = deps.sseTransports[sid];
+    expect(transport).toBeDefined();
+    const spy = vi
+      .spyOn(transport, "handlePostMessage")
+      .mockImplementation(async (_req, res) => {
+        res.writeHead(202).end();
+      });
+
+    const activityBefore = deps.sessionLastActivity[sid];
+    // Ensure clock tick so activity timestamp advances.
+    await new Promise((r) => setTimeout(r, 5));
+
+    const postRes = await fetch(`${url}/messages?sessionId=${sid}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+
+    expect(postRes.status).toBe(202);
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(deps.sessionLastActivity[sid]).toBeGreaterThanOrEqual(
+      activityBefore,
+    );
+
+    await reader.cancel();
+  });
+
+  it("GET /sse enforces IP rate limit via ipLimiter", async () => {
+    // IpSessionLimiter capped at 1; second concurrent GET from same IP should 429.
+    const limiter = new IpSessionLimiter(1);
+    const { app } = buildApp({ ipLimiter: limiter });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const first = await fetch(`${url}/sse`);
+    expect(first.status).toBe(200);
+    // Do not close first — keep the session active so the counter stays at 1.
+
+    const second = await fetch(`${url}/sse`);
+    expect(second.status).toBe(429);
+
+    await first.body?.cancel();
+    await second.body?.cancel();
+  });
+
+  it("closing the SSE stream removes the session from sseTransports", async () => {
+    const { app, deps } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+    expect(deps.sseTransports[sid]).toBeDefined();
+
+    // Cancel the reader to close the client side of the stream.
+    await reader.cancel();
+
+    // Wait briefly for server-side 'close' event to propagate.
+    await new Promise((r) => setTimeout(r, 50));
+    expect(deps.sseTransports[sid]).toBeUndefined();
+  });
+});
+
+describe("reapIdleSseSessions", () => {
+  it("removes SSE sessions whose last activity exceeds TTL", async () => {
+    const { reapIdleSseSessions } = await import("../sse-handlers.js");
+
+    const sseTransports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+
+    const closed: string[] = [];
+    const now = Date.now();
+    // Fresh session (recent activity) — should not be reaped
+    sseTransports["fresh"] = {
+      close: async () => {
+        closed.push("fresh");
+      },
+    };
+    sessionLastActivity["fresh"] = now - 1000;
+    // Stale session — should be reaped
+    sseTransports["stale"] = {
+      close: async () => {
+        closed.push("stale");
+      },
+    };
+    sessionLastActivity["stale"] = now - 10 * 60 * 1000;
+
+    const reaped = reapIdleSseSessions({
+      sseTransports: sseTransports as unknown as Parameters<
+        typeof reapIdleSseSessions
+      >[0]["sseTransports"],
+      sessionLastActivity,
+      ttlMs: 5 * 60 * 1000,
+      now,
+    });
+
+    expect(reaped).toEqual(["stale"]);
+    expect(sseTransports["stale"]).toBeUndefined();
+    expect(sseTransports["fresh"]).toBeDefined();
+  });
+});

--- a/src/server.ts
+++ b/src/server.ts
@@ -3,8 +3,10 @@ import cors from "cors";
 import { randomUUID } from "node:crypto";
 import { Bash } from "just-bash";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
+import type { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import { isInitializeRequest } from "@modelcontextprotocol/sdk/types.js";
 import { createMcpServer } from "./mcp/server.js";
+import { createSseHandlers, reapIdleSseSessions } from "./sse-handlers.js";
 import { buildBashFilesMap, rebuildBashInstance } from "./mcp/tools/bash-fs.js";
 import { initializeSchema, closePool } from "./db/client.js";
 import {
@@ -243,17 +245,20 @@ app.post("/revoke", revocationHandler);
 // ---------------------------------------------------------------------------
 
 const transports: Record<string, StreamableHTTPServerTransport> = {};
+const sseTransports: Record<string, SSEServerTransport> = {};
 const sessionLastActivity: Record<string, number> = {};
 let SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes default, overridden by config
 let ipLimiter: IpSessionLimiter | undefined;
 let workspaceManager: WorkspaceManager | undefined;
 
-// Reap idle sessions every 5 minutes
+// Reap idle sessions every 5 minutes (both /mcp Streamable HTTP and /sse legacy SSE)
 setInterval(
   () => {
     const now = Date.now();
     let reaped = 0;
     for (const sid of Object.keys(sessionLastActivity)) {
+      // Skip SSE-owned sessions — they're reaped by reapIdleSseSessions below.
+      if (sseTransports[sid]) continue;
       if (now - sessionLastActivity[sid] > SESSION_TTL_MS) {
         delete transports[sid];
         delete sessionLastActivity[sid];
@@ -284,6 +289,36 @@ setInterval(
     if (reaped > 0) {
       console.log(
         `[mcp] Reaped ${reaped} idle sessions (${Object.keys(transports).length} active)`,
+      );
+    }
+
+    // Reap idle SSE sessions. reapIdleSseSessions closes the transport (which
+    // triggers our onclose → removes from sseTransports, ipLimiter, workspace)
+    // and also defensively clears the maps itself.
+    const reapedSse = reapIdleSseSessions({
+      sseTransports,
+      sessionLastActivity,
+      ttlMs: SESSION_TTL_MS,
+      now,
+    });
+    for (const sid of reapedSse) {
+      try {
+        ipLimiter?.remove(sid);
+      } catch (e) {
+        console.error(`[mcp] SSE IP limiter cleanup failed:`, e);
+      }
+      try {
+        workspaceManager?.cleanup(sid);
+      } catch (e) {
+        console.error(
+          `[mcp] SSE workspace cleanup failed for ${sid.slice(0, 8)}:`,
+          e,
+        );
+      }
+    }
+    if (reapedSse.length > 0) {
+      console.log(
+        `[mcp] Reaped ${reapedSse.length} idle SSE sessions (${Object.keys(sseTransports).length} SSE active)`,
       );
     }
   },
@@ -439,6 +474,45 @@ app.delete("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
     });
   }
 });
+
+// ---------------------------------------------------------------------------
+// Legacy SSE transport — /sse (GET, opens stream) + /messages (POST, client→server)
+//
+// Claude.ai's web connector and older MCP clients probe /sse before falling
+// back to Streamable HTTP. Hidden showcase docs point users at
+// https://mcp.copilotkit.ai/sse, so we serve both transports side-by-side.
+// ---------------------------------------------------------------------------
+
+const sseHandlers = createSseHandlers({
+  sseTransports,
+  sessionLastActivity,
+  ipLimiter: () => ipLimiter,
+  workspaceManager: () => workspaceManager,
+  createMcpServer: () => {
+    let transportRef: SSEServerTransport | undefined;
+    // The handler creates the transport first, then calls createMcpServer()
+    // and connect(transport). We need the sessionId late-bound so bash tools
+    // can discover it via getSessionId().
+    const server = createMcpServer(
+      bashInstances,
+      sessionStateManager,
+      () => transportRef?.sessionId,
+      bashTelemetry,
+      workspaceManager,
+    );
+    // Intercept connect() so we can capture the transport reference for
+    // the getSessionId closure above.
+    const origConnect = server.connect.bind(server);
+    server.connect = async (t) => {
+      transportRef = t as SSEServerTransport;
+      return origConnect(t);
+    };
+    return server;
+  },
+});
+
+app.get("/sse", ...sseHandlers.getHandler);
+app.post("/messages", ...sseHandlers.postHandler);
 
 // ---------------------------------------------------------------------------
 // Health check
@@ -930,6 +1004,18 @@ export async function startServer(options?: ServerOptions): Promise<void> {
       await bashTelemetry?.flush();
     } catch (e) {
       console.error("[shutdown] Telemetry flush failed:", e);
+    }
+    // Close all open SSE transports so hanging streams don't block exit.
+    for (const sid of Object.keys(sseTransports)) {
+      try {
+        await sseTransports[sid].close();
+      } catch (e) {
+        console.error(
+          `[shutdown] SSE transport close failed for ${sid.slice(0, 8)}:`,
+          e,
+        );
+      }
+      delete sseTransports[sid];
     }
     try {
       workspaceManager?.cleanupAll();

--- a/src/sse-handlers.ts
+++ b/src/sse-handlers.ts
@@ -1,0 +1,176 @@
+import type { Request, Response, RequestHandler } from "express";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { bearerMiddleware } from "./oauth/handlers.js";
+import type { IpSessionLimiter } from "./ip-limiter.js";
+import type { WorkspaceManager } from "./workspace.js";
+
+/**
+ * Dependencies for the SSE endpoint handlers.
+ *
+ * State is injected (not module-scoped) so tests can exercise handlers against
+ * isolated maps without poisoning shared server.ts state.
+ */
+export interface SseHandlerDeps {
+  sseTransports: Record<string, SSEServerTransport>;
+  sessionLastActivity: Record<string, number>;
+  /**
+   * IP rate limiter. Accepts either a direct instance or a getter to support
+   * late binding in server.ts (the limiter is constructed during startServer()).
+   */
+  ipLimiter:
+    | IpSessionLimiter
+    | undefined
+    | (() => IpSessionLimiter | undefined);
+  createMcpServer: () => McpServer;
+  /**
+   * Workspace manager. Accepts either a direct instance or a getter to support
+   * late binding in server.ts.
+   */
+  workspaceManager:
+    | WorkspaceManager
+    | undefined
+    | (() => WorkspaceManager | undefined);
+}
+
+function resolve<T>(value: T | (() => T)): T {
+  return typeof value === "function" ? (value as () => T)() : value;
+}
+
+function clientIp(req: Request): string {
+  return (
+    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
+    req.socket.remoteAddress ||
+    "unknown"
+  );
+}
+
+/**
+ * Create the /sse (GET) and /messages (POST) handler pair for the legacy
+ * MCP SSE transport. Bearer auth is enforced via the same bearerMiddleware
+ * used by /mcp (opportunistic — missing/invalid bearer behaves like /mcp).
+ *
+ * The returned handlers include bearerMiddleware in their middleware chain so
+ * that callers only need to register a single handler per route.
+ */
+export function createSseHandlers(deps: SseHandlerDeps): {
+  getHandler: RequestHandler[];
+  postHandler: RequestHandler[];
+} {
+  const { sseTransports, sessionLastActivity, createMcpServer } = deps;
+
+  const sseGet: RequestHandler = async (req: Request, res: Response) => {
+    const ip = clientIp(req);
+    const ipLimiter = resolve(deps.ipLimiter);
+    const workspaceManager = resolve(deps.workspaceManager);
+
+    try {
+      // Create transport. sessionId is assigned in the constructor.
+      const transport = new SSEServerTransport("/messages", res);
+      const sessionId = transport.sessionId;
+
+      // IP rate limit — same counter as /mcp.
+      if (ipLimiter && !ipLimiter.tryAdd(ip, sessionId)) {
+        console.warn(
+          `[mcp] IP rate limit exceeded for ${ip}, rejecting SSE session`,
+        );
+        res.status(429).json({ error: "Too many sessions from this IP" });
+        return;
+      }
+
+      sseTransports[sessionId] = transport;
+      sessionLastActivity[sessionId] = Date.now();
+      workspaceManager?.ensureSession(sessionId);
+
+      // Wire cleanup before connect() so a start() failure still fires it.
+      const cleanup = () => {
+        if (sseTransports[sessionId]) {
+          delete sseTransports[sessionId];
+          delete sessionLastActivity[sessionId];
+          ipLimiter?.remove(sessionId);
+          workspaceManager?.cleanup(sessionId);
+          console.log(
+            `[mcp] SSE session ${sessionId.slice(0, 8)} closed (${Object.keys(sseTransports).length} active)`,
+          );
+        }
+      };
+      transport.onclose = cleanup;
+      res.on("close", cleanup);
+
+      // Attach a per-session MCP server. createMcpServer().connect() calls
+      // transport.start() internally which writes SSE headers + the
+      // "endpoint" event to the response stream.
+      const server = createMcpServer();
+      await server.connect(transport);
+
+      console.log(
+        `[mcp] New SSE session ${sessionId.slice(0, 8)} (${Object.keys(sseTransports).length} active) [${ip}]`,
+      );
+    } catch (err) {
+      console.error("[mcp] SSE connection error:", err);
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Failed to establish SSE session" });
+      }
+    }
+  };
+
+  const messagesPost: RequestHandler = async (req: Request, res: Response) => {
+    const sessionId = req.query.sessionId;
+    if (typeof sessionId !== "string" || !sessionId) {
+      res.status(404).json({ error: "Session not found" });
+      return;
+    }
+    const transport = sseTransports[sessionId];
+    if (!transport) {
+      res.status(404).json({ error: "Session not found" });
+      return;
+    }
+    sessionLastActivity[sessionId] = Date.now();
+    try {
+      await transport.handlePostMessage(req, res, req.body);
+    } catch (err) {
+      console.error(
+        `[mcp] SSE handlePostMessage failed for session ${sessionId.slice(0, 8)}:`,
+        err,
+      );
+      if (!res.headersSent) {
+        res.status(500).json({ error: "Message handling failed" });
+      }
+    }
+  };
+
+  return {
+    getHandler: [bearerMiddleware, sseGet],
+    postHandler: [bearerMiddleware, messagesPost],
+  };
+}
+
+/**
+ * Reap idle SSE sessions. Pure function for testability — server.ts calls
+ * this from its periodic reaper alongside the existing Streamable-HTTP reaper.
+ */
+export function reapIdleSseSessions(opts: {
+  sseTransports: Record<string, { close: () => Promise<void> | void }>;
+  sessionLastActivity: Record<string, number>;
+  ttlMs: number;
+  now?: number;
+}): string[] {
+  const { sseTransports, sessionLastActivity, ttlMs } = opts;
+  const now = opts.now ?? Date.now();
+  const reaped: string[] = [];
+  for (const sid of Object.keys(sseTransports)) {
+    const last = sessionLastActivity[sid] ?? 0;
+    if (now - last > ttlMs) {
+      const transport = sseTransports[sid];
+      try {
+        void transport.close();
+      } catch (e) {
+        console.error(`[mcp] SSE close failed for ${sid.slice(0, 8)}:`, e);
+      }
+      delete sseTransports[sid];
+      delete sessionLastActivity[sid];
+      reaped.push(sid);
+    }
+  }
+  return reaped;
+}


### PR DESCRIPTION
## Summary

- Adds GET /sse (SSE stream) + POST /messages (JSON-RPC sink) alongside the existing /mcp Streamable HTTP transport, using the MCP SDK's SSEServerTransport
- Claude.ai web connector probes /sse. Users configured with https://mcp.copilotkit.ai/sse per hidden showcase docs were failing because we only offered /mcp. This fixes that path while leaving /mcp Streamable HTTP intact.
- Per-session MCP server, shared bash instances, shared IpSessionLimiter + WorkspaceManager, shared sessionLastActivity + TTL reaper, opportunistic bearerMiddleware — full parity with /mcp

## Design

- `src/sse-handlers.ts` — new module that returns `getHandler` / `postHandler` pairs from a `createSseHandlers(deps)` factory. State (sseTransports map, sessionLastActivity, ipLimiter, workspaceManager, createMcpServer) is injected so unit tests isolate the handlers from server.ts module state.
- `src/server.ts` — registers the routes, wires a per-session McpServer closure that late-binds sessionId via the transport reference (same pattern /mcp uses), folds SSE reaping into the existing 5-minute interval, and closes open SSE transports on graceful shutdown.
- Reaping: Streamable-HTTP reaper skips SSE-owned ids (identified by presence in sseTransports) so the SSE reaper owns those; both share sessionLastActivity.

## Test plan

- [x] Unit tests (`src/__tests__/sse-transport.test.ts`, 10 cases): content-type, endpoint event, session registration, 401 on invalid bearer, 200 on no bearer (opportunistic), POST /messages 404 on bogus/missing sessionId, POST forwards to transport and bumps activity, IP limiter returns 429 when cap hit, client disconnect cleans up the map, reapIdleSseSessions reaps only stale sessions
- [x] E2E test (`src/__tests__/sse-e2e.test.ts`, 1 case): full MCP initialize handshake over the real SSEServerTransport + McpServer
- [x] `npm run build` clean
- [x] `npx prettier --check` clean
- [x] Full suite: 1202 passing / 7 pre-existing failures (baseline was 1191 + 7; +11 new tests all green). No /mcp regression.