### PR TITLE
Analytics: fix stats/charts not updating + Today preset

### DIFF
--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -262,6 +262,18 @@
         var sourceChartInstance = null;
         var datePopoverOpen = false;
         var dateCustomMode = false;
+        // Preserves source pills across filter changes — tool-type filters
+        // shrink/remove sources from the summary response, but the UI should
+        // still show the full set so users can switch between them.
+        var unfilteredSourcesCache = null;
+        // Monotonic counter to guard against out-of-order load() responses.
+        // A stale response (user clicked fast) would otherwise clobber the
+        // current UI state with old data.
+        var loadGeneration = 0;
+        // Draft custom-range values so a re-render (e.g. outside click on
+        // another filter) doesn't wipe the user's in-progress date picks.
+        var draftFromInput = null;
+        var draftToInput = null;
 
         // Intl formatters (cached)
         var shortDateFmt = new Intl.DateTimeFormat(undefined, { month: 'short', day: 'numeric' });
@@ -371,7 +383,7 @@
 
             // Tool-type group (left)
             var toolHtml = '<div class="filter-group tool-group">';
-            toolHtml += '<span class="pill' + (activeToolType === null ? ' active' : '') + '" data-tool="">'
+            toolHtml += '<span class="pill' + (activeToolType === null ? ' active' : '') + '" data-tool-all="1">'
                 + 'All <span class="count">(' + total.toLocaleString() + ')</span></span>';
             toolCounts.forEach(function(t) {
                 var isActive = activeToolType === t.tool_type;
@@ -419,13 +431,14 @@
                 + '<span class="check">&#10003;</span></div>';
 
             // Default the custom-range inputs to whatever is active, falling back to today/week.
+            // Prefer in-progress draft values so re-renders don't clobber user typing.
             var today = new Date();
             function toISO(d) {
                 var y = d.getFullYear(), m = String(d.getMonth() + 1).padStart(2, '0'), dd = String(d.getDate()).padStart(2, '0');
                 return y + '-' + m + '-' + dd;
             }
-            var defaultTo = activeTo || toISO(today);
-            var defaultFrom = activeFrom;
+            var defaultTo = draftToInput != null ? draftToInput : (activeTo || toISO(today));
+            var defaultFrom = draftFromInput != null ? draftFromInput : activeFrom;
             if (!defaultFrom) {
                 var back = new Date(today);
                 back.setDate(back.getDate() - 6);
@@ -464,7 +477,7 @@
             var sourceHtml = '';
             if (sources && sources.length > 0) {
                 sourceHtml += '<div class="filter-group source-group">';
-                sourceHtml += '<span class="pill' + (activeSource === null ? ' active' : '') + '" data-source="">All Sources</span>';
+                sourceHtml += '<span class="pill' + (activeSource === null ? ' active' : '') + '" data-source-all="1">All Sources</span>';
                 sources.forEach(function(s) {
                     var isActive = activeSource === s.source_name;
                     sourceHtml += '<span class="pill' + (isActive ? ' active' : '') + '" data-source="' + esc(s.source_name) + '">'
@@ -474,18 +487,18 @@
             }
 
             row.innerHTML = toolHtml + dateHtml + sourceHtml;
-            row.querySelectorAll('.pill[data-tool]').forEach(function(pill) {
+            row.querySelectorAll('.pill[data-tool], .pill[data-tool-all]').forEach(function(pill) {
                 pill.addEventListener('click', function() {
-                    var val = this.getAttribute('data-tool');
-                    activeToolType = val || null;
+                    var isAll = this.hasAttribute('data-tool-all');
+                    activeToolType = isAll ? null : this.getAttribute('data-tool');
                     activeSource = null;
                     load();
                 });
             });
-            row.querySelectorAll('.pill[data-source]').forEach(function(pill) {
+            row.querySelectorAll('.pill[data-source], .pill[data-source-all]').forEach(function(pill) {
                 pill.addEventListener('click', function() {
-                    var val = this.getAttribute('data-source');
-                    activeSource = val || null;
+                    var isAll = this.hasAttribute('data-source-all');
+                    activeSource = isAll ? null : this.getAttribute('data-source');
                     load();
                 });
             });
@@ -511,6 +524,8 @@
                     activeTo = null;
                     datePopoverOpen = false;
                     dateCustomMode = false;
+                    draftFromInput = null;
+                    draftToInput = null;
                     load();
                 });
             });
@@ -527,6 +542,8 @@
                     activeDaysBack = null;
                     datePopoverOpen = false;
                     dateCustomMode = false;
+                    draftFromInput = null;
+                    draftToInput = null;
                     load();
                 });
             }
@@ -541,6 +558,18 @@
                 });
             }
 
+            // Track draft input values so re-renders preserve in-progress edits.
+            var fromInputEl = document.getElementById('dateFromInput');
+            if (fromInputEl) {
+                fromInputEl.addEventListener('input', function() { draftFromInput = this.value; });
+                fromInputEl.addEventListener('change', function() { draftFromInput = this.value; });
+            }
+            var toInputEl = document.getElementById('dateToInput');
+            if (toInputEl) {
+                toInputEl.addEventListener('input', function() { draftToInput = this.value; });
+                toInputEl.addEventListener('change', function() { draftToInput = this.value; });
+            }
+
             // Cancel — close popover without applying
             var cancelBtn = document.getElementById('dateCancelBtn');
             if (cancelBtn) {
@@ -548,6 +577,8 @@
                     e.stopPropagation();
                     datePopoverOpen = false;
                     dateCustomMode = false;
+                    draftFromInput = null;
+                    draftToInput = null;
                     renderFilters(currentToolCounts, currentSources);
                 });
             }
@@ -567,6 +598,8 @@
                     activeDaysBack = null;
                     datePopoverOpen = false;
                     dateCustomMode = false;
+                    draftFromInput = null;
+                    draftToInput = null;
                     load();
                 });
             }
@@ -579,10 +612,18 @@
         }
 
         // Outside-click closes the date popover without applying. Installed once.
-        document.addEventListener('click', function() {
+        // Scoped to clicks outside `#dateGroup` — clicks on other filter pills
+        // shouldn't both trigger a fresh load and tear down the popover, and
+        // clicks inside the group (presets, inputs, buttons) are handled by
+        // the group's own event handlers.
+        document.addEventListener('click', function(e) {
             if (!datePopoverOpen) return;
+            var group = document.getElementById('dateGroup');
+            if (group && group.contains(e.target)) return;
             datePopoverOpen = false;
             dateCustomMode = false;
+            draftFromInput = null;
+            draftToInput = null;
             renderFilters(currentToolCounts, currentSources);
         });
 
@@ -592,6 +633,9 @@
 
         // --- Main load ---
         async function load() {
+            // Race guard — if another load() starts before this one finishes,
+            // the stale response is dropped to avoid clobbering current UI state.
+            var gen = ++loadGeneration;
             try {
                 var fp = buildFilterParams();
                 // Prefix a '?' so the '&' in fp hangs off cleanly; summary needs special handling
@@ -605,6 +649,7 @@
                     fetchJson(emptyUrl),
                     fetchJson(toolCountsUrl),
                 ]);
+                if (gen !== loadGeneration) return;  // stale response — abort
                 var summary = results[0];
                 var topQueries = results[1];
                 var emptyQueries = results[2];
@@ -616,10 +661,17 @@
 
                 // Cache for non-fetching re-renders (e.g. toggling the date popover)
                 currentToolCounts = toolCounts;
-                currentSources = summary.queries_by_source;
+                // When no tool-type filter is active, the summary.queries_by_source
+                // reflects the full set. Snapshot it so that later, when a
+                // tool-type filter shrinks the response, the source pills still
+                // render the complete list.
+                if (activeToolType === null && summary.queries_by_source) {
+                    unfilteredSourcesCache = summary.queries_by_source.slice();
+                }
+                currentSources = unfilteredSourcesCache || summary.queries_by_source;
 
                 // Render filters
-                renderFilters(toolCounts, summary.queries_by_source);
+                renderFilters(toolCounts, currentSources);
 
                 // Stats cards — window label is derived from the active
                 // range so switching presets keeps the labels honest.
@@ -666,6 +718,12 @@
                             activeFrom = day;
                             activeTo = day;
                             activeDaysBack = null;
+                            // Close any open popover so its stale state doesn't
+                            // linger on top of the newly-filtered view.
+                            datePopoverOpen = false;
+                            dateCustomMode = false;
+                            draftFromInput = null;
+                            draftToInput = null;
                             load();
                         },
                     },

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -273,9 +273,23 @@
             return new Date(parseInt(m[1], 10), parseInt(m[2], 10) - 1, parseInt(m[3], 10), 12, 0, 0);
         }
 
