### PR TITLE
docs: OAuth + SSE transport for Pathfinder users

### DIFF
--- a/docs/clients/index.html
+++ b/docs/clients/index.html
@@ -248,7 +248,18 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
 
   <main class="docs-content">
     <h1>MCP <span class="accent">Client</span> Setup</h1>
-    <p class="lead">Point your AI agent at Pathfinder. Any client that supports Streamable HTTP transport works.</p>
+    <p class="lead">Pathfinder supports both the modern Streamable HTTP transport (<code>/mcp</code>) and the legacy SSE transport (<code>/sse</code>). OAuth authentication is automatic — no user accounts needed; clients register dynamically.</p>
+
+    <h2>Transport Choices</h2>
+
+    <p>Two endpoints ship in every Pathfinder instance. Pick the one your client supports:</p>
+
+    <ul>
+        <li><strong>Streamable HTTP (<code>/mcp</code>)</strong> — recommended for modern clients (Claude Code, Cursor HTTP mode, OpenCode).</li>
+        <li><strong>SSE (<code>/sse</code> + <code>/messages</code>)</strong> — legacy transport; needed for the claude.ai web connector and older MCP clients.</li>
+    </ul>
+
+    <p>Both transports share the same tools, sessions, and OAuth flow. Clients without a bearer token pass through; invalid bearers are rejected with 401.</p>
 
     <h2>Client Configurations</h2>
 
@@ -278,6 +289,17 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     }
   }
 }</div>
+    </div>
+
+    <div class="client-card">
+        <h3>Claude.ai (Web Connector)</h3>
+        <div class="config-path">Settings &rarr; Connectors &rarr; Add custom connector</div>
+        <p>claude.ai uses the legacy SSE transport. Paste your Pathfinder URL into the custom connector dialog, then click <strong>Authenticate</strong> — the OAuth handshake runs automatically and the connector is approved anonymously.</p>
+        <div class="code-block"><span class="comment"># Streamable HTTP (newer clients)</span>
+<span class="key">URL:</span> <span class="value">https://your-pathfinder-host/mcp</span>
+
+<span class="comment"># SSE (claude.ai and older clients)</span>
+<span class="key">URL:</span> <span class="value">https://your-pathfinder-host/sse</span></div>
     </div>
 
     <div class="client-card">

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -623,6 +623,37 @@ https://docs.example.com/getting-started</div>
 
     <p>Point a GitHub webhook at <code>https://your-server/webhooks/github</code> with the <code>push</code> event. Set <code>GITHUB_WEBHOOK_SECRET</code> to match the webhook secret.</p>
 
+    <h2 id="authentication">Authentication</h2>
+
+    <p>Pathfinder runs an anonymous OAuth 2.1 ceremonial flow for MCP clients. No user accounts, no sign-up, no dashboard — clients that perform the handshake receive a token whose subject is always <code>anonymous</code>. This satisfies MCP clients that require OAuth (claude.ai, newer Claude Code builds) while keeping Pathfinder a pure knowledge server.</p>
+
+    <p>There is nothing to configure in <code>pathfinder.yaml</code>. The only environment variable required is <code>MCP_JWT_SECRET</code> in production — see the <a href="/deploy#environment-variables">Deployment Guide</a>.</p>
+
+    <h3 id="auth-endpoints">OAuth endpoints</h3>
+
+    <p>All standard OAuth 2.1 + dynamic client registration endpoints are served automatically:</p>
+
+    <ul>
+        <li><strong><code>/.well-known/oauth-protected-resource</code></strong> — resource metadata (RFC 9728).</li>
+        <li><strong><code>/.well-known/oauth-authorization-server</code></strong> — authorization server metadata (RFC 8414).</li>
+        <li><strong><code>/register</code></strong> — dynamic client registration (RFC 7591). Clients register themselves on first connect.</li>
+        <li><strong><code>/authorize</code></strong> — authorization endpoint. Renders a one-click approve page and redirects with a code.</li>
+        <li><strong><code>/token</code></strong> — token endpoint. Exchanges codes or refresh tokens for access tokens.</li>
+        <li><strong><code>/revoke</code></strong> — token revocation (RFC 7009).</li>
+    </ul>
+
+    <h3 id="auth-bearer">Bearer auth on <code>/mcp</code> and <code>/sse</code></h3>
+
+    <p>Both transport endpoints use <em>opportunistic</em> bearer authentication:</p>
+
+    <ul>
+        <li>Requests without an <code>Authorization</code> header pass through unchanged — useful for clients that don't speak OAuth.</li>
+        <li>Requests with a valid bearer token attach the token claims to the session.</li>
+        <li>Requests with an invalid or expired bearer are rejected with <code>401 Unauthorized</code> and a <code>WWW-Authenticate</code> challenge pointing at the resource metadata endpoint.</li>
+    </ul>
+
+    <p>Clients that see the 401 challenge automatically discover the OAuth server, register, and retry with a valid token. Rotating <code>MCP_JWT_SECRET</code> invalidates all issued tokens at once — clients re-authenticate transparently on the next request.</p>
+
     <h2 id="analytics">analytics</h2>
 
     <p>Optional. Enables query logging and the built-in analytics dashboard at <code>/analytics</code>.</p>

