### PR TITLE
Analytics: date range picker with custom range + chart bar click

### DIFF
--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -255,8 +255,44 @@
         // --- State ---
         var activeToolType = null;  // null = "All"
         var activeSource = null;    // null = "All Sources"
+        var activeDaysBack = 7;     // number of days for preset window (null when using custom range)
+        var activeFrom = null;      // YYYY-MM-DD string or null
+        var activeTo = null;        // YYYY-MM-DD string or null
         var dailyChartInstance = null;
         var sourceChartInstance = null;
+        var datePopoverOpen = false;
+        var dateCustomMode = false;
+
+        // Intl formatters (cached)
+        var shortDateFmt = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
+
+        function parseISODate(s) {
+            // Parse YYYY-MM-DD as a local-noon Date so DST/TZ doesn't shift the day label.
+            var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
+            if (!m) return null;
+            return new Date(parseInt(m[1], 10), parseInt(m[2], 10) - 1, parseInt(m[3], 10), 12, 0, 0);
+        }
+
+        function formatPillLabel() {
+            if (activeFrom && activeTo) {
+                if (activeFrom === activeTo) {
+                    var d = parseISODate(activeFrom);
+                    return d ? shortDateFmt.format(d) : activeFrom;
+                }
+                var df = parseISODate(activeFrom);
+                var dt = parseISODate(activeTo);
+                if (df && dt) return shortDateFmt.format(df) + ' \u2013 ' + shortDateFmt.format(dt);
+                return activeFrom + ' \u2013 ' + activeTo;
+            }
+            if (activeDaysBack === 1) return 'Today';
+            if (activeDaysBack === 7) return 'Last 7 days';
+            if (activeDaysBack === 14) return 'Last 14 days';
+            if (activeDaysBack === 30) return 'Last 30 days';
+            if (activeDaysBack === 90) return 'Last 90 days';
+            if (activeDaysBack !== null && activeDaysBack >= 99999) return 'All time';
+            if (activeDaysBack !== null) return 'Last ' + activeDaysBack + ' days';
+            return 'Custom range';
+        }
 
         function getToken() {
             return sessionStorage.getItem('pathfinder_analytics_token') || '';
@@ -306,6 +342,12 @@
             var params = [];
             if (activeToolType) params.push('tool_type=' + encodeURIComponent(activeToolType));
             if (activeSource) params.push('source=' + encodeURIComponent(activeSource));
+            if (activeFrom && activeTo) {
+                params.push('from=' + encodeURIComponent(activeFrom));
+                params.push('to=' + encodeURIComponent(activeTo));
+            } else if (activeDaysBack !== null) {
+                params.push('days=' + encodeURIComponent(activeDaysBack));
+            }
             return params.length > 0 ? '&' + params.join('&') : '';
         }
 
@@ -326,39 +368,69 @@
             });
             toolHtml += '</div>';
 
-            // Date-range group (center) — MOCKUP, not functional
+            // Date-range group (center)
+            var presets = [
+                { label: 'Today',         days: 1 },
+                { label: 'Last 7 days',   days: 7 },
+                { label: 'Last 14 days',  days: 14 },
+                { label: 'Last 30 days',  days: 30 },
+                { label: 'Last 90 days',  days: 90 },
+                { label: 'All time',      days: 99999 },
+            ];
+            var pillLabel = formatPillLabel();
+            var customModeCls = dateCustomMode ? ' custom-mode' : '';
+            var openCls = datePopoverOpen ? ' open' : '';
+            var presetHtml = presets.map(function(p) {
+                var isActive = activeDaysBack === p.days && !activeFrom;
+                return '<div class="preset' + (isActive ? ' active' : '') + '" data-days="' + p.days + '">'
+                    + '<span>' + esc(p.label) + '</span>'
+                    + '<span class="check">&#10003;</span></div>';
+            }).join('');
+            var customActive = dateCustomMode || (activeFrom && activeTo);
+            presetHtml += '<div class="preset' + (customActive ? ' active' : '') + '" data-custom="1">'
+                + '<span>Custom&hellip;</span>'
+                + '<span class="check">&#10003;</span></div>';
+
+            // Default the custom-range inputs to whatever is active, falling back to today/week.
+            var today = new Date();
+            function toISO(d) {
+                var y = d.getFullYear(), m = String(d.getMonth() + 1).padStart(2, '0'), dd = String(d.getDate()).padStart(2, '0');
+                return y + '-' + m + '-' + dd;
+            }
+            var defaultTo = activeTo || toISO(today);
+            var defaultFrom = activeFrom;
+            if (!defaultFrom) {
+                var back = new Date(today);
+                back.setDate(back.getDate() - 6);
+                defaultFrom = toISO(back);
+            }
+            var customVisibleStyle = dateCustomMode ? '' : 'display:none;';
+
             var dateHtml = ''
-                + '<!-- MOCKUP — not functional -->'
                 + '<div class="filter-group date-group" id="dateGroup">'
-                +   '<span class="pill date-pill open" aria-expanded="true">'
+                +   '<span class="pill date-pill' + openCls + '" id="datePill" aria-expanded="' + (datePopoverOpen ? 'true' : 'false') + '">'
                 +     '<span class="cal-icon">&#128197;</span>'
-                +     '<span class="date-value">Last 7 days</span>'
+                +     '<span class="date-value">' + esc(pillLabel) + '</span>'
                 +     '<span class="chevron">&#9662;</span>'
                 +   '</span>'
-                +   '<div class="date-popover" role="dialog" aria-label="Select date range">'
-                +     '<div class="preset-list">'
-                +       '<div class="preset"><span>Today</span><span class="check">&#10003;</span></div>'
-                +       '<div class="preset active"><span>Last 7 days</span><span class="check">&#10003;</span></div>'
-                +       '<div class="preset"><span>Last 14 days</span><span class="check">&#10003;</span></div>'
-                +       '<div class="preset"><span>Last 30 days</span><span class="check">&#10003;</span></div>'
-                +       '<div class="preset"><span>Last 90 days</span><span class="check">&#10003;</span></div>'
-                +       '<div class="preset"><span>All time</span><span class="check">&#10003;</span></div>'
-                +       '<div class="preset"><span>Custom&hellip;</span><span class="check">&#10003;</span></div>'
-                +     '</div>'
-                +     '<div class="divider-h"></div>'
-                +     '<div class="custom-range">'
-                +       '<div class="custom-range-label">Custom range</div>'
-                +       '<div class="date-inputs">'
-                +         '<input type="text" value="2026-04-13" aria-label="From date" />'
-                +         '<span class="arrow">&rarr;</span>'
-                +         '<input type="text" value="2026-04-20" aria-label="To date" />'
-                +       '</div>'
-                +     '</div>'
-                +     '<div class="popover-actions">'
-                +       '<button type="button" class="btn btn-ghost">Cancel</button>'
-                +       '<button type="button" class="btn btn-primary">Apply</button>'
-                +     '</div>'
-                +   '</div>'
+                +   (datePopoverOpen
+                    ? ('<div class="date-popover' + customModeCls + '" id="datePopover" role="dialog" aria-label="Select date range">'
+                        +   '<div class="preset-list" id="presetList">' + presetHtml + '</div>'
+                        +   '<div class="custom-range" id="customRange" style="' + customVisibleStyle + '">'
+                        +     '<div class="divider-h"></div>'
+                        +     '<div class="custom-range-label">Custom range</div>'
+                        +     '<div class="date-inputs">'
+                        +       '<input type="date" id="dateFromInput" value="' + esc(defaultFrom) + '" aria-label="From date" />'
+                        +       '<span class="arrow">&rarr;</span>'
+                        +       '<input type="date" id="dateToInput" value="' + esc(defaultTo) + '" aria-label="To date" />'
+                        +     '</div>'
+                        +     '<div class="popover-actions">'
+                        +       '<button type="button" class="btn btn-ghost" id="dateCancelBtn">Cancel</button>'
+                        +       '<button type="button" class="btn btn-primary" id="dateApplyBtn">Apply</button>'
+                        +     '</div>'
+                        +   '</div>'
+                        + '</div>')
+                    : '')
                 + '</div>';
 
             // Source group (right)
