### PR TITLE
Suppress spurious bash-fs startup warning for repo-backed sources

### DIFF
--- a/src/__tests__/bash-fs.test.ts
+++ b/src/__tests__/bash-fs.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { buildBashFilesMap } from "../mcp/tools/bash-fs.js";
 import type { SourceConfig } from "../types.js";
 
@@ -98,5 +98,61 @@ describe("buildBashFilesMap", () => {
     ];
     const map = await buildBashFilesMap(sources);
     expect(Object.keys(map)).toHaveLength(0);
+  });
+
+  describe("missing-path warnings", () => {
+    let warnSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warnSpy.mockRestore();
+    });
+
+    it("does NOT warn when a repo-backed source's clone directory is not yet populated", async () => {
+      // Simulates the startup race: the orchestrator hasn't cloned yet,
+      // so the resolved path doesn't exist — but that's expected and should
+      // not fire a misleading "path does not exist" warning.
+      const sources: SourceConfig[] = [
+        {
+          name: "pathfinder-docs",
+          type: "markdown",
+          repo: "https://github.com/CopilotKit/pathfinder",
+          path: "docs",
+          file_patterns: ["**/*.md"],
+          chunk: { target_tokens: 600, overlap_tokens: 50 },
+        },
+      ];
+      const map = await buildBashFilesMap(sources, {
+        cloneDir: "/tmp/does-not-exist-pathfinder-test",
+      });
+      expect(Object.keys(map)).toHaveLength(0);
+      const missingPathWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0] ?? "").includes("path does not exist"),
+      );
+      expect(missingPathWarnings).toHaveLength(0);
+    });
+
+    it("DOES warn when a local (no-repo) source's path does not exist", async () => {
+      // True misconfiguration: user pointed at a path that doesn't exist
+      // and there's no repo to later populate it. Must still fire.
+      const sources: SourceConfig[] = [
+        {
+          name: "local-ghost",
+          type: "markdown",
+          path: "fixtures/definitely-not-here-" + Date.now(),
+          file_patterns: ["**/*.md"],
+          chunk: { target_tokens: 600, overlap_tokens: 50 },
+        },
+      ];
+      const map = await buildBashFilesMap(sources);
+      expect(Object.keys(map)).toHaveLength(0);
+      const missingPathWarnings = warnSpy.mock.calls.filter((call: unknown[]) =>
+        String(call[0] ?? "").includes("path does not exist"),
+      );
+      expect(missingPathWarnings.length).toBeGreaterThan(0);
+    });
   });
 });

--- a/src/mcp/tools/bash-fs.ts
+++ b/src/mcp/tools/bash-fs.ts
@@ -67,9 +67,17 @@ export async function buildBashFilesMap(
       rootDir = path.resolve(source.path);
     }
     if (!fs.existsSync(rootDir)) {
-      console.warn(
-        `[bash-fs] Source "${source.name}" path does not exist: ${rootDir}`,
-      );
+      // Sources with a `repo` configured are populated asynchronously by the
+      // orchestrator's clone step. On startup the first bash build races ahead
+      // of `checkAndIndex()`, so the rootDir legitimately doesn't exist yet —
+      // suppress the warning to avoid noise. A later refreshBashInstances()
+      // call rebuilds once clones complete. Keep the warning for truly local
+      // sources (no `repo`) where a missing path is a real misconfiguration.
+      if (!source.repo) {
+        console.warn(
+          `[bash-fs] Source "${source.name}" path does not exist: ${rootDir}`,
+        );
+      }
       continue;
     }
 


### PR DESCRIPTION
## Summary

The initial synchronous bash build runs before the orchestrator's `checkAndIndex()` has had a chance to clone repos, so every repo-backed source hits the `[bash-fs] Source "X" path does not exist` warning at startup — even though the path is about to be populated by a later `refreshBashInstances(..., "startup-refresh")` rebuild.

This is cosmetic but noisy and misleading: real missing-path errors get lost in the boot log.

## Why

Observed in Railway logs for `pathfinder-docs`:

```
[bash-fs] Source "pathfinder-docs" path does not exist: /tmp/mcp-repos/pathfinder/docs/
...
[file-provider:pathfinder-docs] Cloning ... → No new commits, skipping
```

The warning fires ~1s before the clone completes. The fix: when a source has `repo` configured, the rootDir not existing at build time is expected — suppress the warning for that case. Sources with **no** `repo` (truly local paths) still warn, because there a missing path is a real misconfiguration.

## Test plan

- [x] Added two tests in `src/__tests__/bash-fs.test.ts`:
  - Repo-backed source with missing clone dir: asserts NO warning
  - Local source (no repo) with missing path: asserts warning STILL fires
- [x] Red-green verified: first test failed pre-fix (1 warn call captured), both green post-fix
- [x] Full suite: 174 files / 2698 tests pass
- [x] `tsc` clean for modified files (unrelated pre-existing `domhandler` error in `indexing/chunking/html.ts` is on main)
- [x] Prettier clean