--- a/docs/deploy/index.html
+++ b/docs/deploy/index.html
@@ -397,6 +397,7 @@ server {
         </thead>
         <tbody>
             <tr><td><code>DATABASE_URL</code></td><td>For search tools</td><td>-</td><td>PostgreSQL connection string (with pgvector)</td></tr>
+            <tr><td><code>MCP_JWT_SECRET</code></td><td><strong>Required in production</strong></td><td>-</td><td>HMAC secret for signing OAuth access/refresh tokens. Generate with <code>openssl rand -hex 32</code>. Rotating this invalidates all issued tokens — clients will re-authenticate transparently. In development mode (<code>NODE_ENV=development</code>) a random secret is generated per process and logged as a warning.</td></tr>
             <tr><td><code>OPENAI_API_KEY</code></td><td>When embedding.provider is "openai" (default)</td><td>-</td><td>OpenAI API key for computing embeddings. Not needed for ollama or local providers.</td></tr>
             <tr><td><code>GITHUB_TOKEN</code></td><td>For private repos</td><td>-</td><td>GitHub PAT for cloning private repositories</td></tr>
             <tr><td><code>GITHUB_WEBHOOK_SECRET</code></td><td>For webhooks</td><td>-</td><td>Secret for validating GitHub webhook payloads</td></tr>
@@ -414,6 +415,11 @@ server {
             <tr><td><code>ANALYTICS_TOKEN</code></td><td>When analytics enabled</td><td>-</td><td>Bearer token for authenticating <code>/api/analytics/*</code> endpoints</td></tr>
         </tbody>
     </table>
+
+    <div class="gap-card">
+        <h4>MCP_JWT_SECRET must be set in production</h4>
+        <p><code>MCP_JWT_SECRET</code> MUST be set before <code>NODE_ENV=production</code> — the server will throw on startup if it's missing. See <a href="/config#authentication">Authentication</a> for how the OAuth flow uses this secret.</p>
+    </div>
 
     <h3 id="optional-dependencies">Optional dependencies</h3>
     <p>Some features require extra packages that are not bundled by default. Install only the ones your config needs:</p>


### PR DESCRIPTION
## Summary

Documents the two features that shipped today so external users can self-serve.

## Changes per file

- **`docs/clients/index.html`** — rewrote intro lead to mention both transports + automatic OAuth; added **Transport Choices** section explaining `/mcp` vs `/sse`; added new **Claude.ai (Web Connector)** client card with SSE URL and one-click Authenticate flow.
- **`docs/config/index.html`** — new **Authentication** top-level section covering the anonymous OAuth 2.1 ceremonial flow, every well-known/register/authorize/token/revoke endpoint, and opportunistic bearer auth on `/mcp` + `/sse`. Links out to the deploy guide for `MCP_JWT_SECRET`.
- **`docs/deploy/index.html`** — added `MCP_JWT_SECRET` row to the env variables table (Required in production, with generation command and rotation behavior) plus a warning callout ("MUST be set before `NODE_ENV=production`") linking to the new Authentication section in config.

## Scope decisions

- **Sidebar** — left untouched. The new Authentication heading lives inside the existing Config Reference page and is auto-discovered by the right-side page TOC; adding a nav entry would bloat the sidebar for a sub-section.
- **Homepage** — skipped. Feature grid is exactly 3x3 (9 cards); a 10th would break the grid.

## Test plan

- [x] Served via `python3 -m http.server` — all three pages return 200 and render the new content.
- [x] Cross-links verified: `/config#authentication` and `/deploy#environment-variables` resolve to real anchor ids (latter auto-generated by `sidebar.js` from the existing h2).
- [x] HTML tag-balance check on all three files — no unclosed or mismatched tags.
- [x] Uses existing CSS classes only (`client-card`, `code-block`, `env-table`, `gap-card`) — no new design patterns introduced.