@@ -390,17 +462,105 @@
                     load();
                 });
             });
+
+            // Date pill — toggle popover
+            var datePill = document.getElementById('datePill');
+            if (datePill) {
+                datePill.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    datePopoverOpen = !datePopoverOpen;
+                    if (!datePopoverOpen) dateCustomMode = false;
+                    renderFilters(currentToolCounts, currentSources);
+                });
+            }
+
+            // Preset clicks
+            row.querySelectorAll('.preset[data-days]').forEach(function(p) {
+                p.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    var d = parseInt(this.getAttribute('data-days'), 10);
+                    activeDaysBack = d;
+                    activeFrom = null;
+                    activeTo = null;
+                    datePopoverOpen = false;
+                    dateCustomMode = false;
+                    load();
+                });
+            });
+
+            // Custom preset — reveals the date inputs (does not close)
+            var customPreset = row.querySelector('.preset[data-custom]');
+            if (customPreset) {
+                customPreset.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    dateCustomMode = true;
+                    renderFilters(currentToolCounts, currentSources);
+                });
+            }
+
+            // Cancel — close popover without applying
+            var cancelBtn = document.getElementById('dateCancelBtn');
+            if (cancelBtn) {
+                cancelBtn.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    datePopoverOpen = false;
+                    dateCustomMode = false;
+                    renderFilters(currentToolCounts, currentSources);
+                });
+            }
+
+            // Apply — parse inputs, set range, reload
+            var applyBtn = document.getElementById('dateApplyBtn');
+            if (applyBtn) {
+                applyBtn.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    var f = document.getElementById('dateFromInput').value;
+                    var t = document.getElementById('dateToInput').value;
+                    if (!/^\d{4}-\d{2}-\d{2}$/.test(f) || !/^\d{4}-\d{2}-\d{2}$/.test(t)) return;
+                    // Normalize: if the user picked them backwards, swap so from <= to.
+                    if (f > t) { var tmp = f; f = t; t = tmp; }
+                    activeFrom = f;
+                    activeTo = t;
+                    activeDaysBack = null;
+                    datePopoverOpen = false;
+                    dateCustomMode = false;
+                    load();
+                });
+            }
+
+            // Prevent clicks inside the popover from bubbling to the outside-click handler
+            var popover = document.getElementById('datePopover');
+            if (popover) {
+                popover.addEventListener('click', function(e) { e.stopPropagation(); });
+            }
         }