+        function todayISO() {
+            // Today's UTC date in YYYY-MM-DD. We anchor on UTC to match what the
+            // server compares against (created_at in UTC) — using local time
+            // here means users near midnight see yesterday's or tomorrow's rows.
+            var d = new Date();
+            var y = d.getUTCFullYear();
+            var m = String(d.getUTCMonth() + 1).padStart(2, '0');
+            var dd = String(d.getUTCDate()).padStart(2, '0');
+            return y + '-' + m + '-' + dd;
+        }
+
         function formatPillLabel() {
             if (activeFrom && activeTo) {
+                // Single-day range collapses to a "Today" label when it is in
+                // fact today, otherwise falls back to the formatted date.
                 if (activeFrom === activeTo) {
+                    if (activeFrom === todayISO()) return 'Today';
                     var d = parseISODate(activeFrom);
                     return d ? shortDateFmt.format(d) : activeFrom;
                 }
@@ -284,7 +298,6 @@
                 if (df && dt) return shortDateFmt.format(df) + ' \u2013 ' + shortDateFmt.format(dt);
                 return activeFrom + ' \u2013 ' + activeTo;
             }
-            if (activeDaysBack === 1) return 'Today';
             if (activeDaysBack === 7) return 'Last 7 days';
             if (activeDaysBack === 14) return 'Last 14 days';
             if (activeDaysBack === 30) return 'Last 30 days';
@@ -368,21 +381,35 @@
             });
             toolHtml += '</div>';
 
-            // Date-range group (center)
+            // Date-range group (center). "Today" is special — it uses an
+            // explicit from=today&to=today range instead of a rolling N-day
+            // window, because `days=1` on the server means "last 24 hours"
+            // (NOW() - INTERVAL '1 day') which straddles today + yesterday
+            // instead of showing only today's data.
             var presets = [
-                { label: 'Today',         days: 1 },
-                { label: 'Last 7 days',   days: 7 },
-                { label: 'Last 14 days',  days: 14 },
-                { label: 'Last 30 days',  days: 30 },
-                { label: 'Last 90 days',  days: 90 },
-                { label: 'All time',      days: 99999 },
+                { label: 'Today',         kind: 'today' },
+                { label: 'Last 7 days',   kind: 'days',  days: 7 },
+                { label: 'Last 14 days',  kind: 'days',  days: 14 },
+                { label: 'Last 30 days',  kind: 'days',  days: 30 },
+                { label: 'Last 90 days',  kind: 'days',  days: 90 },
+                { label: 'All time',      kind: 'days',  days: 99999 },
             ];
             var pillLabel = formatPillLabel();
             var customModeCls = dateCustomMode ? ' custom-mode' : '';
             var openCls = datePopoverOpen ? ' open' : '';
+            var todayStr = todayISO();
             var presetHtml = presets.map(function(p) {
-                var isActive = activeDaysBack === p.days && !activeFrom;
-                return '<div class="preset' + (isActive ? ' active' : '') + '" data-days="' + p.days + '">'
+                var isActive;
+                var attrs;
+                if (p.kind === 'today') {
+                    // "Today" is active when from === to === today.
+                    isActive = activeFrom === todayStr && activeTo === todayStr;
+                    attrs = 'data-preset="today"';
+                } else {
+                    isActive = activeDaysBack === p.days && !activeFrom;
+                    attrs = 'data-days="' + p.days + '"';
+                }
+                return '<div class="preset' + (isActive ? ' active' : '') + '" ' + attrs + '>'
                     + '<span>' + esc(p.label) + '</span>'
                     + '<span class="check">&#10003;</span></div>';
             }).join('');
@@ -474,7 +501,7 @@
                 });
             }
 
-            // Preset clicks
+            // Preset clicks (rolling "Last N days" windows)
             row.querySelectorAll('.preset[data-days]').forEach(function(p) {
                 p.addEventListener('click', function(e) {
                     e.stopPropagation();
@@ -487,6 +514,22 @@
                     load();
                 });
             });
+
+            // "Today" preset — explicit from/to range so the server doesn't
+            // fall back to a 24-hour rolling window.
+            var todayPreset = row.querySelector('.preset[data-preset="today"]');
+            if (todayPreset) {
+                todayPreset.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    var t = todayISO();
+                    activeFrom = t;
+                    activeTo = t;
+                    activeDaysBack = null;
+                    datePopoverOpen = false;
+                    dateCustomMode = false;
+                    load();
+                });
+            }
 
             // Custom preset — reveals the date inputs (does not close)
             var customPreset = row.querySelector('.preset[data-custom]');

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -135,7 +135,7 @@
 
     <div class="chart-row">
         <div class="chart-box">
-            <h2 id="dailyChartTitle">Queries per Day (7d)</h2>
+            <h2 id="dailyChartTitle">Queries per Day</h2>
             <canvas id="dailyChart"></canvas>
             <span class="chart-caption">Click a bar to filter to that day</span>
         </div>
@@ -149,13 +149,13 @@
         <div class="filter-row" id="filterRow"></div>
     </div>
 
-    <h2 style="margin-bottom: 12px;">Top Queries (7d)</h2>
+    <h2 id="topQueriesTitle" style="margin-bottom: 12px;">Top Queries</h2>
     <table id="topQueriesTable">
         <thead><tr><th>Query</th><th>Tool</th><th>Count</th><th>Avg Results</th><th>Avg Score</th></tr></thead>
         <tbody></tbody>
     </table>
 
-    <h2 style="margin-bottom: 12px;">Empty Result Queries (7d) <span class="empty">&#x26a0;</span></h2>
+    <h2 id="emptyQueriesTitle" style="margin-bottom: 12px;">Empty Result Queries <span class="empty">&#x26a0;</span></h2>
     <table id="emptyQueriesTable">
         <thead><tr><th>Query</th><th>Tool</th><th>Source</th><th>Count</th><th>Last Seen</th></tr></thead>
         <tbody></tbody>
@@ -621,20 +621,31 @@
                 // Render filters
                 renderFilters(toolCounts, summary.queries_by_source);
 
-                // Stats cards
+                // Stats cards — window label is derived from the active
+                // range so switching presets keeps the labels honest.
+                var winLabel = formatPillLabel();
                 document.getElementById('stats').innerHTML = [
                     { label: 'Total Queries', value: summary.total_queries.toLocaleString() },
-                    { label: 'Queries (7d)', value: summary.total_queries_7d.toLocaleString() },
-                    { label: 'Empty Result Rate (7d)', value: (summary.empty_result_rate_7d * 100).toFixed(1) + '%' },
-                    { label: 'Avg Latency (7d)', value: summary.avg_latency_ms_7d + 'ms' },
-                    { label: 'P95 Latency (7d)', value: summary.p95_latency_ms_7d + 'ms' },
-                    { label: 'Empty Queries (7d)', value: summary.empty_result_count_7d.toLocaleString() },
-                ].map(function(s) { return '<div class="stat-card"><div class="label">' + s.label + '</div><div class="value">' + s.value + '</div></div>'; }).join('');
+                    { label: 'Queries (' + winLabel + ')', value: summary.total_queries_7d.toLocaleString() },
+                    { label: 'Empty Result Rate (' + winLabel + ')', value: (summary.empty_result_rate_7d * 100).toFixed(1) + '%' },
+                    { label: 'Avg Latency (' + winLabel + ')', value: summary.avg_latency_ms_7d + 'ms' },
+                    { label: 'P95 Latency (' + winLabel + ')', value: summary.p95_latency_ms_7d + 'ms' },
+                    { label: 'Empty Queries (' + winLabel + ')', value: summary.empty_result_count_7d.toLocaleString() },
+                ].map(function(s) { return '<div class="stat-card"><div class="label">' + esc(s.label) + '</div><div class="value">' + s.value + '</div></div>'; }).join('');
+
+                // Table title h2s — also carry the window label.
+                var topTitle = document.getElementById('topQueriesTitle');
+                if (topTitle) topTitle.textContent = 'Top Queries (' + winLabel + ')';
+                var emptyTitle = document.getElementById('emptyQueriesTitle');
+                if (emptyTitle) {
+                    // Preserve the trailing warning icon span.
+                    emptyTitle.innerHTML = 'Empty Result Queries (' + esc(winLabel) + ') <span class="empty">&#x26a0;</span>';
+                }
 
                 // Daily chart - destroy previous instance
                 if (dailyChartInstance) { dailyChartInstance.destroy(); dailyChartInstance = null; }
                 var titleSuffix = activeToolType ? ' - ' + activeToolType.charAt(0).toUpperCase() + activeToolType.slice(1) : '';