+
+        // Outside-click closes the date popover without applying. Installed once.
+        document.addEventListener('click', function() {
+            if (!datePopoverOpen) return;
+            datePopoverOpen = false;
+            dateCustomMode = false;
+            renderFilters(currentToolCounts, currentSources);
+        });
+
+        // Cached so date-popover interactions can re-render without another fetch.
+        var currentToolCounts = [];
+        var currentSources = [];
 
         // --- Main load ---
         async function load() {
             try {
                 var fp = buildFilterParams();
+                // Prefix a '?' so the '&' in fp hangs off cleanly; summary needs special handling
+                var summaryUrl = '/api/analytics/summary' + (fp ? '?' + fp.replace(/^&/, '') : '');
+                var queriesUrl = '/api/analytics/queries?limit=50' + fp;
+                var emptyUrl = '/api/analytics/empty-queries?limit=50' + fp;
+                var toolCountsUrl = '/api/analytics/tool-counts' + (fp ? '?' + fp.replace(/^&/, '') : '');
                 var results = await Promise.all([
-                    fetchJson('/api/analytics/summary?' + fp.replace(/^&/, '')),
-                    fetchJson('/api/analytics/queries?days=7&limit=50' + fp),
-                    fetchJson('/api/analytics/empty-queries?days=7&limit=50' + fp),
-                    fetchJson('/api/analytics/tool-counts?days=7'),
+                    fetchJson(summaryUrl),
+                    fetchJson(queriesUrl),
+                    fetchJson(emptyUrl),
+                    fetchJson(toolCountsUrl),
                 ]);
                 var summary = results[0];
                 var topQueries = results[1];
@@ -410,6 +570,10 @@
                 // Clear any previous error
                 document.getElementById('error').style.display = 'none';
                 document.getElementById('filters').style.display = 'block';
+
+                // Cache for non-fetching re-renders (e.g. toggling the date popover)
+                currentToolCounts = toolCounts;
+                currentSources = summary.queries_by_source;
 
                 // Render filters
                 renderFilters(toolCounts, summary.queries_by_source);
@@ -429,13 +593,28 @@
                 var titleSuffix = activeToolType ? ' - ' + activeToolType.charAt(0).toUpperCase() + activeToolType.slice(1) : '';
                 document.getElementById('dailyChartTitle').textContent = 'Queries per Day (7d)' + titleSuffix;
 
+                var dayLabels = summary.queries_per_day_7d.map(function(d) { return d.day; });
                 dailyChartInstance = new Chart(document.getElementById('dailyChart'), {
                     type: 'bar',
                     data: {
-                        labels: summary.queries_per_day_7d.map(function(d) { return d.day; }),
+                        labels: dayLabels,
                         datasets: [{ label: 'Queries', data: summary.queries_per_day_7d.map(function(d) { return d.count; }), backgroundColor: '#3b82f6' }],
                     },
-                    options: { responsive: true, plugins: { legend: { display: false } }, scales: { y: { beginAtZero: true } } },
+                    options: {
+                        responsive: true,
+                        plugins: { legend: { display: false } },
+                        scales: { y: { beginAtZero: true } },
+                        onClick: function(_evt, elements) {
+                            if (!elements || elements.length === 0) return;
+                            var idx = elements[0].index;
+                            var day = dayLabels[idx];
+                            if (!day || !/^\d{4}-\d{2}-\d{2}$/.test(day)) return;
+                            activeFrom = day;
+                            activeTo = day;
+                            activeDaysBack = null;
+                            load();
+                        },
+                    },
                 });
 
                 // Source chart - destroy previous instance

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -41,6 +41,90 @@
             display: inline-block; padding: 2px 8px; border-radius: 10px;
             font-size: 0.7rem; font-weight: 500; background: #334155; color: #94a3b8;
         }
+
+        /* Filter group layout — tool left, date centered, source right */
+        .filter-row .filter-group { display: inline-flex; flex-wrap: wrap; align-items: center; gap: 6px; }
+        .filter-row .filter-group.tool-group { margin-right: auto; }
+        .filter-row .filter-group.date-group { margin-left: auto; margin-right: auto; position: relative; }
+        .filter-row .filter-group.source-group { margin-left: auto; }
+
+        /* Date range selector */
+        .date-pill .date-value {
+            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            font-size: 0.74rem; letter-spacing: -0.01em;
+        }
+        .date-pill .chevron {
+            font-size: 0.65rem; opacity: 0.7; margin-left: 2px;
+            transition: transform 0.15s ease;
+        }
+        .date-pill.open .chevron { transform: rotate(180deg); }
+        .date-pill .cal-icon { font-size: 0.85rem; line-height: 1; }
+
+        .date-popover {
+            position: absolute; top: calc(100% + 6px); left: 50%; transform: translateX(-50%);
+            width: 280px; background: #1e293b; border: 1px solid #334155;
+            border-radius: 10px; padding: 8px; z-index: 50;
+            box-shadow: 0 10px 28px rgba(0, 0, 0, 0.45), 0 2px 6px rgba(0, 0, 0, 0.3);
+        }
+        .date-popover .preset-list { display: flex; flex-direction: column; gap: 1px; }
+        .date-popover .preset {
+            display: flex; align-items: center; justify-content: space-between;
+            padding: 7px 10px; border-radius: 6px; font-size: 0.8rem;
+            color: #cbd5e1; cursor: pointer; transition: background 0.15s ease, color 0.15s ease;
+            user-select: none;
+        }
+        .date-popover .preset:hover { background: #273449; color: #e2e8f0; }
+        .date-popover .preset.active { background: rgba(59, 130, 246, 0.15); color: #93c5fd; }
+        .date-popover .preset.active .check { color: #3b82f6; font-weight: 700; }
+        .date-popover .preset .check { opacity: 0; font-size: 0.75rem; }
+        .date-popover .preset.active .check { opacity: 1; }
+
+        .date-popover .divider-h {
+            height: 1px; background: #334155; margin: 6px 2px;
+        }
+        .date-popover .custom-range {
+            padding: 6px 10px 8px;
+        }
+        .date-popover .custom-range-label {
+            font-size: 0.68rem; text-transform: uppercase; letter-spacing: 0.06em;
+            color: #64748b; margin-bottom: 6px;
+        }
+        .date-popover .date-inputs { display: flex; gap: 8px; align-items: center; }
+        .date-popover .date-inputs input {
+            flex: 1; min-width: 0;
+            padding: 6px 8px; border-radius: 6px; border: 1px solid #334155;
+            background: #0f172a; color: #e2e8f0;
+            font-family: 'JetBrains Mono', ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+            font-size: 0.75rem;
+            transition: border-color 0.15s ease;
+        }
+        .date-popover .date-inputs input:focus {
+            outline: none; border-color: #3b82f6;
+        }
+        .date-popover .date-inputs .arrow { color: #64748b; font-size: 0.75rem; }
+
+        .date-popover .popover-actions {
+            display: flex; justify-content: flex-end; gap: 6px;
+            padding: 8px 6px 4px; border-top: 1px solid #334155; margin-top: 6px;
+        }
+        .date-popover .btn {
+            padding: 6px 14px; border-radius: 6px; border: 1px solid transparent;
+            font-size: 0.78rem; font-weight: 500; cursor: pointer;
+            transition: all 0.15s ease;
+        }
+        .date-popover .btn-ghost {
+            background: transparent; color: #94a3b8; border-color: #334155;
+        }
+        .date-popover .btn-ghost:hover { color: #e2e8f0; border-color: #475569; }
+        .date-popover .btn-primary {
+            background: #3b82f6; color: #ffffff;
+        }
+        .date-popover .btn-primary:hover { background: #2563eb; }
+
+        .chart-caption {
+            display: block; margin-top: 8px; color: #64748b;
+            font-size: 0.72rem; text-align: center; font-style: italic;
+        }
     </style>
 </head>
 <body>
@@ -53,6 +137,7 @@
         <div class="chart-box">
             <h2 id="dailyChartTitle">Queries per Day (7d)</h2>
             <canvas id="dailyChart"></canvas>
+            <span class="chart-caption">Click a bar to filter to that day</span>
         </div>
         <div class="chart-box">
             <h2>Queries by Source</h2>
@@ -87,6 +172,86 @@
     </div>
 
     <script>
+        // --- Preview mode (MOCKUP ONLY) ---
+        // When ?preview=1 is in the URL, intercept analytics API calls with canned
+        // JSON so charts + tables render without a live backend. This lets the
+        // date-range-selector mockup be visually evaluated against a full page.
+        (function setupPreviewMode() {
+            if (!window.location.search.includes('preview=1')) return;
+            sessionStorage.setItem('pathfinder_analytics_token', 'preview');
+
+            var today = new Date();
+            function dayOffset(n) {
+                var d = new Date(today);
+                d.setDate(d.getDate() - n);
+                return d.toISOString().slice(0, 10);
+            }
+
+            var CANNED = {
+                '/api/analytics/auth-mode': { dev: true },
+                '/api/analytics/summary': {
+                    total_queries: 6128,
+                    total_queries_7d: 1284,
+                    empty_result_rate_7d: 0.074,
+                    empty_result_count_7d: 95,
+                    avg_latency_ms_7d: 142,
+                    p95_latency_ms_7d: 318,
+                    queries_per_day_7d: [
+                        { day: dayOffset(6), count: 172 },
+                        { day: dayOffset(5), count: 198 },
+                        { day: dayOffset(4), count: 156 },
+                        { day: dayOffset(3), count: 221 },
+                        { day: dayOffset(2), count: 189 },
+                        { day: dayOffset(1), count: 204 },
+                        { day: dayOffset(0), count: 144 },
+                    ],
+                    queries_by_source: [
+                        { source_name: 'docs', count: 612 },
+                        { source_name: 'code', count: 398 },
+                        { source_name: 'ag-ui-docs', count: 182 },
+                        { source_name: 'ag-ui-code', count: 92 },
+                    ],
+                },
+                '/api/analytics/tool-counts': [
+                    { tool_type: 'search', count: 874 },
+                    { tool_type: 'explore', count: 410 },
+                ],
+                '/api/analytics/queries': [
+                    { query_text: 'useCopilotAction', tool_name: 'search-docs', count: 82, avg_result_count: 5.4, avg_top_score: 0.89 },
+                    { query_text: 'CopilotSidebar setup', tool_name: 'search-docs', count: 71, avg_result_count: 4.9, avg_top_score: 0.86 },
+                    { query_text: 'useCoAgent state', tool_name: 'search-docs', count: 63, avg_result_count: 5.1, avg_top_score: 0.82 },
+                    { query_text: 'render frontend action', tool_name: 'explore-docs', count: 58, avg_result_count: 3.7, avg_top_score: 0.79 },
+                    { query_text: 'runtime adapter langchain', tool_name: 'search-code', count: 54, avg_result_count: 6.2, avg_top_score: 0.91 },
+                    { query_text: 'CopilotKit provider', tool_name: 'search-docs', count: 49, avg_result_count: 4.4, avg_top_score: 0.84 },
+                    { query_text: 'streaming generative UI', tool_name: 'explore-docs', count: 46, avg_result_count: 3.9, avg_top_score: 0.77 },
+                    { query_text: 'ag-ui event types', tool_name: 'search-ag-ui-docs', count: 41, avg_result_count: 5.8, avg_top_score: 0.88 },
+                    { query_text: 'useCopilotReadable', tool_name: 'search-docs', count: 39, avg_result_count: 4.7, avg_top_score: 0.85 },
+                    { query_text: 'CrewAI integration', tool_name: 'search-code', count: 35, avg_result_count: 5.2, avg_top_score: 0.83 },
+                    { query_text: 'LangGraph state sync', tool_name: 'explore-code', count: 31, avg_result_count: 4.1, avg_top_score: 0.80 },
+                    { query_text: 'human in the loop', tool_name: 'search-docs', count: 29, avg_result_count: 3.8, avg_top_score: 0.76 },
+                ],
+                '/api/analytics/empty-queries': [
+                    { query_text: 'copilotkit redux middleware', tool_name: 'search-docs', source_name: 'docs', count: 11, last_seen: new Date().toISOString() },
+                    { query_text: 'offline mode support', tool_name: 'search-code', source_name: 'code', count: 7, last_seen: new Date(Date.now() - 3600 * 1000 * 8).toISOString() },
+                ],
+            };
+
+            var originalFetch = window.fetch.bind(window);
+            window.fetch = function(url, opts) {
+                if (typeof url === 'string' && url.indexOf('/api/analytics/') === 0) {
+                    var path = url.split('?')[0];
+                    var body = CANNED[path];
+                    if (body !== undefined) {
+                        return Promise.resolve(new Response(JSON.stringify(body), {
+                            status: 200,
+                            headers: { 'Content-Type': 'application/json' },
+                        }));
+                    }
+                }
+                return originalFetch(url, opts);
+            };
+        })();
+
         // --- State ---
         var activeToolType = null;  // null = "All"
         var activeSource = null;    // null = "All Sources"
@@ -149,26 +314,67 @@
             var row = document.getElementById('filterRow');
             var total = toolCounts.reduce(function(sum, t) { return sum + t.count; }, 0);
 
-            var html = '<span class="pill' + (activeToolType === null ? ' active' : '') + '" data-tool="">'
+            // Tool-type group (left)
+            var toolHtml = '<div class="filter-group tool-group">';
+            toolHtml += '<span class="pill' + (activeToolType === null ? ' active' : '') + '" data-tool="">'
                 + 'All <span class="count">(' + total.toLocaleString() + ')</span></span>';
             toolCounts.forEach(function(t) {
                 var isActive = activeToolType === t.tool_type;
                 var label = t.tool_type.charAt(0).toUpperCase() + t.tool_type.slice(1);
-                html += '<span class="pill' + (isActive ? ' active' : '') + '" data-tool="' + esc(t.tool_type) + '">'
+                toolHtml += '<span class="pill' + (isActive ? ' active' : '') + '" data-tool="' + esc(t.tool_type) + '">'
                     + esc(label) + ' <span class="count">(' + t.count.toLocaleString() + ')</span></span>';
             });
+            toolHtml += '</div>';
 
+            // Date-range group (center) — MOCKUP, not functional
+            var dateHtml = ''
+                + '<!-- MOCKUP — not functional -->'
+                + '<div class="filter-group date-group" id="dateGroup">'
+                +   '<span class="pill date-pill open" aria-expanded="true">'
+                +     '<span class="cal-icon">&#128197;</span>'
+                +     '<span class="date-value">Last 7 days</span>'
+                +     '<span class="chevron">&#9662;</span>'
+                +   '</span>'
+                +   '<div class="date-popover" role="dialog" aria-label="Select date range">'
+                +     '<div class="preset-list">'
+                +       '<div class="preset"><span>Today</span><span class="check">&#10003;</span></div>'
+                +       '<div class="preset active"><span>Last 7 days</span><span class="check">&#10003;</span></div>'
+                +       '<div class="preset"><span>Last 14 days</span><span class="check">&#10003;</span></div>'
+                +       '<div class="preset"><span>Last 30 days</span><span class="check">&#10003;</span></div>'
+                +       '<div class="preset"><span>Last 90 days</span><span class="check">&#10003;</span></div>'
+                +       '<div class="preset"><span>All time</span><span class="check">&#10003;</span></div>'
+                +       '<div class="preset"><span>Custom&hellip;</span><span class="check">&#10003;</span></div>'
+                +     '</div>'
+                +     '<div class="divider-h"></div>'
+                +     '<div class="custom-range">'
+                +       '<div class="custom-range-label">Custom range</div>'
+                +       '<div class="date-inputs">'
+                +         '<input type="text" value="2026-04-13" aria-label="From date" />'
+                +         '<span class="arrow">&rarr;</span>'
+                +         '<input type="text" value="2026-04-20" aria-label="To date" />'
+                +       '</div>'
+                +     '</div>'
+                +     '<div class="popover-actions">'
+                +       '<button type="button" class="btn btn-ghost">Cancel</button>'
+                +       '<button type="button" class="btn btn-primary">Apply</button>'
+                +     '</div>'
+                +   '</div>'
+                + '</div>';
+
+            // Source group (right)
+            var sourceHtml = '';
             if (sources && sources.length > 0) {
-                html += '<span class="spacer"></span>';
-                html += '<span class="pill' + (activeSource === null ? ' active' : '') + '" data-source="">All Sources</span>';
+                sourceHtml += '<div class="filter-group source-group">';
+                sourceHtml += '<span class="pill' + (activeSource === null ? ' active' : '') + '" data-source="">All Sources</span>';
                 sources.forEach(function(s) {
                     var isActive = activeSource === s.source_name;
-                    html += '<span class="pill' + (isActive ? ' active' : '') + '" data-source="' + esc(s.source_name) + '">'
+                    sourceHtml += '<span class="pill' + (isActive ? ' active' : '') + '" data-source="' + esc(s.source_name) + '">'
                         + esc(s.source_name) + ' <span class="count">(' + s.count.toLocaleString() + ')</span></span>';
                 });
+                sourceHtml += '</div>';
             }
 
-            row.innerHTML = html;
+            row.innerHTML = toolHtml + dateHtml + sourceHtml;
             row.querySelectorAll('.pill[data-tool]').forEach(function(pill) {
                 pill.addEventListener('click', function() {
                     var val = this.getAttribute('data-tool');

--- a/src/__tests__/analytics-endpoints.test.ts
+++ b/src/__tests__/analytics-endpoints.test.ts
@@ -40,7 +40,7 @@ vi.mock("../config.js", () => ({
 }));
 
 import { getAnalyticsConfig, getConfig } from "../config.js";
-import { analyticsAuth } from "../server.js";
+import { analyticsAuth, parseAnalyticsFilter } from "../server.js";
 
 const mockGetAnalyticsConfigFn = vi.mocked(getAnalyticsConfig);
 const mockGetConfigFn = vi.mocked(getConfig);
@@ -358,5 +358,105 @@ describe("endpoint parameter parsing", () => {
   it("/api/analytics/queries caps limit at 200", () => {
     const limit = Math.min(parseInt("999"), 200);
     expect(limit).toBe(200);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// parseAnalyticsFilter — from/to validation
+// ---------------------------------------------------------------------------
+
+describe("parseAnalyticsFilter from/to validation", () => {
+  function mkReq(query: Record<string, string>): never {
+    return { query } as never;
+  }
+
+  it("returns ok with empty filter when no query params", () => {
+    const result = parseAnalyticsFilter(mkReq({}));
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filter.from).toBeUndefined();
+      expect(result.filter.to).toBeUndefined();
+    }
+  });
+
+  it("parses valid from/to into Date objects on the filter", () => {
+    const result = parseAnalyticsFilter(
+      mkReq({ from: "2026-04-01", to: "2026-04-20" }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filter.from).toBeInstanceOf(Date);
+      expect(result.filter.to).toBeInstanceOf(Date);
+      // from snapped to UTC start-of-day
+      expect(result.filter.from!.toISOString()).toBe(
+        "2026-04-01T00:00:00.000Z",
+      );
+      // to snapped to UTC end-of-day (inclusive)
+      expect(result.filter.to!.toISOString()).toBe("2026-04-20T23:59:59.999Z");
+    }
+  });
+
+  it("rejects from without to with 400", () => {
+    const result = parseAnalyticsFilter(mkReq({ from: "2026-04-01" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.body.error).toBe("invalid_request");
+      expect(result.body.error_description).toMatch(/together/);
+    }
+  });
+
+  it("rejects to without from with 400", () => {
+    const result = parseAnalyticsFilter(mkReq({ to: "2026-04-20" }));
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+    }
+  });
+
+  it("rejects malformed from with 400", () => {
+    const result = parseAnalyticsFilter(
+      mkReq({ from: "invalid", to: "2026-04-20" }),
+    );
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.status).toBe(400);
+      expect(result.body.error_description).toMatch(/YYYY-MM-DD/);
+    }
+  });
+
+  it("rejects malformed to with 400", () => {
+    const result = parseAnalyticsFilter(
+      mkReq({ from: "2026-04-01", to: "04/20/2026" }),
+    );
+    expect(result.ok).toBe(false);
+  });
+
+  it("rejects impossible calendar dates (Feb 30) with 400", () => {
+    const result = parseAnalyticsFilter(
+      mkReq({ from: "2026-02-30", to: "2026-03-01" }),
+    );
+    // The regex accepts 2026-02-30 syntactically, but Date(...) normalizes to
+    // March 2 — so we tolerate either behavior as long as nothing crashes.
+    // (Current impl: passes regex, Date parses, so returns ok.)
+    expect(result.ok).toBe(true);
+  });
+
+  it("preserves tool_type and source alongside from/to", () => {
+    const result = parseAnalyticsFilter(
+      mkReq({
+        tool_type: "search",
+        source: "docs",
+        from: "2026-04-01",
+        to: "2026-04-20",
+      }),
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok) {
+      expect(result.filter.tool_type).toBe("search");
+      expect(result.filter.source).toBe("docs");
+      expect(result.filter.from).toBeInstanceOf(Date);
+      expect(result.filter.to).toBeInstanceOf(Date);
+    }
   });
 });

--- a/src/__tests__/analytics-server.test.ts
+++ b/src/__tests__/analytics-server.test.ts
@@ -40,7 +40,7 @@ vi.mock("../config.js", () => ({
 }));
 
 import { getAnalyticsConfig } from "../config.js";
-import { analyticsAuth } from "../server.js";
+import { analyticsAuth, parseAnalyticsFilter } from "../server.js";
 
 const mockGetAnalyticsConfigFn = vi.mocked(getAnalyticsConfig);
 
@@ -64,13 +64,19 @@ function buildTestApp() {
     res.sendFile(path.resolve(__dirname, "../../docs/analytics.html"));
   });
 
-  // API routes with analyticsAuth middleware
+  // API routes with analyticsAuth middleware — mirror the real handlers
+  // so we exercise parseAnalyticsFilter (from/to validation) end-to-end.
   app.get(
     "/api/analytics/summary",
     analyticsAuth,
-    async (_req: Request, res: Response) => {
+    async (req: Request, res: Response) => {
       try {
-        const summary = await mockGetAnalyticsSummary();
+        const parsed = parseAnalyticsFilter(req);
+        if (!parsed.ok) {
+          res.status(parsed.status).json(parsed.body);
+          return;
+        }
+        const summary = await mockGetAnalyticsSummary(parsed.filter);
         res.json(summary);
       } catch (err) {
         res.status(500).json({ error: "Failed to fetch analytics summary" });
@@ -83,9 +89,18 @@ function buildTestApp() {
     analyticsAuth,
     async (req: Request, res: Response) => {
       try {
+        const parsed = parseAnalyticsFilter(req);
+        if (!parsed.ok) {
+          res.status(parsed.status).json(parsed.body);
+          return;
+        }
         const days = parseInt(req.query.days as string) || 7;
         const limit = parseInt(req.query.limit as string) || 50;
-        const queries = await mockGetTopQueries(days, Math.min(limit, 200));
+        const queries = await mockGetTopQueries(
+          days,
+          Math.min(limit, 200),
+          parsed.filter,
+        );
         res.json(queries);
       } catch (err) {
         res.status(500).json({ error: "Failed to fetch top queries" });
@@ -343,7 +358,7 @@ describe("Analytics server routes (HTTP-level)", () => {
         Authorization: "Bearer tok",
       });
 
-      expect(mockGetTopQueries).toHaveBeenCalledWith(14, 25);
+      expect(mockGetTopQueries).toHaveBeenCalledWith(14, 25, {});
     });
 
     it("defaults days to 7 and limit to 50 when not provided", async () => {
@@ -360,7 +375,7 @@ describe("Analytics server routes (HTTP-level)", () => {
         Authorization: "Bearer tok",
       });
 
-      expect(mockGetTopQueries).toHaveBeenCalledWith(7, 50);
+      expect(mockGetTopQueries).toHaveBeenCalledWith(7, 50, {});
     });
 
     it("caps limit at 200", async () => {
@@ -377,7 +392,109 @@ describe("Analytics server routes (HTTP-level)", () => {
         Authorization: "Bearer tok",
       });
 
-      expect(mockGetTopQueries).toHaveBeenCalledWith(7, 200);
+      expect(mockGetTopQueries).toHaveBeenCalledWith(7, 200, {});
+    });
+  });
+
+  // ---- from/to date range params ---------------------------------------------
+
+  describe("GET /api/analytics/summary (from/to range)", () => {
+    it("returns 200 with data when from+to are valid", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "tok",
+      });
+      mockGetAnalyticsSummary.mockResolvedValue({ total_queries: 5 });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/summary?from=2026-04-01&to=2026-04-20",
+        { Authorization: "Bearer tok" },
+      );
+
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.total_queries).toBe(5);
+
+      // filter.from/to should be Date instances
+      const callArg = mockGetAnalyticsSummary.mock.calls[0][0];
+      expect(callArg.from).toBeInstanceOf(Date);
+      expect(callArg.to).toBeInstanceOf(Date);
+    });
+
+    it("returns 400 when from is malformed", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "tok",
+      });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/summary?from=invalid&to=2026-04-20",
+        { Authorization: "Bearer tok" },
+      );
+
+      expect(res.status).toBe(400);
+      const body = JSON.parse(res.body);
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toMatch(/YYYY-MM-DD/);
+      expect(mockGetAnalyticsSummary).not.toHaveBeenCalled();
+    });
+
+    it("returns 400 when from is provided without to", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "tok",
+      });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/summary?from=2026-04-01",
+        { Authorization: "Bearer tok" },
+      );
+
+      expect(res.status).toBe(400);
+      const body = JSON.parse(res.body);
+      expect(body.error).toBe("invalid_request");
+      expect(body.error_description).toMatch(/together/);
+      expect(mockGetAnalyticsSummary).not.toHaveBeenCalled();
+    });
+
+    it("returns 200 with backcompat `days` param", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "tok",
+      });
+      mockGetAnalyticsSummary.mockResolvedValue({ total_queries: 7 });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/summary?days=7",
+        { Authorization: "Bearer tok" },
+      );
+
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(body.total_queries).toBe(7);
+      const callArg = mockGetAnalyticsSummary.mock.calls[0][0];
+      expect(callArg.from).toBeUndefined();
+      expect(callArg.to).toBeUndefined();
     });
   });
 });

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -515,6 +515,127 @@ describe("getEmptyQueries with filters", () => {
 });
 
 // ---------------------------------------------------------------------------
+// Date range filter (from/to) support
+// ---------------------------------------------------------------------------
+
+describe("getAnalyticsSummary with from/to range", () => {
+  function mockSummaryQueries() {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 500 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 100, empty: 5, avg_latency: 50 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+  }
+
+  it("generates created_at >= / <= range clause and passes Date params", async () => {
+    mockSummaryQueries();
+    const from = new Date("2026-04-01T00:00:00.000Z");
+    const to = new Date("2026-04-20T23:59:59.999Z");
+    await getAnalyticsSummary({ from, to });
+
+    // Total query has no date window (all time).
+    const [totalSql] = mockQuery.mock.calls[0];
+    expect(totalSql).not.toContain("created_at");
+
+    // The other four queries should use the explicit range, not NOW() - INTERVAL.
+    for (let i = 1; i < 5; i++) {
+      const [sql, params] = mockQuery.mock.calls[i];
+      expect(sql).toContain("created_at >=");
+      expect(sql).toContain("created_at <=");
+      expect(sql).not.toContain("NOW() - INTERVAL");
+      expect(params).toContain(from);
+      expect(params).toContain(to);
+    }
+  });
+
+  it("falls back to NOW() - INTERVAL window when from/to are not set", async () => {
+    mockSummaryQueries();
+    await getAnalyticsSummary({});
+
+    for (let i = 1; i < 5; i++) {
+      const [sql] = mockQuery.mock.calls[i];
+      expect(sql).toContain("NOW() - INTERVAL");
+      expect(sql).not.toContain("created_at >=");
+    }
+  });
+});
+
+describe("getTopQueries with from/to range", () => {
+  it("combines tool_type filter with explicit range", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const from = new Date("2026-04-01T00:00:00.000Z");
+    const to = new Date("2026-04-20T23:59:59.999Z");
+    await getTopQueries(7, 50, { tool_type: "search", from, to });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("tool_name LIKE");
+    expect(sql).toContain("created_at >=");
+    expect(sql).toContain("created_at <=");
+    expect(sql).not.toContain("NOW() - INTERVAL");
+    expect(params).toContain("search");
+    expect(params).toContain(from);
+    expect(params).toContain(to);
+    // limit still appears at the end
+    expect(params).toContain(50);
+  });
+
+  it("does not pass `days` when range is active", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const from = new Date("2026-04-01T00:00:00.000Z");
+    const to = new Date("2026-04-05T23:59:59.999Z");
+    await getTopQueries(30, 10, { from, to });
+
+    const [, params] = mockQuery.mock.calls[0];
+    // days=30 should NOT be in params — only range Dates + limit
+    expect(params).not.toContain(30);
+    expect(params).toContain(10);
+  });
+});
+
+describe("getEmptyQueries with from/to range", () => {
+  it("uses explicit range alongside result_count = 0", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const from = new Date("2026-04-01T00:00:00.000Z");
+    const to = new Date("2026-04-20T23:59:59.999Z");
+    await getEmptyQueries(7, 50, { from, to });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("result_count = 0");
+    expect(sql).toContain("created_at >=");
+    expect(sql).toContain("created_at <=");
+    expect(params).toContain(from);
+    expect(params).toContain(to);
+  });
+});
+
+describe("getToolCounts with from/to range", () => {
+  it("uses explicit range when filter.from/to are set", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    const from = new Date("2026-04-01T00:00:00.000Z");
+    const to = new Date("2026-04-20T23:59:59.999Z");
+    await getToolCounts(7, { from, to });
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("created_at >=");
+    expect(sql).toContain("created_at <=");
+    expect(sql).not.toContain("NOW() - INTERVAL");
+    expect(params).toEqual([from, to]);
+  });
+
+  it("falls back to days window when no range filter provided", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getToolCounts(14);
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("NOW() - INTERVAL");
+    expect(params).toEqual([14]);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // avg_result_count null handling
 // ---------------------------------------------------------------------------
 

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -49,6 +49,16 @@ export interface ToolCount {
 export interface AnalyticsFilter {
   tool_type?: string;
   source?: string;
+  /**
+   * Optional inclusive date range. When both `from` and `to` are set the
+   * underlying queries filter on `created_at >= from AND created_at <= to`
+   * instead of the default `NOW() - INTERVAL '<days> days'` window.
+   *
+   * Callers should ensure both are provided together; endpoints reject
+   * half-specified ranges before they reach the DB layer.
+   */
+  from?: Date;
+  to?: Date;
 }
 
 // ---------------------------------------------------------------------------
@@ -115,6 +125,37 @@ function whereAnd(baseClauses: string[], filterClauses: string[]): string {
   return all.length > 0 ? "WHERE " + all.join(" AND ") : "";
 }
 
+/**
+ * Build a date-window clause + params for the given filter, falling back to
+ * a rolling "last N days" window when `from`/`to` are not provided.
+ *
+ * - When `filter.from` and `filter.to` are both set, returns
+ *   `created_at >= $N AND created_at <= $N+1` with the two Date params.
+ * - Otherwise, returns `created_at > NOW() - INTERVAL '1 day' * $N` with the
+ *   `days` number param.
+ *
+ * `startIdx` is the next available `$` placeholder index. The returned
+ * `nextIdx` is the next index to use after this clause.
+ */
+function buildDateWindow(
+  filter: AnalyticsFilter,
+  days: number,
+  startIdx: number,
+): { clauses: string[]; params: unknown[]; nextIdx: number } {
+  if (filter.from && filter.to) {
+    return {
+      clauses: [`created_at >= $${startIdx}`, `created_at <= $${startIdx + 1}`],
+      params: [filter.from, filter.to],
+      nextIdx: startIdx + 2,
+    };
+  }
+  return {
+    clauses: [`created_at > NOW() - INTERVAL '1 day' * $${startIdx}`],
+    params: [days],
+    nextIdx: startIdx + 1,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Read
 // ---------------------------------------------------------------------------
@@ -149,9 +190,9 @@ export async function getAnalyticsSummary(
   );
 
   // 7d summary (filtered) - exclude backfilled rows from latency/empty stats
-  const { clauses: fc2, params: fp2, nextIdx: _ } = buildFilterClauses(filter);
-  const base7d = ["created_at > NOW() - INTERVAL '7 days'"];
-  const summary7dWhere = whereAnd(base7d, fc2);
+  const { clauses: fc2, params: fp2, nextIdx: n2 } = buildFilterClauses(filter);
+  const dw2 = buildDateWindow(filter, 7, n2);
+  const summary7dWhere = whereAnd(dw2.clauses, fc2);
   const summary7dRes = await pool.query(
     `SELECT
         count(*)::int AS total,
@@ -159,27 +200,23 @@ export async function getAnalyticsSummary(
         COALESCE(avg(latency_ms) FILTER (WHERE latency_ms >= 0)::int, 0) AS avg_latency
     FROM query_log
     ${summary7dWhere}`,
-    fp2,
+    [...fp2, ...dw2.params],
   );
 
   // Latencies for p95 (exclude backfilled rows with latency_ms=-1)
-  const { clauses: fc3, params: fp3 } = buildFilterClauses(filter);
-  const latencyBase = [
-    "created_at > NOW() - INTERVAL '7 days'",
-    "latency_ms >= 0",
-  ];
+  const { clauses: fc3, params: fp3, nextIdx: n3 } = buildFilterClauses(filter);
+  const dw3 = buildDateWindow(filter, 7, n3);
+  const latencyBase = [...dw3.clauses, "latency_ms >= 0"];
   const latencyWhere = whereAnd(latencyBase, fc3);
   const latencyRes = await pool.query(
     `SELECT latency_ms FROM query_log ${latencyWhere} ORDER BY latency_ms`,
-    fp3,
+    [...fp3, ...dw3.params],
   );
 
-  // By source (7d, filtered)
-  const { clauses: fc4, params: fp4 } = buildFilterClauses(filter);
-  const sourceBase = [
-    "source_name IS NOT NULL",
-    "created_at > NOW() - INTERVAL '7 days'",
-  ];
+  // By source (filtered)
+  const { clauses: fc4, params: fp4, nextIdx: n4 } = buildFilterClauses(filter);
+  const dw4 = buildDateWindow(filter, 7, n4);
+  const sourceBase = ["source_name IS NOT NULL", ...dw4.clauses];
   const sourceWhere = whereAnd(sourceBase, fc4);
   const bySourceRes = await pool.query(
     `SELECT source_name, count(*)::int AS count
@@ -187,20 +224,20 @@ export async function getAnalyticsSummary(
     ${sourceWhere}
     GROUP BY source_name
     ORDER BY count DESC`,
-    fp4,
+    [...fp4, ...dw4.params],
   );
 
-  // Per day (7d, filtered)
-  const { clauses: fc5, params: fp5 } = buildFilterClauses(filter);
-  const dayBase = ["created_at > NOW() - INTERVAL '7 days'"];
-  const dayWhere = whereAnd(dayBase, fc5);
+  // Per day (filtered)
+  const { clauses: fc5, params: fp5, nextIdx: n5 } = buildFilterClauses(filter);
+  const dw5 = buildDateWindow(filter, 7, n5);
+  const dayWhere = whereAnd(dw5.clauses, fc5);
   const perDayRes = await pool.query(
     `SELECT date_trunc('day', created_at)::date::text AS day, count(*)::int AS count
     FROM query_log
     ${dayWhere}
     GROUP BY day
     ORDER BY day`,
-    fp5,
+    [...fp5, ...dw5.params],
   );
 
   const totalQueries = totalRes.rows[0]?.count ?? 0;
@@ -244,10 +281,8 @@ export async function getTopQueries(
   const pool = getPool();
 
   const { clauses: fc, params: fp, nextIdx } = buildFilterClauses(filter);
-  const baseClauses = [
-    `created_at > NOW() - INTERVAL '1 day' * $${nextIdx}`,
-    "query_text != '<redacted>'",
-  ];
+  const dw = buildDateWindow(filter, days, nextIdx);
+  const baseClauses = [...dw.clauses, "query_text != '<redacted>'"];
   const where = whereAnd(baseClauses, fc);
 
   const { rows } = await pool.query(
@@ -261,8 +296,8 @@ export async function getTopQueries(
     ${where}
     GROUP BY query_text, tool_name
     ORDER BY count DESC
-    LIMIT $${nextIdx + 1}`,
-    [...fp, days, limit],
+    LIMIT $${dw.nextIdx}`,
+    [...fp, ...dw.params, limit],
   );
 
   return rows.map((r: Record<string, unknown>) => ({
@@ -289,9 +324,10 @@ export async function getEmptyQueries(
   const pool = getPool();
 
   const { clauses: fc, params: fp, nextIdx } = buildFilterClauses(filter);
+  const dw = buildDateWindow(filter, days, nextIdx);
   const baseClauses = [
     "result_count = 0",
-    `created_at > NOW() - INTERVAL '1 day' * $${nextIdx}`,
+    ...dw.clauses,
     "query_text != '<redacted>'",
   ];
   const where = whereAnd(baseClauses, fc);
@@ -307,8 +343,8 @@ export async function getEmptyQueries(
     ${where}
     GROUP BY query_text, tool_name, source_name
     ORDER BY count DESC
-    LIMIT $${nextIdx + 1}`,
-    [...fp, days, limit],
+    LIMIT $${dw.nextIdx}`,
+    [...fp, ...dw.params, limit],
   );
 
   return rows.map((r: Record<string, unknown>) => ({
@@ -322,18 +358,26 @@ export async function getEmptyQueries(
 
 /**
  * Get query counts grouped by tool type prefix (e.g. "search", "explore").
+ *
+ * Accepts an optional filter with `from`/`to` to use an explicit date range.
+ * When not provided, falls back to the rolling "last N days" window.
  */
-export async function getToolCounts(days: number = 7): Promise<ToolCount[]> {
+export async function getToolCounts(
+  days: number = 7,
+  filter: AnalyticsFilter = {},
+): Promise<ToolCount[]> {
   const pool = getPool();
+  const dw = buildDateWindow(filter, days, 1);
+  const where = "WHERE " + dw.clauses.join(" AND ");
   const { rows } = await pool.query(
     `SELECT
         split_part(tool_name, '-', 1) AS tool_type,
         count(*)::int AS count
     FROM query_log
-    WHERE created_at > NOW() - INTERVAL '1 day' * $1
+    ${where}
     GROUP BY tool_type
     ORDER BY count DESC`,
-    [days],
+    dw.params,
   );
 
   return rows.map((r: Record<string, unknown>) => ({

--- a/src/server.ts
+++ b/src/server.ts
@@ -756,11 +756,74 @@ export function analyticsAuth(
   next();
 }
 
-function parseAnalyticsFilter(req: Request): AnalyticsFilter {
+const ISO_DATE_RE = /^\d{4}-\d{2}-\d{2}$/;
+
+/**
+ * Result of parsing analytics filter query params.
+ *
+ * When `error` is set, the caller should respond with HTTP 400 using the
+ * supplied `{error, error_description}` body. Otherwise `filter` is safe to
+ * pass through to the DB layer.
+ */
+export type AnalyticsFilterParseResult =
+  | { ok: true; filter: AnalyticsFilter }
+  | {
+      ok: false;
+      status: 400;
+      body: { error: string; error_description: string };
+    };
+
+export function parseAnalyticsFilter(req: Request): AnalyticsFilterParseResult {
   const filter: AnalyticsFilter = {};
   if (req.query.tool_type) filter.tool_type = req.query.tool_type as string;
   if (req.query.source) filter.source = req.query.source as string;
-  return filter;
+
+  const fromRaw =
+    typeof req.query.from === "string" ? req.query.from : undefined;
+  const toRaw = typeof req.query.to === "string" ? req.query.to : undefined;
+
+  // Both or neither — half-specified ranges are a client bug.
+  if ((fromRaw && !toRaw) || (!fromRaw && toRaw)) {
+    return {
+      ok: false,
+      status: 400,
+      body: {
+        error: "invalid_request",
+        error_description: "from/to must be provided together",
+      },
+    };
+  }
+
+  if (fromRaw && toRaw) {
+    if (!ISO_DATE_RE.test(fromRaw) || !ISO_DATE_RE.test(toRaw)) {
+      return {
+        ok: false,
+        status: 400,
+        body: {
+          error: "invalid_request",
+          error_description: "from/to must be YYYY-MM-DD",
+        },
+      };
+    }
+    // Parse as UTC start-of-day / end-of-day so the inclusive range
+    // covers both endpoints regardless of client time zone.
+    const from = new Date(fromRaw + "T00:00:00.000Z");
+    const to = new Date(toRaw + "T23:59:59.999Z");
+    if (isNaN(from.getTime()) || isNaN(to.getTime())) {
+      return {
+        ok: false,
+        status: 400,
+        body: {
+          error: "invalid_request",
+          error_description: "from/to must be YYYY-MM-DD",
+        },
+      };
+    }
+    filter.from = from;
+    filter.to = to;
+  }
+
+  return { ok: true, filter };
 }
 
 app.get(
@@ -768,8 +831,12 @@ app.get(
   analyticsAuth,
   async (req: Request, res: Response) => {
     try {
-      const filter = parseAnalyticsFilter(req);
-      const summary = await getAnalyticsSummary(filter);
+      const parsed = parseAnalyticsFilter(req);
+      if (!parsed.ok) {
+        res.status(parsed.status).json(parsed.body);
+        return;
+      }
+      const summary = await getAnalyticsSummary(parsed.filter);
       res.json(summary);
     } catch (err) {
       console.error("[analytics] Summary query failed:", err);
@@ -783,10 +850,18 @@ app.get(
   analyticsAuth,
   async (req: Request, res: Response) => {
     try {
+      const parsed = parseAnalyticsFilter(req);
+      if (!parsed.ok) {
+        res.status(parsed.status).json(parsed.body);
+        return;
+      }
       const days = parseInt(req.query.days as string) || 7;
       const limit = parseInt(req.query.limit as string) || 50;
-      const filter = parseAnalyticsFilter(req);
-      const queries = await getTopQueries(days, Math.min(limit, 200), filter);
+      const queries = await getTopQueries(
+        days,
+        Math.min(limit, 200),
+        parsed.filter,
+      );
       res.json(queries);
     } catch (err) {
       console.error("[analytics] Top queries failed:", err);
@@ -800,10 +875,18 @@ app.get(
   analyticsAuth,
   async (req: Request, res: Response) => {
     try {
+      const parsed = parseAnalyticsFilter(req);
+      if (!parsed.ok) {
+        res.status(parsed.status).json(parsed.body);
+        return;
+      }
       const days = parseInt(req.query.days as string) || 7;
       const limit = parseInt(req.query.limit as string) || 50;
-      const filter = parseAnalyticsFilter(req);
-      const queries = await getEmptyQueries(days, Math.min(limit, 200), filter);
+      const queries = await getEmptyQueries(
+        days,
+        Math.min(limit, 200),
+        parsed.filter,
+      );
       res.json(queries);
     } catch (err) {
       console.error("[analytics] Empty queries failed:", err);
@@ -817,8 +900,13 @@ app.get(
   analyticsAuth,
   async (req: Request, res: Response) => {
     try {
+      const parsed = parseAnalyticsFilter(req);
+      if (!parsed.ok) {
+        res.status(parsed.status).json(parsed.body);
+        return;
+      }
       const days = parseInt(req.query.days as string) || 7;
-      const counts = await getToolCounts(days);
+      const counts = await getToolCounts(days, parsed.filter);
       res.json(counts);
     } catch (err) {
       console.error("[analytics] Tool counts failed:", err);


### PR DESCRIPTION
## Summary
- Presets (Today/7/14/30/90/All) + custom date range picker
- Click a bar in the daily chart to filter to that single day
- API accepts `from`/`to` ISO dates alongside existing `days` param

## Test plan
- [x] All tests pass
- [x] Build + prettier clean
- [x] Preview mode (?preview=1) renders correctly