-                document.getElementById('dailyChartTitle').textContent = 'Queries per Day (7d)' + titleSuffix;
+                document.getElementById('dailyChartTitle').textContent = 'Queries per Day (' + winLabel + ')' + titleSuffix;
 
                 var dayLabels = summary.queries_per_day_7d.map(function(d) { return d.day; });
                 dailyChartInstance = new Chart(document.getElementById('dailyChart'), {

--- a/package-lock.json
+++ b/package-lock.json
@@ -35,8 +35,10 @@
                 "@electric-sql/pglite": "^0.4.2",
                 "@types/cors": "^2.8.19",
                 "@types/express": "^5.0.6",
+                "@types/jsdom": "^28.0.1",
                 "@types/node": "^25.0.6",
                 "@types/pg": "^8.11.10",
+                "jsdom": "^28.0.0",
                 "tsx": "^4.21.0",
                 "typescript": "^5.9.3",
                 "vitest": "^4.1.2"
@@ -50,6 +52,61 @@
                 }
             }
         },
+        "node_modules/@acemir/cssom": {
+            "version": "0.9.31",
+            "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+            "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+            "dev": true,
+            "license": "MIT"
+        },
+        "node_modules/@asamuzakjp/css-color": {
+            "version": "5.1.11",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-5.1.11.tgz",
+            "integrity": "sha512-KVw6qIiCTUQhByfTd78h2yD1/00waTmm9uy/R7Ck/ctUyAPj+AEDLkQIdJW0T8+qGgj3j5bpNKK7Q3G+LedJWg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/generational-cache": "^1.0.1",
+                "@csstools/css-calc": "^3.2.0",
+                "@csstools/css-color-parser": "^4.1.0",
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/dom-selector": {
+            "version": "6.8.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.8.1.tgz",
+            "integrity": "sha512-MvRz1nCqW0fsy8Qz4dnLIvhOlMzqDVBabZx6lH+YywFDdjXhMY37SmpV1XFX3JzG5GWHn63j6HX6QPr3lZXHvQ==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/nwsapi": "^2.3.9",
+                "bidi-js": "^1.0.3",
+                "css-tree": "^3.1.0",
+                "is-potential-custom-element-name": "^1.0.1",
+                "lru-cache": "^11.2.6"
+            }
+        },
+        "node_modules/@asamuzakjp/generational-cache": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/generational-cache/-/generational-cache-1.0.1.tgz",
+            "integrity": "sha512-wajfB8KqzMCN2KGNFdLkReeHncd0AslUSrvHVvvYWuU8ghncRJoA50kT3zP9MVL0+9g4/67H+cdvBskj9THPzg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/@asamuzakjp/nwsapi": {
+            "version": "2.3.9",
+            "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+            "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@borewit/text-codec": {
             "version": "0.2.2",
             "resolved": "https://registry.npmjs.org/@borewit/text-codec/-/text-codec-0.2.2.tgz",
@@ -58,6 +115,159 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/@bramus/specificity": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/@bramus/specificity/-/specificity-2.4.2.tgz",
+            "integrity": "sha512-ctxtJ/eA+t+6q2++vj5j7FYX3nRu311q1wfYH3xjlLOsczhlhxAg2FWNUXhpGvAw3BWo1xBcvOV6/YLc2r5FJw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "css-tree": "^3.0.0"
+            },
+            "bin": {
+                "specificity": "bin/cli.js"
+            }
+        },
+        "node_modules/@csstools/color-helpers": {
+            "version": "6.0.2",
+            "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-6.0.2.tgz",
+            "integrity": "sha512-LMGQLS9EuADloEFkcTBR3BwV/CGHV7zyDxVRtVDTwdI2Ca4it0CCVTT9wCkxSgokjE5Ho41hEPgb8OEUwoXr6Q==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "engines": {
+                "node": ">=20.19.0"
+            }
+        },
+        "node_modules/@csstools/css-calc": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-3.2.0.tgz",
+            "integrity": "sha512-bR9e6o2BDB12jzN/gIbjHa5wLJ4UjD1CB9pM7ehlc0ddk6EBz+yYS1EV2MF55/HUxrHcB/hehAyt5vhsA3hx7w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-color-parser": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-4.1.0.tgz",
+            "integrity": "sha512-U0KhLYmy2GVj6q4T3WaAe6NPuFYCPQoE3b0dRGxejWDgcPp8TP7S5rVdM5ZrFaqu4N67X8YaPBw14dQSYx3IyQ==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "dependencies": {
+                "@csstools/color-helpers": "^6.0.2",
+                "@csstools/css-calc": "^3.2.0"
+            },
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-parser-algorithms": "^4.0.0",
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-parser-algorithms": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-4.0.0.tgz",
+            "integrity": "sha512-+B87qS7fIG3L5h3qwJ/IFbjoVoOe/bpOdh9hAjXbvx0o8ImEmUsGXN0inFOnk2ChCFgqkkGFQ+TpM5rbhkKe4w==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "peerDependencies": {
+                "@csstools/css-tokenizer": "^4.0.0"
+            }
+        },
+        "node_modules/@csstools/css-syntax-patches-for-csstree": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.1.3.tgz",
+            "integrity": "sha512-SH60bMfrRCJF3morcdk57WklujF4Jr/EsQUzqkarfHXEFcAR1gg7fS/chAE922Sehgzc1/+Tz5H3Ypa1HiEKrg==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT-0",
+            "peerDependencies": {
+                "css-tree": "^3.2.1"
+            },
+            "peerDependenciesMeta": {
+                "css-tree": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/@csstools/css-tokenizer": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-4.0.0.tgz",
+            "integrity": "sha512-QxULHAm7cNu72w97JUNCBFODFaXpbDg+dP8b/oWFAZ2MTRppA3U00Y2L1HqaS4J6yBqxwa/Y3nMBaxVKbB/NsA==",
+            "dev": true,
+            "funding": [
+                {
+                    "type": "github",
+                    "url": "https://github.com/sponsors/csstools"
+                },
+                {
+                    "type": "opencollective",
+                    "url": "https://opencollective.com/csstools"
+                }
+            ],
+            "license": "MIT",
+            "engines": {
+                "node": ">=20.19.0"
             }
         },
         "node_modules/@discordjs/collection": {
@@ -603,6 +813,24 @@
             ],
             "engines": {
                 "node": ">=18"
+            }
+        },
+        "node_modules/@exodus/bytes": {
+            "version": "1.15.0",
+            "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.15.0.tgz",
+            "integrity": "sha512-UY0nlA+feH81UGSHv92sLEPLCeZFjXOuHhrIo0HQydScuQc8s0A7kL/UdgwgDq8g8ilksmuoF35YVTNphV2aBQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "@noble/hashes": "^1.8.0 || ^2.0.0"
+            },
+            "peerDependenciesMeta": {
+                "@noble/hashes": {
+                    "optional": true
+                }
             }
         },
         "node_modules/@hono/node-server": {
@@ -1238,6 +1466,26 @@
             "dev": true,
             "license": "MIT"
         },
+        "node_modules/@types/jsdom": {
+            "version": "28.0.1",
+            "resolved": "https://registry.npmjs.org/@types/jsdom/-/jsdom-28.0.1.tgz",
+            "integrity": "sha512-GJq2QE4TAZ5ajSoCasn5DOFm8u1mI3tIFvM5tIq3W5U/RTB6gsHwc6Yhpl91X9VSDOUVblgXmG+2+sSvFQrdlw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@types/node": "*",
+                "@types/tough-cookie": "*",
+                "parse5": "^7.0.0",
+                "undici-types": "^7.21.0"
+            }
+        },
+        "node_modules/@types/jsdom/node_modules/undici-types": {
+            "version": "7.25.0",
+            "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.25.0.tgz",
+            "integrity": "sha512-AXNgS1Byr27fTI+2bsPEkV9CxkT8H6xNyRI68b3TatlZo3RkzlqQBLL+w7SmGPVpokjHbcuNVQUWE7FRTg+LRA==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/@types/node": {
             "version": "25.5.0",
             "resolved": "https://registry.npmjs.org/@types/node/-/node-25.5.0.tgz",
@@ -1309,6 +1557,13 @@
                 "@types/http-errors": "*",
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/tough-cookie": {
+            "version": "4.0.5",
+            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+            "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/@vitest/expect": {
             "version": "4.1.2",
@@ -1458,6 +1713,16 @@
                 "node": ">= 0.6"
             }
         },
+        "node_modules/agent-base": {
+            "version": "7.1.4",
+            "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+            "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 14"
+            }
+        },
         "node_modules/agentkeepalive": {
             "version": "4.6.0",
             "resolved": "https://registry.npmjs.org/agentkeepalive/-/agentkeepalive-4.6.0.tgz",
@@ -1568,6 +1833,16 @@
             ],
             "license": "MIT",
             "optional": true
+        },
+        "node_modules/bidi-js": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+            "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "require-from-string": "^2.0.2"
+            }
         },
         "node_modules/bl": {
             "version": "4.1.0",
@@ -1885,6 +2160,20 @@
                 "url": "https://github.com/sponsors/fb55"
             }
         },
+        "node_modules/css-tree": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.2.1.tgz",
+            "integrity": "sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "mdn-data": "2.27.1",
+                "source-map-js": "^1.2.1"
+            },
+            "engines": {
+                "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+            }
+        },
         "node_modules/css-what": {
             "version": "6.2.2",
             "resolved": "https://registry.npmjs.org/css-what/-/css-what-6.2.2.tgz",
@@ -1895,6 +2184,84 @@
             },
             "funding": {
                 "url": "https://github.com/sponsors/fb55"
+            }
+        },
+        "node_modules/cssstyle": {
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-6.2.0.tgz",
+            "integrity": "sha512-Fm5NvhYathRnXNVndkUsCCuR63DCLVVwGOOwQw782coXFi5HhkXdu289l59HlXZBawsyNccXfWRYvLzcDCdDig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@asamuzakjp/css-color": "^5.0.1",
+                "@csstools/css-syntax-patches-for-csstree": "^1.0.28",
+                "css-tree": "^3.1.0",
+                "lru-cache": "^11.2.6"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-7.0.0.tgz",
+            "integrity": "sha512-23XHcCF+coGYevirZceTVD7NdJOqVn+49IHyxgszm+JIiHLoB2TkmPtsYkNWT1pvRSGkc35L6NHs0yHkN2SumA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
+        "node_modules/data-urls/node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls/node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/data-urls/node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/debug": {
@@ -1913,6 +2280,13 @@
                     "optional": true
                 }
             }
+        },
+        "node_modules/decimal.js": {
+            "version": "10.6.0",
+            "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+            "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/decompress-response": {
             "version": "6.0.0",
@@ -2736,6 +3110,19 @@
                 "node": ">=16.9.0"
             }
         },
+        "node_modules/html-encoding-sniffer": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+            "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.6.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            }
+        },
         "node_modules/htmlparser2": {
             "version": "10.1.0",
             "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
@@ -2785,6 +3172,34 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/http-proxy-agent": {
+            "version": "7.0.2",
+            "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+            "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.0",
+                "debug": "^4.3.4"
+            },
+            "engines": {
+                "node": ">= 14"
+            }
+        },
+        "node_modules/https-proxy-agent": {
+            "version": "7.0.6",
+            "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+            "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "agent-base": "^7.1.2",
+                "debug": "4"
+            },
+            "engines": {
+                "node": ">= 14"
             }
         },
         "node_modules/humanize-ms": {
@@ -2871,6 +3286,13 @@
             "integrity": "sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==",
             "license": "MIT"
         },
+        "node_modules/is-potential-custom-element-name": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+            "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/is-promise": {
             "version": "4.0.0",
             "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-4.0.0.tgz",
@@ -2902,6 +3324,121 @@
             "license": "MIT",
             "funding": {
                 "url": "https://github.com/sponsors/panva"
+            }
+        },
+        "node_modules/jsdom": {
+            "version": "28.1.0",
+            "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-28.1.0.tgz",
+            "integrity": "sha512-0+MoQNYyr2rBHqO1xilltfDjV9G7ymYGlAUazgcDLQaUf8JDHbuGwsxN6U9qWaElZ4w1B2r7yEGIL3GdeW3Rug==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@acemir/cssom": "^0.9.31",
+                "@asamuzakjp/dom-selector": "^6.8.1",
+                "@bramus/specificity": "^2.4.2",
+                "@exodus/bytes": "^1.11.0",
+                "cssstyle": "^6.0.1",
+                "data-urls": "^7.0.0",
+                "decimal.js": "^10.6.0",
+                "html-encoding-sniffer": "^6.0.0",
+                "http-proxy-agent": "^7.0.2",
+                "https-proxy-agent": "^7.0.6",
+                "is-potential-custom-element-name": "^1.0.1",
+                "parse5": "^8.0.0",
+                "saxes": "^6.0.0",
+                "symbol-tree": "^3.2.4",
+                "tough-cookie": "^6.0.0",
+                "undici": "^7.21.0",
+                "w3c-xmlserializer": "^5.0.0",
+                "webidl-conversions": "^8.0.1",
+                "whatwg-mimetype": "^5.0.0",
+                "whatwg-url": "^16.0.0",
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+            },
+            "peerDependencies": {
+                "canvas": "^3.0.0"
+            },
+            "peerDependenciesMeta": {
+                "canvas": {
+                    "optional": true
+                }
+            }
+        },
+        "node_modules/jsdom/node_modules/entities": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/entities/-/entities-8.0.0.tgz",
+            "integrity": "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20.19.0"
+            },
+            "funding": {
+                "url": "https://github.com/fb55/entities?sponsor=1"
+            }
+        },
+        "node_modules/jsdom/node_modules/parse5": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.1.tgz",
+            "integrity": "sha512-z1e/HMG90obSGeidlli3hj7cbocou0/wa5HacvI3ASx34PecNjNQeaHNo5WIZpWofN9kgkqV1q5YvXe3F0FoPw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "entities": "^8.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/inikulin/parse5?sponsor=1"
+            }
+        },
+        "node_modules/jsdom/node_modules/tr46": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+            "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "punycode": "^2.3.1"
+            },
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/jsdom/node_modules/webidl-conversions": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+            "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+            "dev": true,
+            "license": "BSD-2-Clause",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-mimetype": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+            "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=20"
+            }
+        },
+        "node_modules/jsdom/node_modules/whatwg-url": {
+            "version": "16.0.1",
+            "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-16.0.1.tgz",
+            "integrity": "sha512-1to4zXBxmXHV3IiSSEInrreIlu02vUOvrhxJJH5vcxYTBDAx51cqZiKdyTxlecdKNSjj8EcxGBxNf6Vg+945gw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "@exodus/bytes": "^1.11.0",
+                "tr46": "^6.0.0",
+                "webidl-conversions": "^8.0.1"
+            },
+            "engines": {
+                "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
             }
         },
         "node_modules/json-schema-traverse": {
@@ -3208,6 +3745,16 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/lru-cache": {
+            "version": "11.3.5",
+            "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.3.5.tgz",
+            "integrity": "sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==",
+            "dev": true,
+            "license": "BlueOak-1.0.0",
+            "engines": {
+                "node": "20 || >=22"
+            }
+        },
         "node_modules/magic-bytes.js": {
             "version": "1.13.0",
             "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
@@ -3232,6 +3779,13 @@
             "engines": {
                 "node": ">= 0.4"
             }
+        },
+        "node_modules/mdn-data": {
+            "version": "2.27.1",
+            "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.27.1.tgz",
+            "integrity": "sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==",
+            "dev": true,
+            "license": "CC0-1.0"
         },
         "node_modules/media-typer": {
             "version": "1.1.0",
@@ -3998,6 +4552,16 @@
                 "once": "^1.3.1"
             }
         },
+        "node_modules/punycode": {
+            "version": "2.3.1",
+            "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+            "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+            "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">=6"
+            }
+        },
         "node_modules/qs": {
             "version": "6.15.0",
             "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
@@ -4210,6 +4774,19 @@
             "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
             "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
             "license": "MIT"
+        },
+        "node_modules/saxes": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+            "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+            "dev": true,
+            "license": "ISC",
+            "dependencies": {
+                "xmlchars": "^2.2.0"
+            },
+            "engines": {
+                "node": ">=v12.22.7"
+            }
         },
         "node_modules/semver": {
             "version": "7.7.4",
@@ -4551,6 +5128,13 @@
                 "url": "https://github.com/sponsors/Borewit"
             }
         },
+        "node_modules/symbol-tree": {
+            "version": "3.2.4",
+            "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+            "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/tar-fs": {
             "version": "2.1.4",
             "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
@@ -4625,6 +5209,26 @@
                 "node": ">=14.0.0"
             }
         },
+        "node_modules/tldts": {
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.28.tgz",
+            "integrity": "sha512-+Zg3vWhRUv8B1maGSTFdev9mjoo8Etn2Ayfs4cnjlD3CsGkxXX4QyW3j2WJ0wdjYcYmy7Lx2RDsZMhgCWafKIw==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "tldts-core": "^7.0.28"
+            },
+            "bin": {
+                "tldts": "bin/cli.js"
+            }
+        },
+        "node_modules/tldts-core": {
+            "version": "7.0.28",
+            "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.28.tgz",
+            "integrity": "sha512-7W5Efjhsc3chVdFhqtaU0KtK32J37Zcr9RKtID54nG+tIpcY79CQK/veYPODxtD/LJ4Lue66jvrQzIX2Z2/pUQ==",
+            "dev": true,
+            "license": "MIT"
+        },
         "node_modules/toidentifier": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -4650,6 +5254,19 @@
             "funding": {
                 "type": "github",
                 "url": "https://github.com/sponsors/Borewit"
+            }
+        },
+        "node_modules/tough-cookie": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.1.tgz",
+            "integrity": "sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==",
+            "dev": true,
+            "license": "BSD-3-Clause",
+            "dependencies": {
+                "tldts": "^7.0.5"
+            },
+            "engines": {
+                "node": ">=16"
             }
         },
         "node_modules/tr46": {
@@ -4950,6 +5567,19 @@
                 }
             }
         },
+        "node_modules/w3c-xmlserializer": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+            "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+            "dev": true,
+            "license": "MIT",
+            "dependencies": {
+                "xml-name-validator": "^5.0.0"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/web-streams-polyfill": {
             "version": "4.0.0-beta.3",
             "resolved": "https://registry.npmjs.org/web-streams-polyfill/-/web-streams-polyfill-4.0.0-beta.3.tgz",
@@ -5046,6 +5676,23 @@
             "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
             "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
             "license": "ISC"
+        },
+        "node_modules/xml-name-validator": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+            "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+            "dev": true,
+            "license": "Apache-2.0",
+            "engines": {
+                "node": ">=18"
+            }
+        },
+        "node_modules/xmlchars": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+            "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+            "dev": true,
+            "license": "MIT"
         },
         "node_modules/xtend": {
             "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -79,8 +79,10 @@
         "@electric-sql/pglite": "^0.4.2",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
+        "@types/jsdom": "^28.0.1",
         "@types/node": "^25.0.6",
         "@types/pg": "^8.11.10",
+        "jsdom": "^28.0.0",
         "tsx": "^4.21.0",
         "typescript": "^5.9.3",
         "vitest": "^4.1.2"

--- a/src/__tests__/analytics-server.test.ts
+++ b/src/__tests__/analytics-server.test.ts
@@ -82,7 +82,8 @@ function buildTestApp() {
           res.status(parsed.status).json(parsed.body);
           return;
         }
-        const summary = await mockGetAnalyticsSummary(parsed.filter);
+        const days = parseInt(req.query.days as string) || 7;
+        const summary = await mockGetAnalyticsSummary(parsed.filter, days);
         res.json(summary);
       } catch (err) {
         res.status(500).json({ error: "Failed to fetch analytics summary" });
@@ -501,6 +502,79 @@ describe("Analytics server routes (HTTP-level)", () => {
       const callArg = mockGetAnalyticsSummary.mock.calls[0][0];
       expect(callArg.from).toBeUndefined();
       expect(callArg.to).toBeUndefined();
+    });
+
+    // -------------------------------------------------------------------------
+    // Regression: the summary handler used to drop the `days` query param
+    // entirely — only parseAnalyticsFilter(from/to) made it to the DB layer.
+    // As a result, the dashboard's "Last N days" preset never updated the
+    // stat cards or the daily chart.
+    // -------------------------------------------------------------------------
+    it("forwards `days=30` through to getAnalyticsSummary as the second arg", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "tok",
+      });
+      mockGetAnalyticsSummary.mockResolvedValue({ total_queries: 0 });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/summary?days=30",
+        { Authorization: "Bearer tok" },
+      );
+
+      expect(res.status).toBe(200);
+      // getAnalyticsSummary must be invoked with (filter, days).
+      expect(mockGetAnalyticsSummary).toHaveBeenCalledTimes(1);
+      const [filterArg, daysArg] = mockGetAnalyticsSummary.mock.calls[0];
+      expect(filterArg).toEqual({});
+      expect(daysArg).toBe(30);
+    });
+
+    it("defaults `days` to 7 when no days param is provided", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "tok",
+      });
+      mockGetAnalyticsSummary.mockResolvedValue({ total_queries: 0 });
+
+      await startApp();
+      await request(server, "GET", "/api/analytics/summary", {
+        Authorization: "Bearer tok",
+      });
+
+      const [, daysArg] = mockGetAnalyticsSummary.mock.calls[0];
+      expect(daysArg).toBe(7);
+    });
+
+    it("does not pass `days` to DB when from/to range is active", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "tok",
+      });
+      mockGetAnalyticsSummary.mockResolvedValue({ total_queries: 0 });
+
+      await startApp();
+      await request(
+        server,
+        "GET",
+        "/api/analytics/summary?from=2026-04-01&to=2026-04-20&days=30",
+        { Authorization: "Bearer tok" },
+      );
+
+      // `days` still reaches the DB layer as a fallback (default 7), but the
+      // explicit from/to range takes precedence inside buildDateWindow.
+      const [filterArg] = mockGetAnalyticsSummary.mock.calls[0];
+      expect(filterArg.from).toBeInstanceOf(Date);
+      expect(filterArg.to).toBeInstanceOf(Date);
     });
   });
 });

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -429,3 +429,159 @@ describe("analytics dashboard UI — date preset wiring", () => {
     expect(statsHtml).toContain("7,777");
   });
 });
+
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — dynamic window labels", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  function makeEndpoints() {
+    return {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": (qs: string) => {
+        const p = parseQS(qs);
+        const days = p.days ? parseInt(p.days, 10) : 7;
+        return canned(days, 1234).summary;
+      },
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+  }
+
+  async function clickPresetByDays(dom: JSDOM, days: number) {
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const preset = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === String(days)) as
+      | HTMLElement
+      | undefined;
+    preset!.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  }
+
+  async function clickToday(dom: JSDOM) {
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const todayPreset = Array.from(
+      dom.window.document.querySelectorAll(".preset"),
+    ).find((el) => el.textContent?.trim().startsWith("Today")) as
+      | HTMLElement
+      | undefined;
+    todayPreset!.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+  }
+
+  it("default load shows 'Last 7 days' window label on stat cards, chart title, and table headers", async () => {
+    const { dom } = await loadDashboard(makeEndpoints());
+    const doc = dom.window.document;
+
+    // Stat card labels (first four stat cards carry the window label).
+    const statsHtml = doc.getElementById("stats")!.innerHTML;
+    expect(statsHtml).toContain("Queries (Last 7 days)");
+    expect(statsHtml).toContain("Empty Result Rate (Last 7 days)");
+    expect(statsHtml).toContain("Avg Latency (Last 7 days)");
+    expect(statsHtml).toContain("P95 Latency (Last 7 days)");
+    expect(statsHtml).toContain("Empty Queries (Last 7 days)");
+    // And the "(7d)" literal must be gone from stat card labels.
+    expect(statsHtml).not.toContain("(7d)");
+
+    // Daily chart title.
+    const dailyTitle = doc.getElementById("dailyChartTitle")!.textContent;
+    expect(dailyTitle).toBe("Queries per Day (Last 7 days)");
+
+    // Top queries table h2.
+    const topQueriesTitle = doc.getElementById("topQueriesTitle")!.textContent;
+    expect(topQueriesTitle).toBe("Top Queries (Last 7 days)");
+
+    // Empty queries table h2 (contains the warning span, so check textContent).
+    const emptyTitle = doc
+      .getElementById("emptyQueriesTitle")!
+      .textContent!.trim();
+    expect(emptyTitle.startsWith("Empty Result Queries (Last 7 days)")).toBe(
+      true,
+    );
+  });
+
+  it("switching to 'Last 30 days' updates every label to 'Last 30 days'", async () => {
+    const { dom } = await loadDashboard(makeEndpoints());
+    await clickPresetByDays(dom, 30);
+
+    const doc = dom.window.document;
+    const statsHtml = doc.getElementById("stats")!.innerHTML;
+    expect(statsHtml).toContain("Queries (Last 30 days)");
+    expect(statsHtml).toContain("Empty Result Rate (Last 30 days)");
+    expect(statsHtml).toContain("Avg Latency (Last 30 days)");
+    expect(statsHtml).toContain("P95 Latency (Last 30 days)");
+    expect(statsHtml).toContain("Empty Queries (Last 30 days)");
+    expect(statsHtml).not.toContain("Last 7 days");
+    expect(statsHtml).not.toContain("(7d)");
+
+    expect(doc.getElementById("dailyChartTitle")!.textContent).toBe(
+      "Queries per Day (Last 30 days)",
+    );
+    expect(doc.getElementById("topQueriesTitle")!.textContent).toBe(
+      "Top Queries (Last 30 days)",
+    );
+    const emptyTitle = doc
+      .getElementById("emptyQueriesTitle")!
+      .textContent!.trim();
+    expect(emptyTitle.startsWith("Empty Result Queries (Last 30 days)")).toBe(
+      true,
+    );
+  });
+
+  it("switching to 'Today' updates every label to 'Today'", async () => {
+    const { dom } = await loadDashboard(makeEndpoints());
+    await clickToday(dom);
+
+    const doc = dom.window.document;
+    const statsHtml = doc.getElementById("stats")!.innerHTML;
+    expect(statsHtml).toContain("Queries (Today)");
+    expect(statsHtml).toContain("Empty Result Rate (Today)");
+    expect(statsHtml).toContain("Avg Latency (Today)");
+    expect(statsHtml).toContain("P95 Latency (Today)");
+    expect(statsHtml).toContain("Empty Queries (Today)");
+
+    expect(doc.getElementById("dailyChartTitle")!.textContent).toBe(
+      "Queries per Day (Today)",
+    );
+    expect(doc.getElementById("topQueriesTitle")!.textContent).toBe(
+      "Top Queries (Today)",
+    );
+    const emptyTitle = doc
+      .getElementById("emptyQueriesTitle")!
+      .textContent!.trim();
+    expect(emptyTitle.startsWith("Empty Result Queries (Today)")).toBe(true);
+  });
+
+  it("switching to 'Last 90 days' updates every label to 'Last 90 days'", async () => {
+    const { dom } = await loadDashboard(makeEndpoints());
+    await clickPresetByDays(dom, 90);
+
+    const doc = dom.window.document;
+    const statsHtml = doc.getElementById("stats")!.innerHTML;
+    expect(statsHtml).toContain("Queries (Last 90 days)");
+    expect(doc.getElementById("dailyChartTitle")!.textContent).toBe(
+      "Queries per Day (Last 90 days)",
+    );
+    expect(doc.getElementById("topQueriesTitle")!.textContent).toBe(
+      "Top Queries (Last 90 days)",
+    );
+  });
+});

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -1,0 +1,431 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { JSDOM, VirtualConsole } from "jsdom";
+import fs from "node:fs";
+import path from "node:path";
+
+/**
+ * Integration test for the analytics dashboard UI (docs/analytics.html).
+ *
+ * These tests load the real analytics.html into jsdom, stub window.fetch so
+ * each endpoint returns a configurable canned payload keyed by the query
+ * string, and exercise the date-range preset clicks end-to-end.
+ *
+ * They would have failed against the pre-fix code because:
+ *   - Bug 1: clicking "Last 30 days" did not update the stat cards / charts —
+ *     the summary + tool-counts endpoints were only sent `days=30` but the
+ *     server didn't read it, so the dashboard always rendered 7-day data for
+ *     those sections while tables updated.
+ *   - Bug 2: clicking "Today" sent `days=1`, which on the server means
+ *     "last 24 hours" — not actually today.
+ *
+ * The UI assertions here verify the *outbound* URLs the client sends (i.e.
+ * what the client is asking the server for). Combined with the backend SQL
+ * tests in analytics.test.ts — which confirm those params actually change
+ * the date window — the two together catch the full regression.
+ */
+
+// Chart.js is a global <script src> in the HTML. jsdom won't execute external
+// CDN scripts, so we stub a minimal Chart constructor on the window before
+// the inline script runs. The real chart rendering is not under test here —
+// only the data flow into it.
+function installChartStub(win: Window & typeof globalThis): {
+  instances: Array<{ type: string; data: unknown; options: unknown }>;
+} {
+  const instances: Array<{ type: string; data: unknown; options: unknown }> =
+    [];
+  class ChartStub {
+    type: string;
+    data: unknown;
+    options: unknown;
+    destroyed = false;
+    constructor(
+      _ctx: unknown,
+      cfg: { type: string; data: unknown; options: unknown },
+    ) {
+      this.type = cfg.type;
+      this.data = cfg.data;
+      this.options = cfg.options;
+      instances.push({
+        type: this.type,
+        data: this.data,
+        options: this.options,
+      });
+    }
+    destroy() {
+      this.destroyed = true;
+    }
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (win as any).Chart = ChartStub;
+  return { instances };
+}
+
+/**
+ * Build a fetch stub that:
+ *  - records every URL called
+ *  - returns a per-path response from `handlers` (function of query-string)
+ */
+function buildFetchStub(handlers: Record<string, (qs: string) => unknown>) {
+  const calls: string[] = [];
+  const fetchFn = vi.fn(async (url: string | URL) => {
+    const u = typeof url === "string" ? url : url.toString();
+    calls.push(u);
+    const [path, qs = ""] = u.split("?");
+    const handler = handlers[path];
+    if (!handler) {
+      return new Response("not mocked: " + u, { status: 404 });
+    }
+    const body = handler(qs);
+    return new Response(JSON.stringify(body), {
+      status: 200,
+      headers: { "Content-Type": "application/json" },
+    });
+  });
+  return { fetchFn, calls };
+}
+
+async function loadDashboard(
+  handlers: Record<string, (qs: string) => unknown>,
+): Promise<{
+  dom: JSDOM;
+  calls: string[];
+  chartInstances: Array<{ type: string; data: unknown; options: unknown }>;
+}> {
+  const html = fs.readFileSync(
+    path.join(process.cwd(), "docs", "analytics.html"),
+    "utf8",
+  );
+  // Swallow jsdom's "Could not load script" noise for the Chart.js CDN include.
+  const virtualConsole = new VirtualConsole();
+  virtualConsole.on("jsdomError", () => {});
+  const dom = new JSDOM(html, {
+    runScripts: "outside-only",
+    url: "http://localhost/analytics",
+    pretendToBeVisual: true,
+    virtualConsole,
+  });
+
+  const win = dom.window as unknown as Window & typeof globalThis;
+  const { instances } = installChartStub(win);
+  const { fetchFn, calls } = buildFetchStub(handlers);
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (win as any).fetch = fetchFn;
+
+  // Pull out the inline <script> and execute in the window.
+  const scriptEl = dom.window.document.querySelector("script:not([src])");
+  if (!scriptEl) throw new Error("inline script not found in analytics.html");
+  const code = scriptEl.textContent ?? "";
+  dom.window.eval(code);
+
+  // Init runs async (auth-mode check → load). Flush microtasks.
+  await new Promise((r) => setTimeout(r, 0));
+  await new Promise((r) => setTimeout(r, 0));
+
+  return { dom, calls, chartInstances: instances };
+}
+
+function canned(daysReturned: number, totalQueries: number) {
+  const today = new Date();
+  const dayOffset = (n: number) => {
+    const d = new Date(today);
+    d.setDate(d.getDate() - n);
+    return d.toISOString().slice(0, 10);
+  };
+  const perDay = Array.from({ length: daysReturned }, (_, i) => ({
+    day: dayOffset(daysReturned - 1 - i),
+    count: 10 + i,
+  }));
+  return {
+    summary: {
+      total_queries: totalQueries,
+      total_queries_7d: 500,
+      empty_result_rate_7d: 0.1,
+      empty_result_count_7d: 50,
+      avg_latency_ms_7d: 100,
+      p95_latency_ms_7d: 300,
+      queries_per_day_7d: perDay,
+      queries_by_source: [{ source_name: "docs", count: totalQueries }],
+    },
+    toolCounts: [{ tool_type: "search", count: totalQueries }],
+    queries: [],
+    emptyQueries: [],
+  };
+}
+
+/**
+ * Parse the query string returned by window.fetch calls. Returns a map of
+ * key → value (last-wins). Accepts the raw QS without the leading '?'.
+ */
+function parseQS(qs: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!qs) return out;
+  for (const pair of qs.split("&")) {
+    if (!pair) continue;
+    const [k, v = ""] = pair.split("=");
+    out[decodeURIComponent(k)] = decodeURIComponent(v);
+  }
+  return out;
+}
+
+function todayUTC(): string {
+  const d = new Date();
+  const y = d.getUTCFullYear();
+  const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+  const day = String(d.getUTCDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — date preset wiring", () => {
+  beforeEach(() => {
+    // Ensure no lingering preview mode or token from other tests.
+    // jsdom gives a fresh window per test anyway, but be defensive.
+  });
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("clicking 'Last 30 days' sends days=30 to ALL four endpoints (not just tables)", async () => {
+    // Per-endpoint handlers return a payload whose stat-card value varies
+    // by the `days` param so we can tell if the stat cards rendered fresh
+    // data or stale 7-day data.
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": (qs: string) => {
+        const p = parseQS(qs);
+        const days = p.days ? parseInt(p.days, 10) : 7;
+        return canned(days, days === 30 ? 9999 : 1111).summary;
+      },
+      "/api/analytics/tool-counts": (qs: string) => {
+        const p = parseQS(qs);
+        const days = p.days ? parseInt(p.days, 10) : 7;
+        return canned(days, days === 30 ? 9999 : 1111).toolCounts;
+      },
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls, chartInstances } = await loadDashboard(endpoints);
+
+    // Initial load happens with defaults (days=7).
+    const initialCalls = calls.slice();
+    expect(
+      initialCalls.some((u) => u.startsWith("/api/analytics/summary")),
+    ).toBe(true);
+
+    // Open the date popover.
+    const datePill = dom.window.document.getElementById("datePill");
+    expect(datePill).not.toBeNull();
+    datePill!.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    // Click the "Last 30 days" preset.
+    const presets = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    );
+    const thirty = presets.find(
+      (el) => el.getAttribute("data-days") === "30",
+    ) as HTMLElement | undefined;
+    expect(thirty).toBeDefined();
+    thirty!.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    // Let the reload resolve.
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Collect only the URLs issued AFTER the preset click.
+    const afterClick = calls.slice(initialCalls.length);
+
+    const summaryCall = afterClick.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    const toolCountsCall = afterClick.find((u) =>
+      u.startsWith("/api/analytics/tool-counts"),
+    );
+    const queriesCall = afterClick.find((u) =>
+      u.startsWith("/api/analytics/queries"),
+    );
+    const emptyCall = afterClick.find((u) =>
+      u.startsWith("/api/analytics/empty-queries"),
+    );
+
+    // Every endpoint must be refetched with days=30 — not just queries/empty.
+    expect(summaryCall).toBeDefined();
+    expect(toolCountsCall).toBeDefined();
+    expect(queriesCall).toBeDefined();
+    expect(emptyCall).toBeDefined();
+
+    expect(parseQS(summaryCall!.split("?")[1] ?? "")).toMatchObject({
+      days: "30",
+    });
+    expect(parseQS(toolCountsCall!.split("?")[1] ?? "")).toMatchObject({
+      days: "30",
+    });
+    expect(parseQS(queriesCall!.split("?")[1] ?? "")).toMatchObject({
+      days: "30",
+    });
+    expect(parseQS(emptyCall!.split("?")[1] ?? "")).toMatchObject({
+      days: "30",
+    });
+
+    // Stat card "Total Queries" must reflect the 30-day value (9999),
+    // not the default 7-day value (1111).
+    const statsHtml = dom.window.document.getElementById("stats")!.innerHTML;
+    expect(statsHtml).toContain("9,999");
+    expect(statsHtml).not.toContain("1,111");
+
+    // Daily bar chart should be re-rendered with 30 bars.
+    const lastBarChart = [...chartInstances]
+      .reverse()
+      .find((c) => c.type === "bar");
+    expect(lastBarChart).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labels = (lastBarChart as any).data.labels as string[];
+    expect(labels).toHaveLength(30);
+  });
+
+  it("clicking 'Today' sends from=<today>&to=<today> (both equal, UTC), not days=1", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": (qs: string) => {
+        const p = parseQS(qs);
+        // Return a distinguishing value when the `from`/`to` range is used.
+        const usingRange = Boolean(p.from && p.to);
+        return canned(1, usingRange ? 4242 : 1111).summary;
+      },
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboard(endpoints);
+    const initial = calls.slice();
+
+    // Open popover.
+    const datePill = dom.window.document.getElementById("datePill")!;
+    datePill.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    // Click "Today" preset. data-days is whatever the UI chose — the test
+    // only asserts on outbound fetches, which is what actually matters.
+    const todayPreset = Array.from(
+      dom.window.document.querySelectorAll(".preset"),
+    ).find((el) => el.textContent?.trim().startsWith("Today")) as
+      | HTMLElement
+      | undefined;
+    expect(todayPreset).toBeDefined();
+    todayPreset!.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const after = calls.slice(initial.length);
+    const summaryCall = after.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+
+    const today = todayUTC();
+    // from and to must both be present AND equal to today's date.
+    expect(qs.from).toBe(today);
+    expect(qs.to).toBe(today);
+    // days= must NOT be sent — "Today" uses explicit range, not rolling window.
+    expect(qs.days).toBeUndefined();
+
+    // Every endpoint must send the explicit range.
+    for (const p of [
+      "/api/analytics/summary",
+      "/api/analytics/tool-counts",
+      "/api/analytics/queries",
+      "/api/analytics/empty-queries",
+    ]) {
+      const call = after.find((u) => u.startsWith(p));
+      expect(call, p + " should be refetched").toBeDefined();
+      const q = parseQS(call!.split("?")[1] ?? "");
+      expect(q.from, p + " from=today").toBe(today);
+      expect(q.to, p + " to=today").toBe(today);
+      expect(q.days, p + " should not send days").toBeUndefined();
+    }
+
+    // Stat card must show the range-using payload, not the default 7-day one.
+    const statsHtml = dom.window.document.getElementById("stats")!.innerHTML;
+    expect(statsHtml).toContain("4,242");
+
+    // Pill label must say "Today" — not the formatted date.
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toBe("Today");
+  });
+
+  it("clicking 'Last 7 days' AFTER 'Today' switches back to days=7 and updates stats", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": (qs: string) => {
+        const p = parseQS(qs);
+        if (p.from && p.to) return canned(1, 4242).summary;
+        const days = p.days ? parseInt(p.days, 10) : 7;
+        return canned(days, days === 7 ? 7777 : 1111).summary;
+      },
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboard(endpoints);
+
+    // Today first.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const todayPreset = Array.from(
+      dom.window.document.querySelectorAll(".preset"),
+    ).find((el) => el.textContent?.trim().startsWith("Today")) as HTMLElement;
+    todayPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    // Snapshot of fetches so far.
+    const beforeSwitch = calls.length;
+
+    // Then switch to Last 7 days.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const seven = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === "7") as HTMLElement;
+    seven.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await new Promise((r) => setTimeout(r, 0));
+    await new Promise((r) => setTimeout(r, 0));
+
+    const after = calls.slice(beforeSwitch);
+    const summaryCall = after.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.days).toBe("7");
+    expect(qs.from).toBeUndefined();
+    expect(qs.to).toBeUndefined();
+
+    const statsHtml = dom.window.document.getElementById("stats")!.innerHTML;
+    expect(statsHtml).toContain("7,777");
+  });
+});

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -518,6 +518,69 @@ describe("getEmptyQueries with filters", () => {
 // Date range filter (from/to) support
 // ---------------------------------------------------------------------------
 
+// ---------------------------------------------------------------------------
+// getAnalyticsSummary honors `days` parameter
+//
+// Regression: pre-fix, getAnalyticsSummary ignored any caller-supplied window
+// and always hardcoded `buildDateWindow(filter, 7, ...)`. The dashboard's
+// "Last 30 days" preset sent days=30 to /api/analytics/summary, but the
+// handler never parsed it — so stat cards + daily chart showed 7-day data
+// while the tables (which DO thread days through) showed 30-day data.
+// ---------------------------------------------------------------------------
+
+describe("getAnalyticsSummary honors days window", () => {
+  function mockSummaryQueries() {
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 500 }] }) // total
+      .mockResolvedValueOnce({
+        rows: [{ total: 100, empty: 5, avg_latency: 50 }],
+      }) // 7d summary
+      .mockResolvedValueOnce({ rows: [] }) // latency rows
+      .mockResolvedValueOnce({ rows: [] }) // by source
+      .mockResolvedValueOnce({ rows: [] }); // per day
+  }
+
+  it("passes the requested `days` value to every windowed subquery", async () => {
+    mockSummaryQueries();
+    await getAnalyticsSummary({}, 30);
+
+    // Skip mock.calls[0] — the totals query has no date window.
+    for (let i = 1; i < 5; i++) {
+      const [sql, params] = mockQuery.mock.calls[i];
+      expect(sql).toContain("NOW() - INTERVAL");
+      expect(params).toContain(30);
+      expect(params).not.toContain(7);
+    }
+  });
+
+  it("defaults `days` to 7 when not provided (backward compatible)", async () => {
+    mockSummaryQueries();
+    await getAnalyticsSummary({});
+
+    for (let i = 1; i < 5; i++) {
+      const [, params] = mockQuery.mock.calls[i];
+      expect(params).toContain(7);
+    }
+  });
+
+  it("explicit from/to takes precedence over days", async () => {
+    mockSummaryQueries();
+    const from = new Date("2026-04-01T00:00:00.000Z");
+    const to = new Date("2026-04-20T23:59:59.999Z");
+    // Passing a `days` value should be ignored when from/to is set.
+    await getAnalyticsSummary({ from, to }, 30);
+
+    for (let i = 1; i < 5; i++) {
+      const [sql, params] = mockQuery.mock.calls[i];
+      expect(sql).toContain("created_at >=");
+      expect(params).toContain(from);
+      expect(params).toContain(to);
+      expect(params).not.toContain(30);
+      expect(params).not.toContain(7);
+    }
+  });
+});
+
 describe("getAnalyticsSummary with from/to range", () => {
   function mockSummaryQueries() {
     mockQuery

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -174,9 +174,15 @@ function computeP95(latencies: number[]): number {
 
 /**
  * Get a summary of analytics data.
+ *
+ * `days` controls the rolling "last N days" window for the non-total
+ * subqueries (summary counts, latency, per-day, by-source). When the caller
+ * supplies `filter.from`/`filter.to`, that explicit range takes precedence
+ * and `days` is ignored — see {@link buildDateWindow}.
  */
 export async function getAnalyticsSummary(
   filter: AnalyticsFilter = {},
+  days: number = 7,
 ): Promise<AnalyticsSummary> {
   const pool = getPool();
 
@@ -189,23 +195,23 @@ export async function getAnalyticsSummary(
     fp,
   );
 
-  // 7d summary (filtered) - exclude backfilled rows from latency/empty stats
+  // Windowed summary (filtered) - exclude backfilled rows from latency/empty stats
   const { clauses: fc2, params: fp2, nextIdx: n2 } = buildFilterClauses(filter);
-  const dw2 = buildDateWindow(filter, 7, n2);
-  const summary7dWhere = whereAnd(dw2.clauses, fc2);
-  const summary7dRes = await pool.query(
+  const dw2 = buildDateWindow(filter, days, n2);
+  const summaryWhere = whereAnd(dw2.clauses, fc2);
+  const summaryRes = await pool.query(
     `SELECT
         count(*)::int AS total,
         count(*) FILTER (WHERE result_count = 0)::int AS empty,
         COALESCE(avg(latency_ms) FILTER (WHERE latency_ms >= 0)::int, 0) AS avg_latency
     FROM query_log
-    ${summary7dWhere}`,
+    ${summaryWhere}`,
     [...fp2, ...dw2.params],
   );
 
   // Latencies for p95 (exclude backfilled rows with latency_ms=-1)
   const { clauses: fc3, params: fp3, nextIdx: n3 } = buildFilterClauses(filter);
-  const dw3 = buildDateWindow(filter, 7, n3);
+  const dw3 = buildDateWindow(filter, days, n3);
   const latencyBase = [...dw3.clauses, "latency_ms >= 0"];
   const latencyWhere = whereAnd(latencyBase, fc3);
   const latencyRes = await pool.query(
@@ -215,7 +221,7 @@ export async function getAnalyticsSummary(
 
   // By source (filtered)
   const { clauses: fc4, params: fp4, nextIdx: n4 } = buildFilterClauses(filter);
-  const dw4 = buildDateWindow(filter, 7, n4);
+  const dw4 = buildDateWindow(filter, days, n4);
   const sourceBase = ["source_name IS NOT NULL", ...dw4.clauses];
   const sourceWhere = whereAnd(sourceBase, fc4);
   const bySourceRes = await pool.query(
@@ -229,7 +235,7 @@ export async function getAnalyticsSummary(
 
   // Per day (filtered)
   const { clauses: fc5, params: fp5, nextIdx: n5 } = buildFilterClauses(filter);
-  const dw5 = buildDateWindow(filter, 7, n5);
+  const dw5 = buildDateWindow(filter, days, n5);
   const dayWhere = whereAnd(dw5.clauses, fc5);
   const perDayRes = await pool.query(
     `SELECT date_trunc('day', created_at)::date::text AS day, count(*)::int AS count
@@ -241,7 +247,7 @@ export async function getAnalyticsSummary(
   );
 
   const totalQueries = totalRes.rows[0]?.count ?? 0;
-  const s = summary7dRes.rows[0] ?? {};
+  const s = summaryRes.rows[0] ?? {};
   const total7d = s.total ?? 0;
   const empty7d = s.empty ?? 0;
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -836,7 +836,8 @@ app.get(
         res.status(parsed.status).json(parsed.body);
         return;
       }
-      const summary = await getAnalyticsSummary(parsed.filter);
+      const days = parseInt(req.query.days as string) || 7;
+      const summary = await getAnalyticsSummary(parsed.filter, days);
       res.json(summary);
     } catch (err) {
       console.error("[analytics] Summary query failed:", err);


### PR DESCRIPTION
## Summary

Two date picker regressions from #38:

- **Stat cards + charts didn't update on preset change.** `/api/analytics/summary` ignored `req.query.days` and `getAnalyticsSummary()` hardcoded a 7-day window, so every preset returned 7-day data. Tables worked because the other endpoints already read `days`. Fix threads `days` through `getAnalyticsSummary` + all its subqueries; explicit `from`/`to` still wins in `buildDateWindow`.
- **"Today" preset behaved like "Last 7 days".** `days=1` on the server is a rolling 24h window that straddles today + yesterday. Fix: "Today" sends `from=<todayUTC>&to=<todayUTC>` instead of `days=1`. Pill label shows "Today" for that case.

Also:
- Dynamic window labels on stat cards, chart title, and table headers (so the UI reflects the actual preset).
- UI race + state preservation fixes for rapid preset-switching.
- jsdom test infrastructure for analytics UI integration tests.

## Why

Fixes user-visible regressions shipped in #38. No other changes — the rest of the analytics hardening lives in #40.

## Test plan

- [x] `npm test` — all analytics DB / server / UI suites green
- [x] `npm run build` — clean
- [x] `npx prettier --check "src/**/*.ts"` — clean
- [ ] CI green on HEAD
- [ ] Manual smoke: click each preset, stat cards + chart + tables all update; "Today" shows only today's rows