### PR TITLE
Rate limiter: IP allowlist + descriptive rejection payloads

### DIFF
--- a/deploy/copilotkit-docs.yaml
+++ b/deploy/copilotkit-docs.yaml
@@ -1,6 +1,11 @@
 server:
   name: copilotkit-docs-mcp
   version: "1.0.0"
+  # Anthropic crawler — bypasses per-IP session limit (requires trust_proxy: true to match the forwarded IP)
+  allowlist: ["160.79.106.35"]
+  # Safe to enable: Railway's edge discards any client-supplied X-Forwarded-For
+  # and sets its own trusted value, so the leftmost XFF entry is the real peer.
+  trust_proxy: true
 
 sources:
   - name: docs

--- a/deploy/pathfinder-docs.yaml
+++ b/deploy/pathfinder-docs.yaml
@@ -1,6 +1,11 @@
 server:
   name: pathfinder-docs
   version: "1.4.0"
+  # Anthropic crawler — bypasses per-IP session limit (requires trust_proxy: true to match the forwarded IP)
+  allowlist: ["160.79.106.35"]
+  # Safe to enable: Railway's edge discards any client-supplied X-Forwarded-For
+  # and sets its own trusted value, so the leftmost XFF entry is the real peer.
+  trust_proxy: true
 
 sources:
   - name: pathfinder-docs

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -251,13 +251,25 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
   <span class="key">name:</span> <span class="value">my-project-docs</span>             <span class="comment"># Server name, exposed in MCP metadata</span>
   <span class="key">version:</span> <span class="value">1.0.0</span>                    <span class="comment"># Server version string</span>
   <span class="key">max_sessions_per_ip:</span> <span class="value">20</span>           <span class="comment"># Max concurrent MCP sessions per IP (default: 20)</span>
-  <span class="key">session_ttl_minutes:</span> <span class="value">30</span>           <span class="comment"># Idle session timeout in minutes (default: 30)</span></div>
+  <span class="key">session_ttl_minutes:</span> <span class="value">30</span>           <span class="comment"># Idle session timeout in minutes (default: 30)</span>
+  <span class="key">allowlist:</span>                       <span class="comment"># IPs / CIDRs that bypass max_sessions_per_ip (default: [])</span>
+    <span class="comment"># NOTE: entries match the per-request client IP only. Behind a reverse proxy</span>
+    <span class="comment"># (Railway, Fly, Nginx, etc.) the server only ever sees the proxy's TCP socket</span>
+    <span class="comment"># peer as the client IP. That IP is not stable across deploys and should not be</span>
+    <span class="comment"># allowlisted — set trust_proxy: true to trust X-Forwarded-For instead.</span>
+    <span class="comment"># Directly-exposed servers use the socket peer.</span>
+    - <span class="value">"160.79.106.35"</span>              <span class="comment"># Example: Anthropic Assistant crawler</span>
+    - <span class="value">"10.0.0.0/8"</span>                 <span class="comment"># Example: internal health-probe CIDR</span>
+  <span class="key">trust_proxy:</span> <span class="value">false</span>                  <span class="comment"># Honor X-Forwarded-For (default: false — see warning below)</span></div>
 
     <ul>
         <li><strong>name</strong> — Identifies the server in MCP tool descriptions. Required.</li>
         <li><strong>version</strong> — Semantic version string. Required.</li>
         <li><strong>max_sessions_per_ip</strong> — Rate limiting. Prevents a single IP from opening too many concurrent sessions. Optional, defaults to 20.</li>
         <li><strong>session_ttl_minutes</strong> — Sessions with no activity for this many minutes are cleaned up. Optional, defaults to 30.</li>
+        <li><strong>allowlist</strong> — Array of IPv4/IPv6 addresses or CIDR ranges that bypass <code>max_sessions_per_ip</code> entirely. Use for trusted crawlers (e.g. <code>160.79.106.35</code> — Anthropic Assistant) or internal health-probe ranges. Optional, defaults to empty. Entries are matched against the per-request client IP — <strong>behind a reverse proxy this requires <code>trust_proxy: true</code></strong>; with the default <code>trust_proxy: false</code> the server only sees the proxy's TCP socket address and no upstream client IP will ever match. Directly-exposed servers use the socket peer and need no extra config. Clients that hit the limit receive a <code>429</code> with a descriptive JSON body (<code>error</code>, <code>reason</code>, <code>limit</code>, <code>currentCount</code>, <code>retryAfterSeconds</code>, <code>contact</code>) and a <code>Retry-After</code> header.</li>
+        <li><strong>trust_proxy</strong> — Whether to honor the <code>X-Forwarded-For</code> header for client-IP resolution (used by rate limiting, allowlist checks, tracing, and analytics). When <code>true</code>, the server populates <code>req.ip</code> from the leftmost entry of <code>X-Forwarded-For</code>. This is REQUIRED when the server runs behind a reverse proxy (Railway, Fly, Nginx, etc.) that sets <code>X-Forwarded-For</code>. Optional, defaults to <code>false</code>.
+            <strong>⚠️ Security:</strong> only enable this when the proxy discards any client-supplied <code>X-Forwarded-For</code> AND sets its own trusted value. If the proxy passes through client-supplied <code>X-Forwarded-For</code>, attackers can send <code>X-Forwarded-For: 160.79.106.35</code> to be seen as an allowlisted IP and bypass the rate limiter entirely. When <code>false</code> (default), <code>X-Forwarded-For</code> is ignored and the server uses the TCP socket's peer address.</li>
     </ul>
 
     <h2 id="sources">sources</h2>
@@ -311,6 +323,8 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
         <li><strong>chunk</strong> — Use <code>target_tokens</code>/<code>overlap_tokens</code> for markdown and raw-text sources. Use <code>target_lines</code>/<code>overlap_lines</code> for code sources.</li>
     </ul>
 
+    <p><em>Note: The <code>chunk</code> config is available on all source types, but the effect varies. Markdown, raw-text, HTML, and document sources use token-based chunks (<code>target_tokens</code>/<code>overlap_tokens</code>). Code sources use line-based chunks (<code>target_lines</code>/<code>overlap_lines</code>). For Slack and Discord, the Q&amp;A chunker produces one chunk per Q&amp;A pair and chunk settings have no effect. For Notion, the markdown chunker respects <code>target_tokens</code> and <code>overlap_tokens</code>.</em></p>
+
     <h3 id="source-markdown">Source type: markdown</h3>
 
     <p>Splits content on Markdown headings and uses token-based chunks. Best for documentation written in <code>.md</code> or <code>.mdx</code> files. Configure with <code>target_tokens</code> and <code>overlap_tokens</code>.</p>
@@ -325,7 +339,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
 
     <h3 id="source-html">Source type: html</h3>
 
-    <p>Parses HTML structure, extracts text content, and uses token-based chunks. Added in v1.4. Best for static sites, rendered documentation, or any HTML content.</p>
+    <p>Parses HTML structure, extracts text content, and uses token-based chunks. Best for static sites, rendered documentation, or any HTML content.</p>
 
     <h3 id="source-slack">Source type: slack</h3>
 
@@ -389,8 +403,8 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     <p>Index Notion pages and database entries as searchable markdown documents. Blocks are recursively converted to markdown, and database entry properties are serialized as YAML frontmatter.</p>
 
     <div class="code-block"><span class="key">sources:</span>
-  - name: notion-wiki
-    type: notion
+  - <span class="key">name:</span> <span class="value">notion-wiki</span>
+    <span class="key">type:</span> <span class="value">notion</span>
     <span class="key">root_pages:</span>
       - <span class="value">"abc123def456..."</span>         <span class="comment"># Notion page IDs to index (including children)</span>
     <span class="key">databases:</span>
@@ -411,8 +425,6 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     <p>If both <code>root_pages</code> and <code>databases</code> are empty, all pages accessible to the integration token are indexed. Requires <code>NOTION_TOKEN</code> environment variable.</p>
 
     <p>By default, Notion sources are indexed as documents and referenced by <code>search</code> tools. To also make them available via <code>knowledge</code> tools and the <code>/faq.txt</code> endpoint, add <code>category: faq</code> to the source config — useful for Notion databases structured as Q&amp;A or FAQ collections.</p>
-
-    <p><em>Note: The <code>chunk</code> config is available on all source types. For Slack and Discord, the Q&amp;A chunker produces one chunk per Q&amp;A pair (chunk settings have no effect). For Notion, the markdown chunker respects <code>target_tokens</code> and <code>overlap_tokens</code>.</em></p>
 
     <h3 id="source-document">Source type: document</h3>
 
@@ -630,13 +642,16 @@ https://docs.example.com/getting-started</div>
     <div class="code-block"><span class="key">analytics:</span>
   <span class="key">enabled:</span> <span class="value">false</span>               <span class="comment"># Enable analytics (default: false)</span>
   <span class="key">log_queries:</span> <span class="value">true</span>            <span class="comment"># Log all search queries (default: true)</span>
-  <span class="key">token:</span> <span class="value">${ANALYTICS_TOKEN}</span>    <span class="comment"># Bearer token for /api/analytics endpoints</span>
+  <span class="comment"># Bearer token for /api/analytics endpoints.</span>
+  <span class="comment"># Preferred: omit `token:` and set the ANALYTICS_TOKEN env var instead.</span>
+  <span class="comment"># Inline literal also works (no ${VAR} interpolation — YAML is loaded as-is):</span>
+  <span class="comment">#   token: "your-secret-here"</span>
   <span class="key">retention_days:</span> <span class="value">90</span>           <span class="comment"># Days to retain data (default: 90)</span></div>
 
     <ul>
         <li><strong>enabled</strong> — When <code>true</code>, Pathfinder logs queries and serves the analytics dashboard at <code>/analytics</code>. Default <code>false</code>.</li>
         <li><strong>log_queries</strong> — When <code>true</code>, all search queries are logged with latency and result counts. Default <code>true</code> (when analytics is enabled).</li>
-        <li><strong>token</strong> — Bearer token for authenticating requests to <code>/api/analytics/*</code> endpoints. Use the <code>ANALYTICS_TOKEN</code> environment variable. Required when analytics is enabled.</li>
+        <li><strong>token</strong> — Bearer token for authenticating requests to <code>/api/analytics/*</code> endpoints. Prefer the <code>ANALYTICS_TOKEN</code> environment variable; set <code>analytics.token</code> only if you need the value inline (YAML is loaded as-is — no <code>${VAR}</code> interpolation). One of <code>analytics.token</code> or the <code>ANALYTICS_TOKEN</code> env var is required when analytics is enabled.</li>
         <li><strong>retention_days</strong> — How long to keep analytics data before automatic cleanup. Default 90 days.</li>
     </ul>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
                 "discord-interactions": "^4.4.0",
                 "dotenv": "^17.3.1",
                 "express": "^5.2.1",
+                "ipaddr.js": "^2.2.0",
                 "just-bash": "^2.14.0",
                 "openai": "^4.80.0",
                 "pg": "^8.13.0",
@@ -3272,12 +3273,12 @@
             }
         },
         "node_modules/ipaddr.js": {
-            "version": "1.9.1",
-            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "version": "2.3.0",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.3.0.tgz",
+            "integrity": "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==",
             "license": "MIT",
             "engines": {
-                "node": ">= 0.10"
+                "node": ">= 10"
             }
         },
         "node_modules/is-electron": {
@@ -4528,6 +4529,15 @@
                 "forwarded": "0.2.0",
                 "ipaddr.js": "1.9.1"
             },
+            "engines": {
+                "node": ">= 0.10"
+            }
+        },
+        "node_modules/proxy-addr/node_modules/ipaddr.js": {
+            "version": "1.9.1",
+            "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+            "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+            "license": "MIT",
             "engines": {
                 "node": ">= 0.10"
             }

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "discord-interactions": "^4.4.0",
         "dotenv": "^17.3.1",
         "express": "^5.2.1",
+        "ipaddr.js": "^2.2.0",
         "just-bash": "^2.14.0",
         "openai": "^4.80.0",
         "pg": "^8.13.0",

--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -5,6 +5,32 @@
 server:
   name: my-project-docs
   version: "1.0.0"
+  # max_sessions_per_ip: 20           # Max concurrent MCP sessions per IP (default: 20)
+  #                                   # When exceeded, returns HTTP 429 with JSON
+  #                                   # {error, reason, limit, currentCount, retryAfterSeconds, contact}
+  #                                   # and a Retry-After header.
+  # session_ttl_minutes: 30           # Idle session timeout in minutes (default: 30)
+  # allowlist:                        # IPs / CIDRs that bypass max_sessions_per_ip. Empty by default.
+  #   - "160.79.106.35"               # Example: Anthropic Assistant crawler
+  #   - "10.0.0.0/8"                  # Example: internal health-probe CIDR
+  # NOTE: behind a reverse proxy (Railway, Fly, etc.), allowlist entries only match
+  # when trust_proxy: true. Otherwise the server sees the proxy IP for every request.
+  #
+  # ⚠️  SECURITY WARNING — trust_proxy ⚠️
+  # When true, the server honors X-Forwarded-For and populates req.ip from
+  # the leftmost entry. This is REQUIRED when the server runs behind a
+  # reverse proxy (Railway, Fly, Nginx, etc.) that sets X-Forwarded-For.
+  #
+  # Only enable this when the proxy discards any client-supplied
+  # X-Forwarded-For AND sets its own trusted value. If the proxy passes
+  # through client-supplied X-Forwarded-For, attackers can send
+  # `X-Forwarded-For: 160.79.106.35` to be seen as an allowlisted IP and
+  # BYPASS the rate limiter entirely.
+  #
+  # When false (the default), X-Forwarded-For is ignored and the server
+  # uses the TCP socket's peer address. Leave this false for any server
+  # exposed directly to the public internet.
+  trust_proxy: false
 
 sources:
   - name: docs

--- a/src/__tests__/analytics-auth.test.ts
+++ b/src/__tests__/analytics-auth.test.ts
@@ -1,0 +1,233 @@
+/**
+ * analyticsAuth: 503 misconfiguration message differentiation by env.
+ *
+ * In production the operator is expected to set ANALYTICS_TOKEN explicitly;
+ * if the auth middleware can't resolve a token we must surface that plainly.
+ * In non-prod environments auto-generation is the normal path and the
+ * production-flavored message would be misleading — so the 503 response body
+ * must differ so operators can tell the two failure modes apart.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+
+const mockGetConfig = vi.fn();
+const mockGetServerConfig = vi.fn();
+const mockGetAnalyticsConfig = vi.fn();
+
+vi.mock("../config.js", () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  getServerConfig: (...args: unknown[]) => mockGetServerConfig(...args),
+  getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+beforeEach(() => {
+  mockGetConfig.mockReturnValue({
+    port: 0,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "e".repeat(64),
+  });
+  mockGetServerConfig.mockReturnValue({
+    server: { name: "pathfinder-test", version: "0.0.0" },
+    sources: [],
+    tools: [],
+  });
+  mockGetAnalyticsConfig.mockReturnValue(undefined);
+});
+
+describe("analyticsAuth 503 message prod vs non-prod", () => {
+  let server: http.Server | undefined;
+  let consoleErrSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(async () => {
+    consoleErrSpy.mockRestore();
+    if (server?.listening) {
+      await new Promise<void>((resolve) => server!.close(() => resolve()));
+    }
+    server = undefined;
+  });
+
+  async function buildAndStart(): Promise<http.Server> {
+    const { registerAnalyticsRoutes, __resetAnalyticsTokenForTesting } =
+      await import("../server.js");
+    __resetAnalyticsTokenForTesting();
+    const app = express();
+    app.use(express.json());
+    registerAnalyticsRoutes(app);
+    return await new Promise<http.Server>((resolve) => {
+      const s = app.listen(0, () => resolve(s));
+    });
+  }
+
+  function request(
+    s: http.Server,
+    path: string,
+    headers: Record<string, string>,
+  ): Promise<{ status: number; body: string }> {
+    return new Promise((resolve, reject) => {
+      const addr = s.address() as { port: number };
+      const req = http.request(
+        { hostname: "127.0.0.1", port: addr.port, path, headers },
+        (res) => {
+          let body = "";
+          res.on("data", (c) => (body += c));
+          res.on("end", () =>
+            resolve({ status: res.statusCode!, body: body.toString() }),
+          );
+        },
+      );
+      req.on("error", reject);
+      req.end();
+    });
+  }
+
+  it("mentions production when NODE_ENV=production and no token configured", async () => {
+    mockGetConfig.mockReturnValue({
+      port: 0,
+      databaseUrl: "",
+      openaiApiKey: "",
+      githubToken: "",
+      githubWebhookSecret: "",
+      nodeEnv: "production",
+      logLevel: "info",
+      cloneDir: "",
+      slackBotToken: "",
+      slackSigningSecret: "",
+      discordBotToken: "",
+      discordPublicKey: "",
+      notionToken: "",
+      mcpJwtSecret: "e".repeat(64),
+    });
+    mockGetAnalyticsConfig.mockReturnValue({
+      enabled: true,
+      log_queries: true,
+      retention_days: 90,
+    });
+
+    server = await buildAndStart();
+    const res = await request(server, "/api/analytics/summary", {
+      Authorization: "Bearer whatever",
+    });
+
+    expect(res.status).toBe(503);
+    const body = JSON.parse(res.body) as Record<string, string>;
+    expect(body.error).toBe("misconfigured");
+    // Production message must mention production explicitly so the operator
+    // knows to set ANALYTICS_TOKEN.
+    expect(body.error_description).toMatch(/production/i);
+  });
+
+  it("dev-bypass is disabled when trust_proxy=true even if the socket peer is loopback (R2 #4)", async () => {
+    // Threat model: with trust_proxy=true AND NODE_ENV=development AND the
+    // server sitting behind a local reverse proxy (Docker sidecar, ngrok,
+    // localhost tunnel), every request's socket peer is 127.0.0.1 — the
+    // pre-fix dev bypass would unlock analytics for the entire public
+    // internet. Fail-closed: when trust_proxy=true we never grant the dev
+    // bypass, and the request flows into the token-required path (which
+    // without a Bearer token returns 401).
+    mockGetConfig.mockReturnValue({
+      port: 0,
+      databaseUrl: "",
+      openaiApiKey: "",
+      githubToken: "",
+      githubWebhookSecret: "",
+      nodeEnv: "development",
+      logLevel: "info",
+      cloneDir: "",
+      slackBotToken: "",
+      slackSigningSecret: "",
+      discordBotToken: "",
+      discordPublicKey: "",
+      notionToken: "",
+      mcpJwtSecret: "e".repeat(64),
+    });
+    mockGetAnalyticsConfig.mockReturnValue({
+      enabled: true,
+      log_queries: true,
+      retention_days: 90,
+    });
+
+    const { __setTrustProxyForTesting } = await import("../server.js");
+    __setTrustProxyForTesting(true);
+    try {
+      server = await buildAndStart();
+      // No Authorization header. Pre-fix: dev bypass on loopback -> 200/404.
+      // Post-fix: dev bypass refused under trust_proxy=true -> 401 because
+      // no Bearer token was supplied.
+      const res = await request(server, "/api/analytics/summary", {});
+      expect(res.status).toBe(401);
+    } finally {
+      __setTrustProxyForTesting(false);
+    }
+  });
+
+  it("does NOT mention production in non-prod 503s (different diagnostic message)", async () => {
+    // Non-prod scenario: in non-production environments, the
+    // "Analytics requires ANALYTICS_TOKEN in production" message is
+    // misleading because auto-generation IS the expected dev path. Drive
+    // the "no token available" fallback branch (getAnalyticsToken returns
+    // undefined) in a non-prod nodeEnv and assert the 503 message is not
+    // the production one.
+    let call = 0;
+    mockGetAnalyticsConfig.mockImplementation(() => {
+      call += 1;
+      if (call === 1) {
+        return {
+          enabled: true,
+          log_queries: true,
+          retention_days: 90,
+        };
+      }
+      throw new Error("downstream token failure");
+    });
+
+    // Use nodeEnv=staging to skip BOTH the production-requires-token branch
+    // AND the dev-localhost bypass (bypass only fires on NODE_ENV=development).
+    mockGetConfig.mockReturnValue({
+      port: 0,
+      databaseUrl: "",
+      openaiApiKey: "",
+      githubToken: "",
+      githubWebhookSecret: "",
+      nodeEnv: "staging",
+      logLevel: "info",
+      cloneDir: "",
+      slackBotToken: "",
+      slackSigningSecret: "",
+      discordBotToken: "",
+      discordPublicKey: "",
+      notionToken: "",
+      mcpJwtSecret: "e".repeat(64),
+    });
+
+    server = await buildAndStart();
+
+    const res = await request(server, "/api/analytics/summary", {
+      Authorization: "Bearer whatever",
+    });
+
+    expect(res.status).toBe(503);
+    const body = JSON.parse(res.body) as Record<string, string>;
+    expect(body.error).toBe("misconfigured");
+    // Non-prod message must NOT mention production — that'd be misleading.
+    expect(body.error_description).not.toMatch(/production/i);
+  });
+});

--- a/src/__tests__/ip-limiter.test.ts
+++ b/src/__tests__/ip-limiter.test.ts
@@ -194,12 +194,8 @@ describe("IpSessionLimiter", () => {
     });
 
     it("emits a single loud error when ALL allowlist entries are invalid", () => {
-      const errorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         // Two entries, both invalid — per-entry warnings plus one summary error.
         const allow = new IpSessionLimiter(2, {
@@ -218,12 +214,8 @@ describe("IpSessionLimiter", () => {
     });
 
     it("does NOT emit the 'all invalid' error when at least one entry parses", () => {
-      const errorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         new IpSessionLimiter(2, {
           allowlist: ["not-an-ip", "10.0.0.0/8"],
@@ -239,9 +231,7 @@ describe("IpSessionLimiter", () => {
     });
 
     it("does NOT emit the 'all invalid' error for an empty allowlist", () => {
-      const errorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
       try {
         new IpSessionLimiter(2, { allowlist: [] });
         const summaryCalls = errorSpy.mock.calls.filter((c: unknown[]) =>
@@ -309,9 +299,7 @@ describe("IpSessionLimiter", () => {
     });
 
     it("tryAdd with a re-used sid from a DIFFERENT IP does not cause counter drift", () => {
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         const drift = new IpSessionLimiter(5);
         expect(drift.tryAdd("1.2.3.4", "sid-x")).toBe(true);
@@ -346,12 +334,8 @@ describe("IpSessionLimiter", () => {
     });
 
     it("ESCALATES to console.error when ALL allowlist entries are invalid", () => {
-      const errorSpy = vi
-        .spyOn(console, "error")
-        .mockImplementation(() => {});
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         new IpSessionLimiter(2, {
           allowlist: ["not-an-ip", "also-bogus/33", "still-wrong"],
@@ -476,10 +460,7 @@ describe("IpSessionLimiter", () => {
           // Advance time by more than the cooldown per cold IP so each one
           // actually logs and inserts into the LRU map.
           vi.setSystemTime(start + (i + 1) * (cooldownMs + 1));
-          allow.tryAdd(
-            `10.1.${(i >> 8) & 0xff}.${i & 0xff}`,
-            `cold-${i}`,
-          );
+          allow.tryAdd(`10.1.${(i >> 8) & 0xff}.${i & 0xff}`, `cold-${i}`);
 
           // Every N iterations, re-touch the hot IP so true-LRU moves it
           // back to the tail.
@@ -502,9 +483,7 @@ describe("IpSessionLimiter", () => {
 
   describe("CIDR with non-zero host bits", () => {
     it("warns and normalizes 10.0.0.1/24 to the network address 10.0.0.0/24", () => {
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         const allow = new IpSessionLimiter(2, {
           // Operator typo / confusion: "10.0.0.1/24" means the whole /24,
@@ -517,10 +496,7 @@ describe("IpSessionLimiter", () => {
         // A warning with identifying detail was emitted.
         const warns = warnSpy.mock.calls.filter((c: unknown[]) => {
           const msg = String(c[0]);
-          return (
-            msg.includes("10.0.0.1/24") &&
-            msg.includes("host bits")
-          );
+          return msg.includes("10.0.0.1/24") && msg.includes("host bits");
         });
         expect(warns.length).toBe(1);
       } finally {
@@ -529,9 +505,7 @@ describe("IpSessionLimiter", () => {
     });
 
     it("accepts properly-formed CIDR without warning", () => {
-      const warnSpy = vi
-        .spyOn(console, "warn")
-        .mockImplementation(() => {});
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         new IpSessionLimiter(2, { allowlist: ["10.0.0.0/24"] });
         const hostBitWarns = warnSpy.mock.calls.filter((c: unknown[]) =>

--- a/src/__tests__/ip-limiter.test.ts
+++ b/src/__tests__/ip-limiter.test.ts
@@ -1,11 +1,43 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { IpSessionLimiter } from "../ip-limiter.js";
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import { IpSessionLimiter, type TryAddResult } from "../ip-limiter.js";
 
 describe("IpSessionLimiter", () => {
   let limiter: IpSessionLimiter;
 
   beforeEach(() => {
     limiter = new IpSessionLimiter(3); // max 3 sessions per IP
+  });
+
+  describe("constructor maxPerIp validation", () => {
+    // Belt-and-suspenders guard for direct consumers of the exported class.
+    // Schema upstream enforces max_sessions_per_ip as a positive integer, but
+    // IpSessionLimiter is a public export — a caller could still hand in a
+    // nonsense value. Silently accepting 0/NaN/negative/non-integer turns the
+    // limiter into "reject every non-allowlisted session" without any signal,
+    // which is indistinguishable from a successful DoS.
+    it("throws TypeError on maxPerIp = 0", () => {
+      expect(() => new IpSessionLimiter(0)).toThrow(TypeError);
+    });
+
+    it("throws TypeError on negative maxPerIp", () => {
+      expect(() => new IpSessionLimiter(-1)).toThrow(TypeError);
+    });
+
+    it("throws TypeError on NaN maxPerIp", () => {
+      expect(() => new IpSessionLimiter(Number.NaN)).toThrow(TypeError);
+    });
+
+    it("throws TypeError on non-integer maxPerIp", () => {
+      expect(() => new IpSessionLimiter(1.5)).toThrow(TypeError);
+    });
+
+    it("accepts maxPerIp = 1", () => {
+      expect(() => new IpSessionLimiter(1)).not.toThrow();
+    });
+
+    it("accepts maxPerIp = 20", () => {
+      expect(() => new IpSessionLimiter(20)).not.toThrow();
+    });
   });
 
   it("allows sessions up to the limit", () => {
@@ -58,6 +90,637 @@ describe("IpSessionLimiter", () => {
 
   it("remove with unknown session is a no-op", () => {
     expect(() => limiter.remove("nonexistent")).not.toThrow();
+  });
+
+  describe("allowlist", () => {
+    let infoSpy: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      infoSpy.mockRestore();
+    });
+
+    it("bypasses the limit for an exact plain-IP match", () => {
+      const allow = new IpSessionLimiter(2, {
+        allowlist: ["160.79.106.35"],
+      });
+      // Fill well past capacity — allowlisted IPs never count against the cap.
+      expect(allow.tryAdd("160.79.106.35", "sess-1")).toBe(true);
+      expect(allow.tryAdd("160.79.106.35", "sess-2")).toBe(true);
+      expect(allow.tryAdd("160.79.106.35", "sess-3")).toBe(true);
+      expect(allow.tryAdd("160.79.106.35", "sess-4")).toBe(true);
+      // Allowlisted traffic is not counted in getSessionCount.
+      expect(allow.getSessionCount("160.79.106.35")).toBe(0);
+    });
+
+    it("bypasses the limit for a CIDR match", () => {
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["160.79.106.0/24"],
+      });
+      expect(allow.tryAdd("160.79.106.7", "a")).toBe(true);
+      expect(allow.tryAdd("160.79.106.7", "b")).toBe(true);
+      expect(allow.tryAdd("160.79.106.250", "c")).toBe(true);
+    });
+
+    it("still enforces the limit on non-matching IPs", () => {
+      const allow = new IpSessionLimiter(2, {
+        allowlist: ["160.79.106.0/24"],
+      });
+      expect(allow.tryAdd("9.9.9.9", "a")).toBe(true);
+      expect(allow.tryAdd("9.9.9.9", "b")).toBe(true);
+      expect(allow.tryAdd("9.9.9.9", "c")).toBe(false);
+    });
+
+    it("supports IPv6 addresses and CIDR ranges", () => {
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["2001:db8::/32"],
+      });
+      // Both in-range calls bypass the cap.
+      expect(allow.tryAdd("2001:db8::1", "a")).toBe(true);
+      expect(allow.tryAdd("2001:db8::1", "b")).toBe(true);
+      // A non-matching IPv6 outside the range is subject to the cap (=1) and
+      // should succeed once, then be rejected on the second add.
+      expect(allow.tryAdd("2001:db9::1", "c")).toBe(true);
+      expect(allow.tryAdd("2001:db9::1", "d")).toBe(false);
+    });
+
+    it("matches an IPv4-mapped IPv6 allowlist entry against an IPv4 request", () => {
+      // Operator writes the mapped form in YAML; request arrives as plain IPv4.
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["::ffff:127.0.0.1"],
+      });
+      expect(allow.isAllowlisted("127.0.0.1")).toBe(true);
+      // And the cap is bypassed for that IPv4 traffic.
+      expect(allow.tryAdd("127.0.0.1", "a")).toBe(true);
+      expect(allow.tryAdd("127.0.0.1", "b")).toBe(true);
+    });
+
+    it("logs an info message on bypass (rate-limited per IP)", () => {
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["160.79.106.35"],
+      });
+      allow.tryAdd("160.79.106.35", "a");
+      allow.tryAdd("160.79.106.35", "b");
+      allow.tryAdd("160.79.106.35", "c");
+      // The log is throttled per IP — expect at least one but not one-per-call.
+      expect(infoSpy).toHaveBeenCalled();
+      const callsForThisIp = infoSpy.mock.calls.filter((c: unknown[]) =>
+        String(c[0]).includes("160.79.106.35"),
+      );
+      expect(callsForThisIp.length).toBeGreaterThanOrEqual(1);
+      expect(callsForThisIp.length).toBeLessThan(3);
+    });
+
+    it("isAllowlisted returns true/false for matching / non-matching IPs", () => {
+      const allow = new IpSessionLimiter(5, {
+        allowlist: ["10.0.0.0/8", "192.168.1.5"],
+      });
+      expect(allow.isAllowlisted("10.1.2.3")).toBe(true);
+      expect(allow.isAllowlisted("192.168.1.5")).toBe(true);
+      expect(allow.isAllowlisted("192.168.1.6")).toBe(false);
+      expect(allow.isAllowlisted("8.8.8.8")).toBe(false);
+    });
+
+    it("ignores unknown / 'unknown' IPs (never allowlisted)", () => {
+      const allow = new IpSessionLimiter(5, {
+        allowlist: ["10.0.0.0/8"],
+      });
+      expect(allow.isAllowlisted("unknown")).toBe(false);
+      expect(allow.isAllowlisted("")).toBe(false);
+      expect(allow.isAllowlisted("not-an-ip")).toBe(false);
+    });
+
+    it("emits a single loud error when ALL allowlist entries are invalid", () => {
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      try {
+        // Two entries, both invalid — per-entry warnings plus one summary error.
+        const allow = new IpSessionLimiter(2, {
+          allowlist: ["not-an-ip", "also-bogus/33"],
+        });
+        // Nothing should be allowlisted.
+        expect(allow.isAllowlisted("10.0.0.1")).toBe(false);
+        const summaryCalls = errorSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("allowlist is now EMPTY"),
+        );
+        expect(summaryCalls.length).toBe(1);
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does NOT emit the 'all invalid' error when at least one entry parses", () => {
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      try {
+        new IpSessionLimiter(2, {
+          allowlist: ["not-an-ip", "10.0.0.0/8"],
+        });
+        const summaryCalls = errorSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("allowlist is now EMPTY"),
+        );
+        expect(summaryCalls.length).toBe(0);
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("does NOT emit the 'all invalid' error for an empty allowlist", () => {
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      try {
+        new IpSessionLimiter(2, { allowlist: [] });
+        const summaryCalls = errorSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("allowlist is now EMPTY"),
+        );
+        expect(summaryCalls.length).toBe(0);
+      } finally {
+        errorSpy.mockRestore();
+      }
+    });
+
+    it("lastAllowlistLog map does not grow unbounded under many distinct IPs", () => {
+      // Use a /8 so 10,000 distinct source IPs all hit the bypass path.
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["10.0.0.0/8"],
+      });
+      for (let i = 0; i < 10_000; i++) {
+        const a = (i >> 16) & 0xff;
+        const b = (i >> 8) & 0xff;
+        const c = i & 0xff;
+        allow.tryAdd(`10.${a}.${b}.${c}`, `sess-${i}`);
+      }
+      // Internal map must not grow past a sane cap (1000).
+      const internal = (
+        allow as unknown as { lastAllowlistLog: Map<string, number> }
+      ).lastAllowlistLog;
+      expect(internal.size).toBeLessThanOrEqual(1000);
+    });
+
+    it("remove() on an allowlisted session is a safe no-op", () => {
+      const allow = new IpSessionLimiter(2, {
+        allowlist: ["160.79.106.35"],
+      });
+      allow.tryAdd("160.79.106.35", "sess-a");
+      // Allowlisted sessions are not tracked; remove() must not throw or
+      // affect any counters.
+      expect(() => allow.remove("sess-a")).not.toThrow();
+      expect(allow.getSessionCount("160.79.106.35")).toBe(0);
+    });
+
+    it("getSessionCount reflects pre-allowlist tracking for an IP later covered by the allowlist", () => {
+      // IP is tracked BEFORE the allowlist covers it (e.g. allowlist loaded
+      // after sessions already opened). Retroactively applying the allowlist
+      // must not silently zero out the tracked count.
+      const allow = new IpSessionLimiter(5, { allowlist: [] });
+      expect(allow.tryAdd("10.1.2.3", "s1")).toBe(true);
+      expect(allow.tryAdd("10.1.2.3", "s2")).toBe(true);
+      expect(allow.getSessionCount("10.1.2.3")).toBe(2);
+
+      // Now a fresh limiter with the SAME IP already "tracked" simulated by
+      // re-adding under an allowlist — but for the existing limiter, the
+      // tracked state must remain visible; the allowlist does not retroactively
+      // remove sessions that were counted.
+      // We can't hot-swap the allowlist, so verify the contract directly:
+      // getSessionCount returns the tracked count regardless of allowlist
+      // status at call time.
+      const allow2 = new IpSessionLimiter(5, { allowlist: ["10.0.0.0/8"] });
+      // Manually simulate pre-existing tracked state by flipping internals:
+      // this models "IP was tracked, then allowlist was applied".
+      const internalIpToSessions = (
+        allow2 as unknown as { ipToSessions: Map<string, Set<string>> }
+      ).ipToSessions;
+      internalIpToSessions.set("10.1.2.3", new Set(["s1", "s2"]));
+      expect(allow2.getSessionCount("10.1.2.3")).toBe(2);
+    });
+
+    it("tryAdd with a re-used sid from a DIFFERENT IP does not cause counter drift", () => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      try {
+        const drift = new IpSessionLimiter(5);
+        expect(drift.tryAdd("1.2.3.4", "sid-x")).toBe(true);
+        expect(drift.getSessionCount("1.2.3.4")).toBe(1);
+
+        // Same sid, different IP. Conservative behavior: reject and warn.
+        expect(drift.tryAdd("5.6.7.8", "sid-x")).toBe(false);
+        // Neither IP's counter should drift.
+        expect(drift.getSessionCount("1.2.3.4")).toBe(1);
+        expect(drift.getSessionCount("5.6.7.8")).toBe(0);
+
+        // remove() targets the original IP cleanly.
+        drift.remove("sid-x");
+        expect(drift.getSessionCount("1.2.3.4")).toBe(0);
+        expect(drift.getSessionCount("5.6.7.8")).toBe(0);
+
+        // A warning was logged.
+        const warnings = warnSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("re-added from different IP"),
+        );
+        expect(warnings.length).toBe(1);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("tryAdd with a re-used sid from the SAME IP is idempotent (returns true)", () => {
+      const same = new IpSessionLimiter(5);
+      expect(same.tryAdd("1.2.3.4", "sid-y")).toBe(true);
+      expect(same.tryAdd("1.2.3.4", "sid-y")).toBe(true);
+      expect(same.getSessionCount("1.2.3.4")).toBe(1);
+    });
+
+    it("ESCALATES to console.error when ALL allowlist entries are invalid", () => {
+      const errorSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      try {
+        new IpSessionLimiter(2, {
+          allowlist: ["not-an-ip", "also-bogus/33", "still-wrong"],
+        });
+        // Must log a loud error (not just a warn) explaining the impact.
+        const errorCalls = errorSpy.mock.calls.filter((c: unknown[]) => {
+          const msg = String(c[0]);
+          return (
+            msg.includes("allowlist is now EMPTY") &&
+            msg.includes("rate limiting will apply")
+          );
+        });
+        expect(errorCalls.length).toBe(1);
+        // Failed-count surfaces in the error message.
+        expect(String(errorCalls[0][0])).toContain("3");
+      } finally {
+        errorSpy.mockRestore();
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("IPv4-mapped IPv6 normalization at map-key boundaries", () => {
+    it("buckets ::ffff:10.0.0.1 and 10.0.0.1 into the SAME per-IP counter", () => {
+      // Without normalization the two forms would double-bucket and effectively
+      // double the per-IP cap for dual-stack clients.
+      const l = new IpSessionLimiter(3);
+      expect(l.tryAdd("::ffff:10.0.0.1", "a")).toBe(true);
+      expect(l.tryAdd("10.0.0.1", "b")).toBe(true);
+      expect(l.tryAdd("::ffff:10.0.0.1", "c")).toBe(true);
+      // Cap is 3 — the fourth (any form) must be rejected.
+      expect(l.tryAdd("10.0.0.1", "d")).toBe(false);
+      expect(l.tryAdd("::ffff:10.0.0.1", "e")).toBe(false);
+      // getSessionCount is consistent across forms.
+      expect(l.getSessionCount("10.0.0.1")).toBe(3);
+      expect(l.getSessionCount("::ffff:10.0.0.1")).toBe(3);
+    });
+
+    it("remove() works regardless of which form called tryAdd()", () => {
+      const l = new IpSessionLimiter(2);
+      expect(l.tryAdd("::ffff:10.0.0.1", "sid-x")).toBe(true);
+      // remove() via the plain-IPv4 form still frees the slot.
+      l.remove("sid-x");
+      expect(l.getSessionCount("10.0.0.1")).toBe(0);
+      expect(l.getSessionCount("::ffff:10.0.0.1")).toBe(0);
+      expect(l.tryAdd("10.0.0.1", "sid-y")).toBe(true);
+    });
+
+    it("non-parseable IPs ('unknown', empty) are bucketed by the raw string", () => {
+      // Fall-through behavior: strings that don't parse as IP are used as-is
+      // for keying, preserving existing test expectations for "unknown".
+      const l = new IpSessionLimiter(1);
+      expect(l.tryAdd("unknown", "a")).toBe(true);
+      expect(l.tryAdd("unknown", "b")).toBe(false);
+      expect(l.getSessionCount("unknown")).toBe(1);
+    });
+  });
+
+  describe("maybeLogBypass cost / LRU semantics", () => {
+    it("does NOT run the O(n) sweep on the throttled path (cooldown early-return)", () => {
+      // Fill the log map to capacity with one IP's recent log, then hammer
+      // the same IP. The sweep branch, if run, mutates the internal Map —
+      // assert the Map's contents are untouched across repeated bypass hits
+      // within the cooldown window.
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["10.0.0.0/8"],
+      });
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+      try {
+        const internal = (
+          allow as unknown as { lastAllowlistLog: Map<string, number> }
+        ).lastAllowlistLog;
+        // Prime the map to ~capacity with stale entries that WOULD be swept
+        // if the sweep ran. Use a timestamp far in the past so the sweep
+        // cutoff would delete them.
+        const staleTs = Date.now() - 10 * 60 * 60 * 1000; // 10h ago
+        for (let i = 0; i < 1000; i++) {
+          internal.set(`stale-${i}`, staleTs);
+        }
+        // Now record a recent bypass for a hot IP so subsequent calls are
+        // within the cooldown.
+        allow.tryAdd("10.1.2.3", "first");
+        const sizeAfterFirst = internal.size;
+        // Hammer the same IP within cooldown — this must early-return and
+        // NOT run the sweep (which would delete the stale-* entries).
+        for (let i = 0; i < 50; i++) {
+          allow.tryAdd("10.1.2.3", `hot-${i}`);
+        }
+        // If the sweep ran on the throttled path, size would have dropped
+        // by up to 1000. It must not have.
+        expect(internal.size).toBe(sizeAfterFirst);
+      } finally {
+        infoSpy.mockRestore();
+      }
+    });
+
+    it("evicts entries in true LRU order, not insertion order", () => {
+      // A hot IP that keeps getting re-touched must stay in the LRU map
+      // while cold one-shot IPs get evicted as the cap is exceeded. Without
+      // true-LRU semantics (delete-then-set on each touch), the hot IP sits
+      // at the head of insertion order and is the FIRST thing evicted once
+      // cold traffic fills the map.
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["10.0.0.0/8"],
+      });
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+      try {
+        vi.useFakeTimers();
+        const start = Date.now();
+        vi.setSystemTime(start);
+
+        // Hot IP logs first (inserted at position 0 of the LRU map).
+        allow.tryAdd("10.9.9.9", "hot-initial");
+
+        // Churn cold IPs while periodically re-touching the hot IP outside
+        // the cooldown window. Without delete-then-set, "10.9.9.9" sits at
+        // the insertion-order head and gets evicted as soon as cold IPs
+        // push the map to capacity.
+        const cooldownMs = 5 * 60 * 1000;
+        const touchEveryNthCold = 500;
+        for (let i = 0; i < 5000; i++) {
+          // Advance time by more than the cooldown per cold IP so each one
+          // actually logs and inserts into the LRU map.
+          vi.setSystemTime(start + (i + 1) * (cooldownMs + 1));
+          allow.tryAdd(
+            `10.1.${(i >> 8) & 0xff}.${i & 0xff}`,
+            `cold-${i}`,
+          );
+
+          // Every N iterations, re-touch the hot IP so true-LRU moves it
+          // back to the tail.
+          if ((i + 1) % touchEveryNthCold === 0) {
+            vi.setSystemTime(start + (i + 1) * (cooldownMs + 1) + 1);
+            allow.tryAdd("10.9.9.9", `hot-touch-${i}`);
+          }
+        }
+
+        const internal = (
+          allow as unknown as { lastAllowlistLog: Map<string, number> }
+        ).lastAllowlistLog;
+        expect(internal.has("10.9.9.9")).toBe(true);
+      } finally {
+        vi.useRealTimers();
+        infoSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("CIDR with non-zero host bits", () => {
+    it("warns and normalizes 10.0.0.1/24 to the network address 10.0.0.0/24", () => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      try {
+        const allow = new IpSessionLimiter(2, {
+          // Operator typo / confusion: "10.0.0.1/24" means the whole /24,
+          // not just 10.0.0.1. Must emit a warning so misconfig is visible.
+          allowlist: ["10.0.0.1/24"],
+        });
+        // Network-wide coverage applies (operator's likely intent).
+        expect(allow.isAllowlisted("10.0.0.50")).toBe(true);
+        expect(allow.isAllowlisted("10.0.0.250")).toBe(true);
+        // A warning with identifying detail was emitted.
+        const warns = warnSpy.mock.calls.filter((c: unknown[]) => {
+          const msg = String(c[0]);
+          return (
+            msg.includes("10.0.0.1/24") &&
+            msg.includes("host bits")
+          );
+        });
+        expect(warns.length).toBe(1);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("accepts properly-formed CIDR without warning", () => {
+      const warnSpy = vi
+        .spyOn(console, "warn")
+        .mockImplementation(() => {});
+      try {
+        new IpSessionLimiter(2, { allowlist: ["10.0.0.0/24"] });
+        const hostBitWarns = warnSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("host bits"),
+        );
+        expect(hostBitWarns.length).toBe(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("IPv4 loopback does NOT implicitly cover IPv6 ::1", () => {
+    // Documented non-auto-expand behavior. An operator who writes 127.0.0.0/8
+    // intending "all loopback" must ALSO add ::1/128 for native IPv6 loopback.
+    // We deliberately don't auto-expand because magic could mask operator
+    // intent in other configurations.
+    it("127.0.0.0/8 does not match ::1", () => {
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["127.0.0.0/8"],
+      });
+      expect(allow.isAllowlisted("127.0.0.1")).toBe(true);
+      // ::1 is a distinct address family, not covered by the IPv4 range.
+      expect(allow.isAllowlisted("::1")).toBe(false);
+    });
+
+    it("operator can opt-in to IPv6 loopback by adding ::1/128 explicitly", () => {
+      const allow = new IpSessionLimiter(1, {
+        allowlist: ["127.0.0.0/8", "::1/128"],
+      });
+      expect(allow.isAllowlisted("127.0.0.1")).toBe(true);
+      expect(allow.isAllowlisted("::1")).toBe(true);
+    });
+  });
+
+  describe("IPv4-mapped IPv6 CIDR with prefix > 32 after normalization", () => {
+    // Regression guard for the CIDR-normalization path: ipaddr.parseCIDR on
+    // "::ffff:10.0.0.0/104" returns [IPv6, 104]. normalizeMapped collapses
+    // the address to IPv4 10.0.0.0, but if we then call
+    // IPv4.networkAddressFromCIDR("10.0.0.0/104") it throws (IPv4 max
+    // prefix is /32). Fix: subtract 96 from the prefix when collapsing the
+    // mapped form, so /104 → /8 (the IPv4 portion of the original prefix).
+    it("accepts ::ffff:10.0.0.0/104 and treats it as IPv4 10.0.0.0/8", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const allow = new IpSessionLimiter(1, {
+          allowlist: ["::ffff:10.0.0.0/104"],
+        });
+        // Plain IPv4 request matches the collapsed /8.
+        expect(allow.isAllowlisted("10.0.0.1")).toBe(true);
+        expect(allow.isAllowlisted("10.255.255.255")).toBe(true);
+        // IPv4-mapped IPv6 form of the same request matches too.
+        expect(allow.isAllowlisted("::ffff:10.0.0.1")).toBe(true);
+        // Outside /8 does not match.
+        expect(allow.isAllowlisted("11.0.0.1")).toBe(false);
+        // No "invalid allowlist entry" warning should have fired.
+        const invalidWarns = warnSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("ignoring invalid allowlist entry"),
+        );
+        expect(invalidWarns.length).toBe(0);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("rejects ::ffff:a.b.c.d/<=96 (does not map cleanly to IPv4 space)", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const allow = new IpSessionLimiter(1, {
+          // Prefix /64 covers a huge block of IPv6 that extends beyond the
+          // mapped IPv4 region. Refuse rather than silently approximate.
+          allowlist: ["::ffff:10.0.0.0/64"],
+        });
+        // The entry was rejected — no IP should match it.
+        expect(allow.isAllowlisted("10.0.0.1")).toBe(false);
+        expect(allow.isAllowlisted("::ffff:10.0.0.1")).toBe(false);
+        // A warning explaining the rejection must have fired.
+        const rejectWarns = warnSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("::ffff:10.0.0.0/64"),
+        );
+        expect(rejectWarns.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("maybeLogBypass normalizes IP before cooldown lookup", () => {
+    // A dual-stack client alternating between "127.0.0.1" and
+    // "::ffff:127.0.0.1" must share ONE cooldown slot, not two — otherwise
+    // the log throttle is halved and the LRU map wastes slots on what is
+    // really the same physical client.
+    it("shares a cooldown slot across plain and IPv4-mapped forms", () => {
+      const infoSpy = vi.spyOn(console, "info").mockImplementation(() => {});
+      try {
+        const allow = new IpSessionLimiter(1, {
+          allowlist: ["127.0.0.0/8"],
+        });
+        allow.tryAdd("::ffff:127.0.0.1", "sess-a");
+        allow.tryAdd("127.0.0.1", "sess-b");
+        // Only one info log for these two calls — second must be throttled.
+        const loopbackCalls = infoSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("127.0.0.1"),
+        );
+        expect(loopbackCalls.length).toBe(1);
+        // The cooldown map itself should only have one entry for this client.
+        const internal = (
+          allow as unknown as { lastAllowlistLog: Map<string, number> }
+        ).lastAllowlistLog;
+        expect(internal.size).toBe(1);
+      } finally {
+        infoSpy.mockRestore();
+      }
+    });
+  });
+
+  describe("tryAddWithReason: discriminated union result", () => {
+    it("returns { ok: true } on success", () => {
+      const l = new IpSessionLimiter(2);
+      const r: TryAddResult = l.tryAddWithReason("1.2.3.4", "sid-1");
+      expect(r.ok).toBe(true);
+    });
+
+    it("returns { ok: false, reason: 'rate-limit' } when cap hit", () => {
+      const l = new IpSessionLimiter(1);
+      l.tryAddWithReason("1.2.3.4", "sid-1");
+      const r = l.tryAddWithReason("1.2.3.4", "sid-2");
+      expect(r.ok).toBe(false);
+      if (!r.ok) expect(r.reason).toBe("rate-limit");
+    });
+
+    it("returns { ok: false, reason: 'sid-collision' } when sid re-used from a different IP", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const l = new IpSessionLimiter(5);
+        l.tryAddWithReason("1.2.3.4", "sid-shared");
+        const r = l.tryAddWithReason("5.6.7.8", "sid-shared");
+        expect(r.ok).toBe(false);
+        if (!r.ok) expect(r.reason).toBe("sid-collision");
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
+
+    it("returns { ok: true } when the same sid is re-added from the SAME IP (idempotent)", () => {
+      const l = new IpSessionLimiter(5);
+      l.tryAddWithReason("1.2.3.4", "sid-same");
+      const r = l.tryAddWithReason("1.2.3.4", "sid-same");
+      expect(r.ok).toBe(true);
+    });
+
+    it("returns { ok: true } for allowlisted traffic regardless of cap", () => {
+      const l = new IpSessionLimiter(1, { allowlist: ["10.0.0.0/8"] });
+      expect(l.tryAddWithReason("10.1.2.3", "a").ok).toBe(true);
+      expect(l.tryAddWithReason("10.1.2.3", "b").ok).toBe(true);
+      expect(l.tryAddWithReason("10.1.2.3", "c").ok).toBe(true);
+    });
+
+    it("tryAdd (boolean) delegates to tryAddWithReason and preserves existing contract", () => {
+      const l = new IpSessionLimiter(1);
+      expect(l.tryAdd("1.2.3.4", "sid-1")).toBe(true);
+      expect(l.tryAdd("1.2.3.4", "sid-2")).toBe(false);
+    });
+  });
+
+  describe("sid-collision warn log does not leak full session id", () => {
+    // Session ids are bearer-equivalent; logs shipped to stdout/aggregators
+    // should mask them. /messages handler already masks to sid.slice(0, 8);
+    // mirror that discipline here.
+    it("masks the sessionId in the re-added-from-different-IP warning", () => {
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      try {
+        const fullSid = "session-abcdef0123456789-secret-token";
+        const l = new IpSessionLimiter(5);
+        l.tryAdd("1.2.3.4", fullSid);
+        l.tryAdd("5.6.7.8", fullSid);
+        const collisionWarns = warnSpy.mock.calls.filter((c: unknown[]) =>
+          String(c[0]).includes("re-added from different IP"),
+        );
+        expect(collisionWarns.length).toBe(1);
+        const msg = String(collisionWarns[0][0]);
+        // Must NOT contain the full sid.
+        expect(msg).not.toContain(fullSid);
+        // Must contain only the 8-char masked prefix.
+        expect(msg).toContain(fullSid.slice(0, 8));
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
   });
 
   // Regression guard for the server.ts onclose path: when a session is

--- a/src/__tests__/ip-util.test.ts
+++ b/src/__tests__/ip-util.test.ts
@@ -17,7 +17,9 @@ function makeReq(opts: {
   if (opts.xff !== undefined) headers["x-forwarded-for"] = opts.xff;
   return {
     ip: opts.ip,
-    socket: { remoteAddress: opts.remoteAddress } as unknown as Request["socket"],
+    socket: {
+      remoteAddress: opts.remoteAddress,
+    } as unknown as Request["socket"],
     headers,
   } as unknown as Request;
 }

--- a/src/__tests__/ip-util.test.ts
+++ b/src/__tests__/ip-util.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from "vitest";
+import type { Request } from "express";
+import { clientIp } from "../ip-util.js";
+
+/**
+ * Minimal Request-shaped object. We construct the exact surface area clientIp
+ * reads (ip, socket.remoteAddress, headers) so we don't have to stand up a
+ * full Express stack — these tests verify the contract, not the Express
+ * proxy-trust machinery itself.
+ */
+function makeReq(opts: {
+  ip?: string;
+  remoteAddress?: string;
+  xff?: string;
+}): Request {
+  const headers: Record<string, string> = {};
+  if (opts.xff !== undefined) headers["x-forwarded-for"] = opts.xff;
+  return {
+    ip: opts.ip,
+    socket: { remoteAddress: opts.remoteAddress } as unknown as Request["socket"],
+    headers,
+  } as unknown as Request;
+}
+
+describe("clientIp", () => {
+  describe("trustProxy=false (default, hardened)", () => {
+    it("returns socket.remoteAddress and IGNORES X-Forwarded-For (spoof defense)", () => {
+      // This is the security-critical case: an attacker sends
+      // `X-Forwarded-For: 160.79.106.35` trying to impersonate the
+      // allowlisted Anthropic crawler. The helper MUST return the socket
+      // address, not the header.
+      const req = makeReq({
+        xff: "160.79.106.35",
+        remoteAddress: "203.0.113.99",
+        // Express would populate `ip` from the XFF chain if it were
+        // configured to trust a proxy — but trustProxy=false, so we
+        // refuse to consult `req.ip` at all.
+        ip: "160.79.106.35",
+      });
+      expect(clientIp(req, false)).toBe("203.0.113.99");
+    });
+
+    it("returns socket.remoteAddress when no X-Forwarded-For is present", () => {
+      const req = makeReq({ remoteAddress: "198.51.100.7" });
+      expect(clientIp(req, false)).toBe("198.51.100.7");
+    });
+
+    it("returns 'unknown' when socket.remoteAddress is missing", () => {
+      const req = makeReq({ xff: "1.2.3.4" });
+      expect(clientIp(req, false)).toBe("unknown");
+    });
+
+    it("treats empty-string socket.remoteAddress as 'unknown' (post-disconnect / HTTP/2 edge)", () => {
+      // `??` does not coalesce "" — if socket.remoteAddress is the empty
+      // string (observed after abrupt disconnects, in some HTTP/2 upgrade
+      // paths, and in test mocks), the rate limiter would bucket every
+      // such caller into a single "" counter, letting one client DoS every
+      // other client in that state. Force the empty string to fall
+      // through to "unknown" instead.
+      const req = makeReq({ remoteAddress: "", xff: "1.2.3.4" });
+      expect(clientIp(req, false)).toBe("unknown");
+    });
+
+    it("returns 'unknown' when socket.remoteAddress is the empty string and no XFF is present", () => {
+      const req = makeReq({ remoteAddress: "" });
+      expect(clientIp(req, false)).toBe("unknown");
+    });
+  });
+
+  describe("trustProxy=true (behind a trusted reverse proxy)", () => {
+    it("returns req.ip (Express populates this from the configured trust chain)", () => {
+      // When Express is configured with `app.set('trust proxy', true)` the
+      // framework itself walks the XFF chain and assigns the result to
+      // `req.ip`. We rely on that — we do NOT re-parse XFF ourselves.
+      const req = makeReq({
+        ip: "160.79.106.35",
+        xff: "160.79.106.35",
+        remoteAddress: "10.0.0.1",
+      });
+      expect(clientIp(req, true)).toBe("160.79.106.35");
+    });
+
+    it("falls back to socket.remoteAddress when req.ip is unset", () => {
+      // Defensive: if req.ip is somehow undefined even with trustProxy=true
+      // (e.g. test harness shortcut), don't crash — return the socket.
+      const req = makeReq({ remoteAddress: "10.0.0.2" });
+      expect(clientIp(req, true)).toBe("10.0.0.2");
+    });
+
+    it("returns 'unknown' when both req.ip and socket.remoteAddress are missing", () => {
+      const req = makeReq({});
+      expect(clientIp(req, true)).toBe("unknown");
+    });
+
+    it("falls through to socket.remoteAddress when req.ip is the empty string", () => {
+      // If Express somehow left req.ip as "" (rather than undefined), `??`
+      // would preserve it and the limiter would then key every such
+      // request into a single "" counter. Treat "" the same as undefined
+      // and keep walking the fallback chain.
+      const req = makeReq({ ip: "", remoteAddress: "5.6.7.8" });
+      expect(clientIp(req, true)).toBe("5.6.7.8");
+    });
+
+    it("returns 'unknown' when req.ip and socket.remoteAddress are both the empty string", () => {
+      const req = makeReq({ ip: "", remoteAddress: "" });
+      expect(clientIp(req, true)).toBe("unknown");
+    });
+  });
+});

--- a/src/__tests__/rate-limit-response.test.ts
+++ b/src/__tests__/rate-limit-response.test.ts
@@ -1,0 +1,230 @@
+import { describe, it, expect } from "vitest";
+import {
+  JSONRPC_RATE_LIMIT_CODE,
+  buildRateLimitPayload,
+  clampRetryAfterSeconds,
+  jsonRpcRateLimitError,
+} from "../rate-limit-response.js";
+
+describe("buildRateLimitPayload", () => {
+  it("returns a fully-populated rejection payload", () => {
+    const payload = buildRateLimitPayload({
+      limit: 20,
+      currentCount: 20,
+      retryAfterSeconds: 60,
+    });
+
+    expect(payload.error).toBe("rate_limited");
+    expect(typeof payload.reason).toBe("string");
+    expect(payload.reason.length).toBeGreaterThan(0);
+    expect(payload.limit).toBe(20);
+    expect(payload.currentCount).toBe(20);
+    expect(payload.retryAfterSeconds).toBe(60);
+    expect(payload.contact).toBe("oss@copilotkit.ai");
+  });
+
+  it("reason mentions the per-IP limit", () => {
+    const { reason } = buildRateLimitPayload({
+      limit: 5,
+      currentCount: 5,
+      retryAfterSeconds: 30,
+    });
+    expect(reason).toMatch(/IP/);
+    expect(reason).toContain("5");
+  });
+
+  describe("retryAfterSeconds clamp", () => {
+    it("clamps a too-large value (1800) down to the 300s upper bound", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 1800,
+      });
+      expect(payload.retryAfterSeconds).toBe(300);
+    });
+
+    it("defaults NaN to 60", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: Number.NaN,
+      });
+      expect(payload.retryAfterSeconds).toBe(60);
+    });
+
+    it("defaults negative values to 60", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: -5,
+      });
+      expect(payload.retryAfterSeconds).toBe(60);
+    });
+
+    it("defaults zero to 60", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 0,
+      });
+      expect(payload.retryAfterSeconds).toBe(60);
+    });
+
+    it("defaults Infinity to 60", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: Number.POSITIVE_INFINITY,
+      });
+      expect(payload.retryAfterSeconds).toBe(60);
+    });
+
+    it("passes 1 through unchanged (lower bound is inclusive)", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 1,
+      });
+      expect(payload.retryAfterSeconds).toBe(1);
+    });
+
+    it("passes 120 through unchanged (within bounds)", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 120,
+      });
+      expect(payload.retryAfterSeconds).toBe(120);
+    });
+
+    it("floors fractional values to whole seconds", () => {
+      // 42.4 is compatible with either floor OR round-to-nearest, so
+      // include 42.6 to disambiguate: Math.floor(42.6) === 42, whereas
+      // Math.round(42.6) === 43. The floor semantics is authoritative.
+      const low = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 42.4,
+      });
+      expect(low.retryAfterSeconds).toBe(42);
+
+      const high = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 42.6,
+      });
+      expect(high.retryAfterSeconds).toBe(42);
+    });
+
+    it("clamps positive sub-second values up to the 1s minimum", () => {
+      // 0.5 is > 0 so it does NOT take the default branch. Math.floor(0.5)
+      // is 0, which is below RETRY_AFTER_MIN_SECONDS (1), so it clamps UP
+      // to 1. This anchors the documented behavior.
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 0.5,
+      });
+      expect(payload.retryAfterSeconds).toBe(1);
+    });
+  });
+
+  describe("clampRetryAfterSeconds contract for header callers", () => {
+    // CONTRACT: HTTP callers (src/server.ts, src/sse-handlers.ts) MUST use
+    // the `retryAfterSeconds` field returned by buildRateLimitPayload (or
+    // call clampRetryAfterSeconds directly) when setting the HTTP
+    // `Retry-After` header. They MUST NOT pass the raw, unclamped input to
+    // the header, otherwise the header value (e.g. 1800) will disagree
+    // with the JSON body value (e.g. 300), violating the module's
+    // single-sanitized-integer guarantee.
+    it("exposes clampRetryAfterSeconds for direct use by header callers", () => {
+      expect(typeof clampRetryAfterSeconds).toBe("function");
+      expect(clampRetryAfterSeconds(1800)).toBe(300);
+      expect(clampRetryAfterSeconds(120)).toBe(120);
+      expect(clampRetryAfterSeconds(Number.NaN)).toBe(60);
+    });
+
+    it("buildRateLimitPayload with retryAfterSeconds=1800 returns 300 (MAX), which is what callers must use for the Retry-After header", () => {
+      const payload = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 1800,
+      });
+      // The JSON body carries 300.
+      expect(payload.retryAfterSeconds).toBe(300);
+      // clampRetryAfterSeconds applied directly to the same raw input
+      // produces the same 300. Callers MUST use this value (not the raw
+      // 1800) when setting the HTTP Retry-After header, to keep header
+      // and body in lockstep.
+      expect(clampRetryAfterSeconds(1800)).toBe(payload.retryAfterSeconds);
+    });
+  });
+
+  describe("reason clarity", () => {
+    it("embeds the clamped retry window into the reason string", () => {
+      const { reason, retryAfterSeconds } = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: 1800,
+      });
+      expect(retryAfterSeconds).toBe(300);
+      expect(reason).toContain("300");
+      expect(reason).toMatch(/retry/i);
+    });
+
+    it("reflects the clamped value in the reason even when defaulted from bad input", () => {
+      const { reason, retryAfterSeconds } = buildRateLimitPayload({
+        limit: 20,
+        currentCount: 20,
+        retryAfterSeconds: Number.NaN,
+      });
+      expect(retryAfterSeconds).toBe(60);
+      expect(reason).toContain("60");
+    });
+  });
+});
+
+describe("jsonRpcRateLimitError", () => {
+  it("produces a JSON-RPC 2.0 error frame with the rate-limit code", () => {
+    const frame = jsonRpcRateLimitError("req-1", {
+      limit: 20,
+      currentCount: 20,
+      retryAfterSeconds: 60,
+    });
+    expect(frame.jsonrpc).toBe("2.0");
+    expect(frame.id).toBe("req-1");
+    expect(frame.error.code).toBe(JSONRPC_RATE_LIMIT_CODE);
+    expect(frame.error.message).toMatch(/rate/i);
+    expect(frame.error.data).toMatchObject({
+      error: "rate_limited",
+      limit: 20,
+      currentCount: 20,
+      retryAfterSeconds: 60,
+      contact: "oss@copilotkit.ai",
+    });
+  });
+
+  it("accepts null id for initialize requests without an id echo", () => {
+    const frame = jsonRpcRateLimitError(null, {
+      limit: 1,
+      currentCount: 1,
+      retryAfterSeconds: 60,
+    });
+    expect(frame.id).toBeNull();
+  });
+
+  it("uses -32000 server-error range for the rate-limit code", () => {
+    expect(JSONRPC_RATE_LIMIT_CODE).toBeGreaterThanOrEqual(-32099);
+    expect(JSONRPC_RATE_LIMIT_CODE).toBeLessThanOrEqual(-32000);
+  });
+
+  it("reflects the clamped retryAfterSeconds in the error data payload", () => {
+    const frame = jsonRpcRateLimitError("req-2", {
+      limit: 20,
+      currentCount: 20,
+      retryAfterSeconds: 1800,
+    });
+    expect(frame.error.data.retryAfterSeconds).toBe(300);
+    expect(frame.error.data.reason).toContain("300");
+  });
+});

--- a/src/__tests__/server-round2.test.ts
+++ b/src/__tests__/server-round2.test.ts
@@ -336,8 +336,7 @@ describe("handleSessionInitRaceFallback", () => {
 
     const warnCalls = warnSpy.mock.calls.map((c) => String(c[0] ?? ""));
     const logged = warnCalls.find(
-      (m) =>
-        m.includes("race fallback") && m.includes(sid.slice(0, 8)),
+      (m) => m.includes("race fallback") && m.includes(sid.slice(0, 8)),
     );
     expect(logged).toBeDefined();
     // Must carry the CLAMPED value (300), not the pre-clamp 1800. Include
@@ -509,18 +508,14 @@ describe("reapIdleSessionsTick (R3 #1: SSE reaper dep plumbing)", () => {
   it("passes ipLimiter.remove, workspaceManager.cleanup, and sessionStateManager.cleanup into the SSE reaper for each reaped sid", async () => {
     const { reapIdleSessionsTickForTesting } = await import("../server.js");
 
-    const sseTransports: Record<
-      string,
-      { close: () => Promise<void> | void }
-    > = {
-      "sse-stale": {
-        close: async () => {},
-      },
-    };
-    const transports: Record<
-      string,
-      { close: () => Promise<void> | void }
-    > = {};
+    const sseTransports: Record<string, { close: () => Promise<void> | void }> =
+      {
+        "sse-stale": {
+          close: async () => {},
+        },
+      };
+    const transports: Record<string, { close: () => Promise<void> | void }> =
+      {};
     const sessionLastActivity: Record<string, number> = {
       "sse-stale": Date.now() - 10 * 60 * 1000,
     };
@@ -711,8 +706,7 @@ describe("handleSessionInitAccept (R3 #2 rollback signaling + H2 sessionStateMan
         c.some(
           (arg) =>
             (typeof arg === "string" && arg.includes("sstate-cleanup-boom")) ||
-            (arg instanceof Error &&
-              arg.message === "sstate-cleanup-boom"),
+            (arg instanceof Error && arg.message === "sstate-cleanup-boom"),
         ),
       );
       expect(sawSstateBoom).toBe(true);
@@ -844,7 +838,9 @@ describe("rejected-sid suppression (R3 #3 / H1)", () => {
   it("markSessionRejected(sid) + onclose path skips cleanup chain", async () => {
     const serverMod = await import("../server.js");
     const markSessionRejected = (
-      serverMod as unknown as { markSessionRejectedForTesting?: (sid: string) => void }
+      serverMod as unknown as {
+        markSessionRejectedForTesting?: (sid: string) => void;
+      }
     ).markSessionRejectedForTesting;
     const wasRejected = (
       serverMod as unknown as {
@@ -1279,21 +1275,19 @@ describe("closeAllSessions (shutdown helper)", () => {
       .mockImplementation(() => {});
     try {
       const closedOk: string[] = [];
-      const transports: Record<
-        string,
-        { close: () => Promise<void> | void }
-      > = {
-        "bad-1": {
-          close: async () => {
-            throw new Error("streamable-shutdown-boom");
+      const transports: Record<string, { close: () => Promise<void> | void }> =
+        {
+          "bad-1": {
+            close: async () => {
+              throw new Error("streamable-shutdown-boom");
+            },
           },
-        },
-        "good-1": {
-          close: async () => {
-            closedOk.push("good-1");
+          "good-1": {
+            close: async () => {
+              closedOk.push("good-1");
+            },
           },
-        },
-      };
+        };
       const sseTransports: Record<
         string,
         { close: () => Promise<void> | void }

--- a/src/__tests__/server-round2.test.ts
+++ b/src/__tests__/server-round2.test.ts
@@ -1,0 +1,1342 @@
+/**
+ * Round-2 hardening tests for src/server.ts:
+ * - Streamable-HTTP session reaper (closes transports, handles stuck sessions).
+ * - /mcp init race fallback (inline map deletion + JSON-RPC error frame).
+ * - Shutdown helper (closes both streamable + SSE transports).
+ * - Retry-After header clamping parity for the /mcp pre-check path.
+ *
+ * These cover behavior owned by server.ts; see sse-transport.test.ts for the
+ * /sse side of the Round-2 changes and analytics-auth.test.ts for the
+ * analytics 503 message differentiation coverage.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type express from "express";
+
+const mockGetConfig = vi.fn();
+const mockGetServerConfig = vi.fn();
+const mockGetAnalyticsConfig = vi.fn();
+
+vi.mock("../config.js", () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  getServerConfig: (...args: unknown[]) => mockGetServerConfig(...args),
+  getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+// Baseline config that individual tests may override.
+beforeEach(() => {
+  mockGetConfig.mockReturnValue({
+    port: 0,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "e".repeat(64),
+  });
+  mockGetServerConfig.mockReturnValue({
+    server: { name: "pathfinder-test", version: "0.0.0" },
+    sources: [],
+    tools: [],
+  });
+  mockGetAnalyticsConfig.mockReturnValue(undefined);
+});
+
+// ---------------------------------------------------------------------------
+// Streamable-HTTP session reaper
+// ---------------------------------------------------------------------------
+
+describe("reapIdleStreamableSessions (exported for testing)", () => {
+  it("calls transport.close() on reaped sessions (prevents listener/timer leaks)", async () => {
+    const { reapIdleStreamableSessions } = await import("../server.js");
+
+    const closed: string[] = [];
+    const transports: Record<string, { close: () => void | Promise<void> }> = {
+      stale: {
+        close: () => {
+          closed.push("stale");
+        },
+      },
+      fresh: {
+        close: () => {
+          closed.push("fresh");
+        },
+      },
+    };
+    const sessionLastActivity: Record<string, number> = {
+      stale: Date.now() - 10 * 60 * 1000,
+      fresh: Date.now() - 1000,
+    };
+
+    const reaped = reapIdleStreamableSessions({
+      transports: transports as unknown as Parameters<
+        typeof reapIdleStreamableSessions
+      >[0]["transports"],
+      sessionLastActivity,
+      ttlMs: 5 * 60 * 1000,
+      now: Date.now(),
+    });
+
+    expect(reaped).toEqual(["stale"]);
+    // close() runs on a microtask (Promise.resolve wrapper); flush the queue
+    // so the callback observes the call before asserting.
+    await new Promise((r) => setTimeout(r, 10));
+    // Transport.close() MUST run for reaped sessions; otherwise listeners /
+    // timers inside the transport leak until process exit.
+    expect(closed).toEqual(["stale"]);
+    expect(transports["stale"]).toBeUndefined();
+    expect(transports["fresh"]).toBeDefined();
+  });
+
+  it("reaps sessions whose last-activity entry is undefined (stuck-session bug)", async () => {
+    const { reapIdleStreamableSessions } = await import("../server.js");
+
+    // Missing/undefined sessionLastActivity[sid] triggers
+    // `now - undefined === NaN`, and `NaN > ttlMs` is always false — so the
+    // pre-fix reaper silently skipped these sessions forever. Defensive fix:
+    // coalesce undefined to 0.
+    const closed: string[] = [];
+    const transports: Record<string, { close: () => void }> = {
+      "no-activity": {
+        close: () => {
+          closed.push("no-activity");
+        },
+      },
+    };
+    const sessionLastActivity: Record<string, number> = {};
+
+    const reaped = reapIdleStreamableSessions({
+      transports: transports as unknown as Parameters<
+        typeof reapIdleStreamableSessions
+      >[0]["transports"],
+      sessionLastActivity,
+      ttlMs: 5 * 60 * 1000,
+      now: Date.now(),
+    });
+
+    expect(reaped).toEqual(["no-activity"]);
+    await new Promise((r) => setTimeout(r, 10));
+    expect(closed).toEqual(["no-activity"]);
+    expect(transports["no-activity"]).toBeUndefined();
+  });
+
+  it("logs async transport.close() rejections instead of leaving them unhandled", async () => {
+    const { reapIdleStreamableSessions } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+    try {
+      const transports: Record<string, { close: () => Promise<void> }> = {
+        stale: {
+          close: () => Promise.reject(new Error("streamable-close-boom")),
+        },
+      };
+      const sessionLastActivity: Record<string, number> = {
+        stale: Date.now() - 10 * 60 * 1000,
+      };
+
+      const reaped = reapIdleStreamableSessions({
+        transports: transports as unknown as Parameters<
+          typeof reapIdleStreamableSessions
+        >[0]["transports"],
+        sessionLastActivity,
+        ttlMs: 5 * 60 * 1000,
+        now: Date.now(),
+      });
+      expect(reaped).toEqual(["stale"]);
+
+      await new Promise((r) => setTimeout(r, 10));
+
+      const sawBoom = consoleErrSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) =>
+            (typeof arg === "string" &&
+              arg.includes("streamable-close-boom")) ||
+            (arg instanceof Error && arg.message === "streamable-close-boom"),
+        ),
+      );
+      expect(sawBoom).toBe(true);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      consoleErrSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /mcp race fallback handler
+// ---------------------------------------------------------------------------
+
+describe("handleSessionInitRaceFallback", () => {
+  it("removes transports[sid] and sessionLastActivity[sid] INLINE (not awaiting onclose)", async () => {
+    const { handleSessionInitRaceFallback } = await import("../server.js");
+
+    const transports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+    const sid = "race-sid";
+    const closed: string[] = [];
+    const transport = {
+      close: async () => {
+        closed.push(sid);
+      },
+      send: vi.fn(),
+    };
+    // Pretend the onsessioninitialized callback already registered the sid.
+    transports[sid] = transport;
+    sessionLastActivity[sid] = Date.now();
+
+    handleSessionInitRaceFallback({
+      transport: transport as unknown as Parameters<
+        typeof handleSessionInitRaceFallback
+      >[0]["transport"],
+      sid,
+      ip: "1.2.3.4",
+      transports: transports as unknown as Parameters<
+        typeof handleSessionInitRaceFallback
+      >[0]["transports"],
+      sessionLastActivity,
+      limit: 10,
+      currentCount: 11,
+      retryAfterSeconds: 60,
+    });
+
+    // Maps cleared synchronously — we do NOT rely on onclose firing later.
+    expect(transports[sid]).toBeUndefined();
+    expect(sessionLastActivity[sid]).toBeUndefined();
+
+    // Allow microtasks so close() promise settles if any.
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  it("emits a JSON-RPC error frame (or documented fallback) before closing the transport", async () => {
+    const { handleSessionInitRaceFallback } = await import("../server.js");
+
+    const transports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+    const sid = "race-sid-2";
+    const sendCalls: unknown[] = [];
+    let closedAt: number | undefined;
+    let sentAt: number | undefined;
+
+    const transport = {
+      close: async () => {
+        closedAt = Date.now();
+      },
+      send: async (msg: unknown) => {
+        sentAt = Date.now();
+        sendCalls.push(msg);
+      },
+    };
+    transports[sid] = transport;
+    sessionLastActivity[sid] = Date.now();
+
+    // Silence warn/error — the fallback will log.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    handleSessionInitRaceFallback({
+      transport: transport as unknown as Parameters<
+        typeof handleSessionInitRaceFallback
+      >[0]["transport"],
+      sid,
+      ip: "1.2.3.4",
+      transports: transports as unknown as Parameters<
+        typeof handleSessionInitRaceFallback
+      >[0]["transports"],
+      sessionLastActivity,
+      limit: 10,
+      currentCount: 11,
+      retryAfterSeconds: 60,
+    });
+
+    // Allow send/close microtasks to flush.
+    await new Promise((r) => setTimeout(r, 20));
+
+    if (sendCalls.length > 0) {
+      // Happy path: the fallback emitted a JSON-RPC error frame via
+      // transport.send BEFORE closing so the client sees a descriptive
+      // rejection rather than a silent disconnect.
+      const frame = sendCalls[0] as Record<string, unknown>;
+      expect(frame.jsonrpc).toBe("2.0");
+      expect((frame.error as Record<string, unknown>)?.code).toBe(-32005);
+      expect(sentAt).toBeDefined();
+      expect(closedAt).toBeDefined();
+      expect(sentAt!).toBeLessThanOrEqual(closedAt!);
+    } else {
+      // Documented fallback path: if transport.send isn't safe at this point
+      // in the SDK lifecycle, the race-fallback still closes the transport
+      // but MUST log a diagnostic warn — the silent-disconnect footgun
+      // turns into a loud log line instead.
+      expect(closedAt).toBeDefined();
+      const warnCalls = warnSpy.mock.calls.map((c) => c[0]);
+      const rejectedLog = warnCalls.find(
+        (m) =>
+          typeof m === "string" &&
+          m.includes("race fallback") &&
+          m.includes(sid.slice(0, 8)),
+      );
+      expect(rejectedLog).toBeDefined();
+    }
+
+    warnSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+
+  it("includes the clamped retry-after value in the warn log so operators see the retry hint (R2 #2)", async () => {
+    const { handleSessionInitRaceFallback } = await import("../server.js");
+
+    const transports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+    const sid = "race-sid-retry-log";
+    const transport = {
+      close: async () => {},
+      send: vi.fn(),
+    };
+    transports[sid] = transport;
+    sessionLastActivity[sid] = Date.now();
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    // Pass an intentionally huge retry-after (mirrors the real site which
+    // derives from SESSION_TTL_MS/1000 = 1800). The log must carry the
+    // CLAMPED value (300 = 5m ceiling) so ops see a retry hint that matches
+    // what clients receive, not the pre-clamp seed value.
+    handleSessionInitRaceFallback({
+      transport: transport as unknown as Parameters<
+        typeof handleSessionInitRaceFallback
+      >[0]["transport"],
+      sid,
+      ip: "1.2.3.4",
+      transports: transports as unknown as Parameters<
+        typeof handleSessionInitRaceFallback
+      >[0]["transports"],
+      sessionLastActivity,
+      limit: 10,
+      currentCount: 11,
+      retryAfterSeconds: 1800,
+    });
+
+    await new Promise((r) => setTimeout(r, 10));
+
+    const warnCalls = warnSpy.mock.calls.map((c) => String(c[0] ?? ""));
+    const logged = warnCalls.find(
+      (m) =>
+        m.includes("race fallback") && m.includes(sid.slice(0, 8)),
+    );
+    expect(logged).toBeDefined();
+    // Must carry the CLAMPED value (300), not the pre-clamp 1800. Include
+    // "retry" marker so we know this is the retry hint, not some other
+    // integer in the log line.
+    expect(logged!).toMatch(/retry[^0-9]*300/i);
+    expect(logged!).not.toMatch(/1800/);
+
+    warnSpy.mockRestore();
+    errSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// /mcp pre-check Retry-After header clamp parity (R2 #1)
+// ---------------------------------------------------------------------------
+
+describe("write429RateLimited (helper used by /mcp pre-check)", () => {
+  it("clamps the Retry-After header to the same ceiling as the JSON body (R2 #1)", async () => {
+    const { write429RateLimited } = await import("../server.js");
+
+    const headers: Record<string, string> = {};
+    let bodyWritten: Record<string, unknown> | undefined;
+    let statusWritten: number | undefined;
+    const res = {
+      setHeader: (name: string, value: string) => {
+        headers[name] = value;
+      },
+      status: (code: number) => {
+        statusWritten = code;
+        return res;
+      },
+      json: (body: Record<string, unknown>) => {
+        bodyWritten = body;
+        return res;
+      },
+    };
+
+    // Seed with the raw SESSION_TTL_MS-derived hint (30m -> 1800s). Pre-clamp
+    // this would flow into the header unchanged while the JSON body got
+    // clamped to 300 via buildRateLimitPayload -> the two values disagreed.
+    write429RateLimited(res as unknown as express.Response, {
+      id: 42,
+      limit: 10,
+      currentCount: 11,
+      retryAfterSeconds: 1800,
+    });
+
+    expect(statusWritten).toBe(429);
+    expect(headers["Retry-After"]).toBe("300");
+    const data = (bodyWritten?.error as { data?: Record<string, unknown> })
+      ?.data;
+    expect(data?.retryAfterSeconds).toBe(300);
+    // Header and body agree — the whole point of this finding.
+    expect(headers["Retry-After"]).toBe(String(data?.retryAfterSeconds));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// onsessioninitialized accept-handler: ensureSession throw rolls back state
+// (R2 #5)
+// ---------------------------------------------------------------------------
+
+describe("handleSessionInitAccept (ensureSession failure rollback)", () => {
+  it("rolls back ipLimiter + clears maps + closes transport when ensureSession throws (no IP-quota leak)", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const sid = "ensure-boom-sid";
+      const ip = "9.9.9.9";
+      const transports: Record<string, unknown> = {};
+      const sessionLastActivity: Record<string, number> = {};
+      transports[sid] = { fake: true };
+      sessionLastActivity[sid] = Date.now();
+
+      const removedSids: string[] = [];
+      const ipLimiter = {
+        remove: (s: string) => {
+          removedSids.push(s);
+        },
+      };
+      const workspaceManager = {
+        ensureSession: () => {
+          throw new Error("ensure-boom");
+        },
+      };
+      const closedSids: string[] = [];
+      const transport = {
+        close: async () => {
+          closedSids.push(sid);
+        },
+      };
+
+      handleSessionInitAccept({
+        transport,
+        sid,
+        ip,
+        transports,
+        sessionLastActivity,
+        ipLimiter,
+        workspaceManager,
+      });
+
+      // Synchronous: maps cleared, ipLimiter rolled back (no TTL leak).
+      expect(transports[sid]).toBeUndefined();
+      expect(sessionLastActivity[sid]).toBeUndefined();
+      expect(removedSids).toEqual([sid]);
+
+      // Microtask: transport.close() completes.
+      await new Promise((r) => setTimeout(r, 10));
+      expect(closedSids).toEqual([sid]);
+
+      const sawBoom = consoleErrSpy.mock.calls.some((c) =>
+        c.some(
+          (arg) =>
+            (typeof arg === "string" && arg.includes("ensure-boom")) ||
+            (arg instanceof Error && arg.message === "ensure-boom"),
+        ),
+      );
+      expect(sawBoom).toBe(true);
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
+
+  it("happy path: ensureSession succeeds and maps stay populated", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const sid = "ensure-ok-sid";
+    const transports: Record<string, unknown> = { [sid]: { fake: true } };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+
+    const ensureCalls: string[] = [];
+    handleSessionInitAccept({
+      transport: { close: async () => {} },
+      sid,
+      ip: "1.1.1.1",
+      transports,
+      sessionLastActivity,
+      ipLimiter: {
+        remove: () => {
+          // must NOT be called on the happy path
+          throw new Error("remove should not be called");
+        },
+      },
+      workspaceManager: {
+        ensureSession: (s: string) => {
+          ensureCalls.push(s);
+        },
+      },
+    });
+
+    expect(ensureCalls).toEqual([sid]);
+    expect(transports[sid]).toBeDefined();
+    expect(sessionLastActivity[sid]).toBeDefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3 #1: reapIdleSessionsTick plumbs ipLimiter/workspaceManager/
+// sessionStateManager into the SSE reaper so cleanup stays with the reaper
+// (not a post-reap loop in server.ts).
+// ---------------------------------------------------------------------------
+
+describe("reapIdleSessionsTick (R3 #1: SSE reaper dep plumbing)", () => {
+  it("passes ipLimiter.remove, workspaceManager.cleanup, and sessionStateManager.cleanup into the SSE reaper for each reaped sid", async () => {
+    const { reapIdleSessionsTickForTesting } = await import("../server.js");
+
+    const sseTransports: Record<
+      string,
+      { close: () => Promise<void> | void }
+    > = {
+      "sse-stale": {
+        close: async () => {},
+      },
+    };
+    const transports: Record<
+      string,
+      { close: () => Promise<void> | void }
+    > = {};
+    const sessionLastActivity: Record<string, number> = {
+      "sse-stale": Date.now() - 10 * 60 * 1000,
+    };
+
+    const removedSids: string[] = [];
+    const cleanedWorkspaceSids: string[] = [];
+    const cleanedSessionStateSids: string[] = [];
+
+    reapIdleSessionsTickForTesting({
+      transports: transports as unknown as Parameters<
+        typeof reapIdleSessionsTickForTesting
+      >[0]["transports"],
+      sseTransports: sseTransports as unknown as Parameters<
+        typeof reapIdleSessionsTickForTesting
+      >[0]["sseTransports"],
+      sessionLastActivity,
+      ttlMs: 5 * 60 * 1000,
+      now: Date.now(),
+      ipLimiter: {
+        remove: (sid: string) => {
+          removedSids.push(sid);
+        },
+      },
+      workspaceManager: {
+        cleanup: (sid: string) => {
+          cleanedWorkspaceSids.push(sid);
+        },
+      },
+      sessionStateManager: {
+        cleanup: (sid: string) => {
+          cleanedSessionStateSids.push(sid);
+        },
+      },
+    });
+
+    // Each cleanup dep got the reaped sid once.
+    expect(removedSids).toEqual(["sse-stale"]);
+    expect(cleanedWorkspaceSids).toEqual(["sse-stale"]);
+    expect(cleanedSessionStateSids).toEqual(["sse-stale"]);
+    // Map entry gone (reaper deletes inline).
+    expect(sseTransports["sse-stale"]).toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3 #2 + H2: handleSessionInitAccept returns false on rollback; includes
+// sessionStateManager cleanup in the rollback chain.
+// ---------------------------------------------------------------------------
+
+describe("handleSessionInitAccept (R3 #2 rollback signaling + H2 sessionStateManager)", () => {
+  it("returns false when ensureSession throws so caller can skip server.connect/handleRequest", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const sid = "r3-rollback-sid";
+      const transports: Record<string, unknown> = { [sid]: { fake: true } };
+      const sessionLastActivity: Record<string, number> = {
+        [sid]: Date.now(),
+      };
+
+      const result = handleSessionInitAccept({
+        transport: { close: async () => {} },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-r3-boom");
+          },
+        },
+      });
+
+      expect(result).toBe(false);
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
+
+  it("returns true on the happy path (caller proceeds to server.connect/handleRequest)", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const sid = "r3-ok-sid";
+    const transports: Record<string, unknown> = { [sid]: { fake: true } };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+
+    const result = handleSessionInitAccept({
+      transport: { close: async () => {} },
+      sid,
+      ip: "1.1.1.1",
+      transports,
+      sessionLastActivity,
+      ipLimiter: { remove: () => {} },
+      workspaceManager: {
+        ensureSession: () => {},
+      },
+    });
+
+    expect(result).toBe(true);
+  });
+
+  it("H2: rollback also invokes sessionStateManager.cleanup(sid) when provided", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const sid = "r3-sstate-sid";
+      const transports: Record<string, unknown> = { [sid]: { fake: true } };
+      const sessionLastActivity: Record<string, number> = {
+        [sid]: Date.now(),
+      };
+
+      const cleanedSessionStateSids: string[] = [];
+      handleSessionInitAccept({
+        transport: { close: async () => {} },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-r3-state-boom");
+          },
+        },
+        sessionStateManager: {
+          cleanup: (s: string) => {
+            cleanedSessionStateSids.push(s);
+          },
+        },
+      });
+
+      expect(cleanedSessionStateSids).toEqual([sid]);
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
+
+  it("H2: a throw from sessionStateManager.cleanup does not mask the rollback (maps still cleared, transport still closed)", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const sid = "r3-sstate-throw-sid";
+      const transports: Record<string, unknown> = { [sid]: { fake: true } };
+      const sessionLastActivity: Record<string, number> = {
+        [sid]: Date.now(),
+      };
+
+      const closedSids: string[] = [];
+      const result = handleSessionInitAccept({
+        transport: {
+          close: async () => {
+            closedSids.push(sid);
+          },
+        },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-boom");
+          },
+        },
+        sessionStateManager: {
+          cleanup: () => {
+            throw new Error("sstate-cleanup-boom");
+          },
+        },
+      });
+
+      expect(result).toBe(false);
+      expect(transports[sid]).toBeUndefined();
+      expect(sessionLastActivity[sid]).toBeUndefined();
+      await new Promise((r) => setTimeout(r, 10));
+      expect(closedSids).toEqual([sid]);
+      const sawSstateBoom = consoleErrSpy.mock.calls.some((c) =>
+        c.some(
+          (arg) =>
+            (typeof arg === "string" && arg.includes("sstate-cleanup-boom")) ||
+            (arg instanceof Error &&
+              arg.message === "sstate-cleanup-boom"),
+        ),
+      );
+      expect(sawSstateBoom).toBe(true);
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
+
+  it("R3 #2: writes a 503 response body on rollback when res is provided and headers not yet sent", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const sid = "r3-503-sid";
+      const transports: Record<string, unknown> = { [sid]: { fake: true } };
+      const sessionLastActivity: Record<string, number> = {
+        [sid]: Date.now(),
+      };
+
+      let statusWritten: number | undefined;
+      let bodyWritten: Record<string, unknown> | undefined;
+      const res = {
+        headersSent: false,
+        status: (c: number) => {
+          statusWritten = c;
+          return res;
+        },
+        json: (b: Record<string, unknown>) => {
+          bodyWritten = b;
+          return res;
+        },
+      };
+
+      handleSessionInitAccept({
+        transport: { close: async () => {} },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-503-boom");
+          },
+        },
+        res: res as unknown as Parameters<
+          typeof handleSessionInitAccept
+        >[0]["res"],
+      });
+
+      expect(statusWritten).toBe(503);
+      expect(bodyWritten).toBeDefined();
+      const err = (bodyWritten as Record<string, unknown>).error as
+        | Record<string, unknown>
+        | undefined;
+      // JSON-RPC shape: error.code/message. A plain string also acceptable —
+      // just verify the client gets a structured signal.
+      expect(
+        typeof (bodyWritten as Record<string, unknown>).error !== "undefined",
+      ).toBe(true);
+      void err;
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
+
+  it("R3 #2: does NOT write a response body on rollback when headersSent is already true", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const sid = "r3-hs-sent-sid";
+      const transports: Record<string, unknown> = { [sid]: { fake: true } };
+      const sessionLastActivity: Record<string, number> = {
+        [sid]: Date.now(),
+      };
+
+      let statusCalled = false;
+      let jsonCalled = false;
+      const res = {
+        headersSent: true,
+        status: () => {
+          statusCalled = true;
+          return res;
+        },
+        json: () => {
+          jsonCalled = true;
+          return res;
+        },
+      };
+
+      handleSessionInitAccept({
+        transport: { close: async () => {} },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-hs-boom");
+          },
+        },
+        res: res as unknown as Parameters<
+          typeof handleSessionInitAccept
+        >[0]["res"],
+      });
+
+      expect(statusCalled).toBe(false);
+      expect(jsonCalled).toBe(false);
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3 #3 (H1): onclose cleanup is suppressed for sids rejected by race fallback
+// or ensureSession rollback — those paths already cleaned up inline and a
+// second round of "Session closed" logs / cleanup calls pollutes operator
+// visibility and risks double-free.
+// ---------------------------------------------------------------------------
+
+describe("rejected-sid suppression (R3 #3 / H1)", () => {
+  it("markSessionRejected(sid) + onclose path skips cleanup chain", async () => {
+    const serverMod = await import("../server.js");
+    const markSessionRejected = (
+      serverMod as unknown as { markSessionRejectedForTesting?: (sid: string) => void }
+    ).markSessionRejectedForTesting;
+    const wasRejected = (
+      serverMod as unknown as {
+        wasSessionRejectedForTesting?: (sid: string) => boolean;
+      }
+    ).wasSessionRejectedForTesting;
+
+    expect(typeof markSessionRejected).toBe("function");
+    expect(typeof wasRejected).toBe("function");
+    markSessionRejected!("rej-sid");
+    expect(wasRejected!("rej-sid")).toBe(true);
+    expect(wasRejected!("other-sid")).toBe(false);
+  });
+
+  it("handleSessionInitRaceFallback marks the sid as rejected", async () => {
+    const serverMod = await import("../server.js");
+    const { handleSessionInitRaceFallback } = serverMod;
+    const wasRejected = (
+      serverMod as unknown as {
+        wasSessionRejectedForTesting?: (sid: string) => boolean;
+      }
+    ).wasSessionRejectedForTesting;
+    expect(typeof wasRejected).toBe("function");
+
+    const sid = "race-marks-rejected";
+    const transports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+    const transport = {
+      close: async () => {},
+    };
+    transports[sid] = transport;
+    sessionLastActivity[sid] = Date.now();
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      handleSessionInitRaceFallback({
+        transport: transport as unknown as Parameters<
+          typeof handleSessionInitRaceFallback
+        >[0]["transport"],
+        sid,
+        ip: "1.2.3.4",
+        transports: transports as unknown as Parameters<
+          typeof handleSessionInitRaceFallback
+        >[0]["transports"],
+        sessionLastActivity,
+        limit: 10,
+        currentCount: 11,
+        retryAfterSeconds: 60,
+      });
+      expect(wasRejected!(sid)).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it("handleSessionInitAccept rollback marks the sid as rejected", async () => {
+    const serverMod = await import("../server.js");
+    const { handleSessionInitAccept } = serverMod;
+    const wasRejected = (
+      serverMod as unknown as {
+        wasSessionRejectedForTesting?: (sid: string) => boolean;
+      }
+    ).wasSessionRejectedForTesting;
+    expect(typeof wasRejected).toBe("function");
+
+    const sid = "accept-rollback-marks-rejected";
+    const transports: Record<string, unknown> = { [sid]: { fake: true } };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      handleSessionInitAccept({
+        transport: { close: async () => {} },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-mark-boom");
+          },
+        },
+      });
+      expect(wasRejected!(sid)).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R4 #1: rejectedSids leak on inline-rollback paths.
+//
+// The race-fallback and accept-rollback helpers seed rejectedSids so that
+// IF transport.onclose were wired, it could suppress double-cleanup. But the
+// outer POST /mcp route wires `transport.onclose` AFTER both early-return
+// paths — in the tryAdd-fail and accept-rollback flows no handler is ever
+// attached. The marker leaked forever under rate-limit hammering / workspace
+// failures. Fix: drain inline once cleanup is done.
+// ---------------------------------------------------------------------------
+
+describe("rejectedSids inline-rollback drain (R4 #1)", () => {
+  it("drainRejectedSidForInlineRollback removes the marker so the Set cannot leak", async () => {
+    const serverMod = await import("../server.js");
+    const { handleSessionInitRaceFallback } = serverMod;
+    const wasRejected = (
+      serverMod as unknown as {
+        wasSessionRejectedForTesting?: (sid: string) => boolean;
+      }
+    ).wasSessionRejectedForTesting;
+    const drain = (
+      serverMod as unknown as {
+        drainRejectedSidForInlineRollback?: (sid: string) => void;
+      }
+    ).drainRejectedSidForInlineRollback;
+
+    expect(typeof drain).toBe("function");
+    expect(typeof wasRejected).toBe("function");
+
+    const sid = "sync-race-leak";
+    const transports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+    transports[sid] = { close: async () => {} };
+    sessionLastActivity[sid] = Date.now();
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      handleSessionInitRaceFallback({
+        transport: transports[sid] as unknown as Parameters<
+          typeof handleSessionInitRaceFallback
+        >[0]["transport"],
+        sid,
+        ip: "1.2.3.4",
+        transports: transports as unknown as Parameters<
+          typeof handleSessionInitRaceFallback
+        >[0]["transports"],
+        sessionLastActivity,
+        limit: 1,
+        currentCount: 2,
+        retryAfterSeconds: 60,
+      });
+      expect(wasRejected!(sid)).toBe(true);
+      drain!(sid);
+      expect(wasRejected!(sid)).toBe(false);
+    } finally {
+      warnSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
+
+  it("drainRejectedSidForInlineRollback also clears markers left by handleSessionInitAccept rollback", async () => {
+    const serverMod = await import("../server.js");
+    const { handleSessionInitAccept } = serverMod;
+    const wasRejected = (
+      serverMod as unknown as {
+        wasSessionRejectedForTesting?: (sid: string) => boolean;
+      }
+    ).wasSessionRejectedForTesting;
+    const drain = (
+      serverMod as unknown as {
+        drainRejectedSidForInlineRollback?: (sid: string) => void;
+      }
+    ).drainRejectedSidForInlineRollback;
+
+    expect(typeof drain).toBe("function");
+    expect(typeof wasRejected).toBe("function");
+
+    const sid = "accept-rollback-leak";
+    const transports: Record<string, unknown> = { [sid]: { fake: true } };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      handleSessionInitAccept({
+        transport: { close: async () => {} },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-drain-boom");
+          },
+        },
+      });
+      expect(wasRejected!(sid)).toBe(true);
+      drain!(sid);
+      expect(wasRejected!(sid)).toBe(false);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R4 #2: completeInitRequestSafely guards the outer /mcp handler against
+// residual handleRequest throws after the onsessioninitialized race-fallback
+// closed the transport mid-flight. Without this wrapper the SDK's closed-
+// transport throw escaped into the outer catch-all and produced a 500 write
+// on top of the 429 the fallback already streamed.
+// ---------------------------------------------------------------------------
+
+describe("completeInitRequestSafely (R4 #2)", () => {
+  it("returns normally when handleRequest resolves and initOutcome stays unrejected", async () => {
+    const serverMod = await import("../server.js");
+    const fn = (
+      serverMod as unknown as {
+        completeInitRequestSafely?: (
+          transport: { handleRequest: (...args: unknown[]) => Promise<void> },
+          req: unknown,
+          res: unknown,
+          body: unknown,
+          initOutcome: { rejected: boolean },
+        ) => Promise<void>;
+      }
+    ).completeInitRequestSafely;
+    expect(typeof fn).toBe("function");
+
+    let called = 0;
+    const transport = {
+      handleRequest: async () => {
+        called++;
+      },
+    };
+    const initOutcome = { rejected: false };
+
+    await fn!(transport, {}, {}, {}, initOutcome);
+    expect(called).toBe(1);
+  });
+
+  it("swallows handleRequest throws when the race-fallback marked initOutcome.rejected", async () => {
+    const serverMod = await import("../server.js");
+    const fn = (
+      serverMod as unknown as {
+        completeInitRequestSafely?: (
+          transport: { handleRequest: (...args: unknown[]) => Promise<void> },
+          req: unknown,
+          res: unknown,
+          body: unknown,
+          initOutcome: { rejected: boolean },
+        ) => Promise<void>;
+      }
+    ).completeInitRequestSafely;
+    expect(typeof fn).toBe("function");
+
+    const transport = {
+      handleRequest: async () => {
+        throw new Error("closed-transport-boom");
+      },
+    };
+    const initOutcome = { rejected: true };
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    try {
+      await expect(
+        fn!(transport, {}, { headersSent: true }, {}, initOutcome),
+      ).resolves.toBeUndefined();
+      const suppressed = warnSpy.mock.calls.some((c) =>
+        c.some(
+          (arg) =>
+            typeof arg === "string" &&
+            arg.toLowerCase().includes("suppressed") &&
+            arg.toLowerCase().includes("rejected"),
+        ),
+      );
+      expect(suppressed).toBe(true);
+    } finally {
+      warnSpy.mockRestore();
+    }
+  });
+
+  it("re-throws handleRequest errors when the session was NOT race-rejected", async () => {
+    const serverMod = await import("../server.js");
+    const fn = (
+      serverMod as unknown as {
+        completeInitRequestSafely?: (
+          transport: { handleRequest: (...args: unknown[]) => Promise<void> },
+          req: unknown,
+          res: unknown,
+          body: unknown,
+          initOutcome: { rejected: boolean },
+        ) => Promise<void>;
+      }
+    ).completeInitRequestSafely;
+    expect(typeof fn).toBe("function");
+
+    const transport = {
+      handleRequest: async () => {
+        throw new Error("real-bug");
+      },
+    };
+    const initOutcome = { rejected: false };
+
+    await expect(
+      fn!(transport, {}, { headersSent: false }, {}, initOutcome),
+    ).rejects.toThrow("real-bug");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R4 #4: Retry-After TTL helper — single source of truth for the
+// Math.max(1, Math.round(SESSION_TTL_MS / 1000)) expression that used to be
+// duplicated across the /mcp init paths.
+// ---------------------------------------------------------------------------
+
+describe("retryAfterSecondsFromTtl (R4 #4)", () => {
+  it("exposes the TTL-derived Retry-After seconds as a positive integer", async () => {
+    const serverMod = await import("../server.js");
+    const fn = (
+      serverMod as unknown as {
+        retryAfterSecondsFromTtl?: () => number;
+      }
+    ).retryAfterSecondsFromTtl;
+
+    expect(typeof fn).toBe("function");
+    const secs = fn!();
+    expect(Number.isInteger(secs)).toBe(true);
+    expect(secs).toBeGreaterThanOrEqual(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// R3 #5: write429RateLimited guards against headersSent
+// ---------------------------------------------------------------------------
+
+describe("write429RateLimited (R3 #5: headersSent guard)", () => {
+  it("bails without throwing and does not call setHeader/status/json when headersSent is true", async () => {
+    const { write429RateLimited } = await import("../server.js");
+
+    let setHeaderCalled = false;
+    let statusCalled = false;
+    let jsonCalled = false;
+    const res = {
+      headersSent: true,
+      setHeader: () => {
+        setHeaderCalled = true;
+      },
+      status: () => {
+        statusCalled = true;
+        return res;
+      },
+      json: () => {
+        jsonCalled = true;
+        return res;
+      },
+    };
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      // Must not throw.
+      expect(() =>
+        write429RateLimited(res as unknown as express.Response, {
+          id: 1,
+          limit: 10,
+          currentCount: 11,
+          retryAfterSeconds: 60,
+        }),
+      ).not.toThrow();
+      expect(setHeaderCalled).toBe(false);
+      expect(statusCalled).toBe(false);
+      expect(jsonCalled).toBe(false);
+      // A diagnostic log line is emitted so operators can correlate.
+      const logged = errSpy.mock.calls.some((c) =>
+        c.some(
+          (arg) =>
+            typeof arg === "string" &&
+            arg.includes("headers sent") &&
+            arg.toLowerCase().includes("429"),
+        ),
+      );
+      expect(logged).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Shutdown helper: closes both streamable-HTTP and SSE transports (R2 #6)
+// ---------------------------------------------------------------------------
+
+describe("closeAllSessions (shutdown helper)", () => {
+  it("closes every streamable-HTTP transport and every SSE transport and clears the maps", async () => {
+    const { closeAllSessions } = await import("../server.js");
+
+    const closedStreamable: string[] = [];
+    const closedSse: string[] = [];
+    const transports: Record<string, { close: () => Promise<void> | void }> = {
+      "s-1": {
+        close: () => {
+          closedStreamable.push("s-1");
+        },
+      },
+      "s-2": {
+        close: async () => {
+          closedStreamable.push("s-2");
+        },
+      },
+    };
+    const sseTransports: Record<string, { close: () => Promise<void> | void }> =
+      {
+        "e-1": {
+          close: async () => {
+            closedSse.push("e-1");
+          },
+        },
+      };
+
+    await closeAllSessions({
+      transports: transports as unknown as Parameters<
+        typeof closeAllSessions
+      >[0]["transports"],
+      sseTransports: sseTransports as unknown as Parameters<
+        typeof closeAllSessions
+      >[0]["sseTransports"],
+    });
+
+    expect(closedStreamable.sort()).toEqual(["s-1", "s-2"]);
+    expect(closedSse).toEqual(["e-1"]);
+    expect(Object.keys(transports)).toEqual([]);
+    expect(Object.keys(sseTransports)).toEqual([]);
+  });
+
+  it("continues closing other transports when one close() rejects and logs the failure", async () => {
+    const { closeAllSessions } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const closedOk: string[] = [];
+      const transports: Record<
+        string,
+        { close: () => Promise<void> | void }
+      > = {
+        "bad-1": {
+          close: async () => {
+            throw new Error("streamable-shutdown-boom");
+          },
+        },
+        "good-1": {
+          close: async () => {
+            closedOk.push("good-1");
+          },
+        },
+      };
+      const sseTransports: Record<
+        string,
+        { close: () => Promise<void> | void }
+      > = {
+        "bad-sse": {
+          close: async () => {
+            throw new Error("sse-shutdown-boom");
+          },
+        },
+      };
+
+      await closeAllSessions({
+        transports: transports as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["transports"],
+        sseTransports: sseTransports as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["sseTransports"],
+      });
+
+      expect(closedOk).toEqual(["good-1"]);
+      expect(Object.keys(transports)).toEqual([]);
+      expect(Object.keys(sseTransports)).toEqual([]);
+      const sawStreamableBoom = consoleErrSpy.mock.calls.some((c) =>
+        c.some(
+          (arg) =>
+            (typeof arg === "string" &&
+              arg.includes("streamable-shutdown-boom")) ||
+            (arg instanceof Error &&
+              arg.message === "streamable-shutdown-boom"),
+        ),
+      );
+      const sawSseBoom = consoleErrSpy.mock.calls.some((c) =>
+        c.some(
+          (arg) =>
+            (typeof arg === "string" && arg.includes("sse-shutdown-boom")) ||
+            (arg instanceof Error && arg.message === "sse-shutdown-boom"),
+        ),
+      );
+      expect(sawStreamableBoom).toBe(true);
+      expect(sawSseBoom).toBe(true);
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
+});

--- a/src/__tests__/sse-transport.test.ts
+++ b/src/__tests__/sse-transport.test.ts
@@ -1,13 +1,4 @@
-import {
-  describe,
-  it,
-  expect,
-  beforeAll,
-  afterAll,
-  beforeEach,
-  afterEach,
-  vi,
-} from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import express from "express";
 import type { Server } from "node:http";
 import type { AddressInfo } from "node:net";
@@ -293,6 +284,120 @@ describe("SSE transport routes", () => {
     await second.body?.cancel();
   });
 
+  it("GET /sse 429 rejection returns a descriptive JSON body + Retry-After header", async () => {
+    const limiter = new IpSessionLimiter(1);
+    const { app } = buildApp({ ipLimiter: limiter });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const first = await fetch(`${url}/sse`);
+    expect(first.status).toBe(200);
+
+    const second = await fetch(`${url}/sse`);
+    expect(second.status).toBe(429);
+    expect(second.headers.get("retry-after")).toBeTruthy();
+    const body = (await second.json()) as Record<string, unknown>;
+    expect(body.error).toBe("rate_limited");
+    expect(typeof body.reason).toBe("string");
+    expect(body.limit).toBe(1);
+    expect(typeof body.currentCount).toBe("number");
+    expect((body.currentCount as number) >= 1).toBe(true);
+    expect(typeof body.retryAfterSeconds).toBe("number");
+    expect(body.contact).toBe("oss@copilotkit.ai");
+
+    await first.body?.cancel();
+  });
+
+  it("GET /sse bypasses the limit for allowlisted IPs (loopback 127.0.0.1)", async () => {
+    // The test client connects from 127.0.0.1, so allowlist that and cap at 1.
+    const limiter = new IpSessionLimiter(1, {
+      allowlist: ["127.0.0.0/8"],
+    });
+    const { app } = buildApp({ ipLimiter: limiter });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    // Open more sessions than the cap; all should succeed because allowlisted.
+    const first = await fetch(`${url}/sse`);
+    expect(first.status).toBe(200);
+    const second = await fetch(`${url}/sse`);
+    expect(second.status).toBe(200);
+    const third = await fetch(`${url}/sse`);
+    expect(third.status).toBe(200);
+
+    await first.body?.cancel();
+    await second.body?.cancel();
+    await third.body?.cancel();
+  });
+
+  it("GET /sse with trust_proxy=false ignores X-Forwarded-For (limiter sees socket IP, not spoofed header)", async () => {
+    // Cap at 1 and allowlist ONLY the spoofed IP an attacker might send via
+    // XFF. With trust_proxy=false the limiter must key off the socket peer
+    // (127.0.0.1) and treat the allowlist check against the socket as well
+    // — so sending XFF: 203.0.113.7 can't pretend to be the allowlisted IP.
+    const limiter = new IpSessionLimiter(1, {
+      allowlist: ["203.0.113.7"],
+    });
+    const { app } = buildApp({ ipLimiter: limiter, trustProxy: false });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    // First request: succeeds (capacity available).
+    const first = await fetch(`${url}/sse`, {
+      headers: { "X-Forwarded-For": "203.0.113.7" },
+    });
+    expect(first.status).toBe(200);
+
+    // Second request — same socket IP (127.0.0.1) — must be rate-limited.
+    // If clientIp wrongly honored XFF, it would see "203.0.113.7",
+    // find it allowlisted, and return 200 — which is the vulnerability.
+    const second = await fetch(`${url}/sse`, {
+      headers: { "X-Forwarded-For": "203.0.113.7" },
+    });
+    expect(second.status).toBe(429);
+
+    await first.body?.cancel();
+    await second.body?.cancel();
+  });
+
+  it("GET /sse with trust_proxy=false — spoofed X-Forwarded-For does not bypass allowlist", async () => {
+    // Allowlist 203.0.113.7 and cap at 1. Attacker sends XFF=203.0.113.7
+    // from the test client. If the handler honored XFF, it would see the
+    // allowlisted IP and skip the counter entirely — then a SECOND request
+    // with the same spoof should also succeed (allowlisted bypass). With
+    // trust_proxy=false, the handler must see the socket (loopback, NOT
+    // on the allowlist) and rate-limit the second request with 429.
+    const limiter = new IpSessionLimiter(1, {
+      allowlist: ["203.0.113.7"],
+    });
+    const { app } = buildApp({
+      ipLimiter: limiter,
+      trustProxy: false,
+    });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const first = await fetch(`${url}/sse`, {
+      headers: { "X-Forwarded-For": "203.0.113.7" },
+    });
+    expect(first.status).toBe(200);
+
+    // Second spoofed request — MUST be rejected. If we honored XFF, this
+    // would return 200 (allowlist bypass), which is the vulnerability.
+    const second = await fetch(`${url}/sse`, {
+      headers: { "X-Forwarded-For": "203.0.113.7" },
+    });
+    expect(second.status).toBe(429);
+
+    // The spoofed IP must NOT have been tracked in the limiter's counters
+    // (allowlisted IPs are never tracked; non-allowlisted IPs keyed by XFF
+    // would show up here if clientIp was broken).
+    expect(limiter.getSessionCount("203.0.113.7")).toBe(0);
+
+    await first.body?.cancel();
+    await second.body?.cancel();
+  });
+
   it("closing the SSE stream removes the session from sseTransports", async () => {
     const { app, deps } = buildApp();
     server = await startServer(app);
@@ -357,5 +462,1012 @@ describe("reapIdleSseSessions", () => {
     expect(reaped).toEqual(["stale"]);
     expect(sseTransports["stale"]).toBeUndefined();
     expect(sseTransports["fresh"]).toBeDefined();
+  });
+
+  it("logs async transport.close() rejections instead of leaving them unhandled", async () => {
+    const { reapIdleSseSessions } = await import("../sse-handlers.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    // Capture any unhandled rejections during the test so we can fail if
+    // the reaper leaks one.
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => unhandled.push(reason);
+    process.on("unhandledRejection", onUnhandled);
+
+    try {
+      const sseTransports: Record<string, { close: () => Promise<void> }> = {};
+      const sessionLastActivity: Record<string, number> = {};
+      const now = Date.now();
+
+      sseTransports["stale-async-reject"] = {
+        // Returns a rejected promise — only caught if the reaper attaches .catch
+        close: () => Promise.reject(new Error("boom-async")),
+      };
+      sessionLastActivity["stale-async-reject"] = now - 10 * 60 * 1000;
+
+      reapIdleSseSessions({
+        sseTransports: sseTransports as unknown as Parameters<
+          typeof reapIdleSseSessions
+        >[0]["sseTransports"],
+        sessionLastActivity,
+        ttlMs: 5 * 60 * 1000,
+        now,
+      });
+
+      // Allow microtasks to flush so the rejection lands.
+      await new Promise((r) => setTimeout(r, 10));
+
+      const loggedBoom = consoleErrSpy.mock.calls.some((call) =>
+        call.some(
+          (arg) =>
+            (typeof arg === "string" && arg.includes("boom-async")) ||
+            (arg instanceof Error && arg.message === "boom-async"),
+        ),
+      );
+      expect(loggedBoom).toBe(true);
+      expect(unhandled).toEqual([]);
+    } finally {
+      process.off("unhandledRejection", onUnhandled);
+      consoleErrSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round 2 — hardening tests for pre-check ordering, error-path cleanup, and
+// per-step cleanup resilience. These mirror the /mcp path's patterns.
+// ---------------------------------------------------------------------------
+
+describe("SSE transport hardening (Round 2)", () => {
+  let server: Server | undefined;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    await closeServer(server);
+    server = undefined;
+  });
+
+  it("429 pre-check does NOT call ipLimiter.tryAdd (transport not constructed on rejection)", async () => {
+    // Use cap=1 and a priming request (not a preload) so we exercise the
+    // actual socket IP the handler sees — dual-stack listeners often report
+    // 127.0.0.1 as ::ffff:127.0.0.1, which would mismatch a hardcoded
+    // "127.0.0.1" preload.
+    const limiter = new IpSessionLimiter(1);
+    const { app, deps } = buildApp({ ipLimiter: limiter });
+
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    // Prime the counter by making a real request that succeeds.
+    const first = await fetch(`${url}/sse`);
+    expect(first.status).toBe(200);
+
+    // NOW spy on tryAdd — the second request (at cap) should 429 via the
+    // pre-check without ever calling tryAdd.
+    const tryAddSpy = vi.spyOn(limiter, "tryAdd");
+
+    const res = await fetch(`${url}/sse`);
+    expect(res.status).toBe(429);
+
+    // tryAdd must not have been called on the rejected path. If the handler
+    // constructs a transport first and THEN calls tryAdd, we'd see a call.
+    expect(tryAddSpy).not.toHaveBeenCalled();
+
+    // The transport map should still hold only the primed session, not a
+    // stray entry from a constructed-but-never-connected transport.
+    expect(Object.keys(deps.sseTransports).length).toBe(1);
+
+    await first.body?.cancel();
+    await res.body?.cancel();
+  });
+
+  it("429 log message mirrors /mcp format: includes (currentCount/limit)", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+
+    // Cap at 1 — prime the limiter with a real request (avoids hardcoding
+    // the loopback IP form the server sees, which varies by dual-stack).
+    const limiter = new IpSessionLimiter(1);
+    const { app } = buildApp({ ipLimiter: limiter });
+
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const first = await fetch(`${url}/sse`);
+    expect(first.status).toBe(200);
+
+    const res = await fetch(`${url}/sse`);
+    expect(res.status).toBe(429);
+    await first.body?.cancel();
+    await res.body?.cancel();
+
+    const warnCalls = consoleWarnSpy.mock.calls.map((c) => c[0]);
+    const rateLog = warnCalls.find(
+      (m) =>
+        typeof m === "string" &&
+        m.includes("IP rate limit exceeded") &&
+        m.includes("rejecting SSE"),
+    );
+    expect(rateLog).toBeDefined();
+    // /mcp format: `... for ${ip} (${currentCount}/${limit}), rejecting ...`
+    expect(rateLog as string).toMatch(/\(\d+\/\d+\)/);
+
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("cleans up the limiter counter when workspaceManager.ensureSession throws", async () => {
+    // Build a workspace manager stub whose ensureSession() throws. If the
+    // handler doesn't install cleanup before ensureSession, the limiter
+    // counter leaks permanently. This test drives the fix: either install
+    // cleanup first OR catch and undo.
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const limiter = new IpSessionLimiter(2);
+    const workspaceManager = {
+      ensureSession: vi.fn(() => {
+        throw new Error("workspace-boom");
+      }),
+      cleanup: vi.fn(),
+      cleanupAll: vi.fn(),
+    };
+    const { app } = buildApp({
+      ipLimiter: limiter,
+      workspaceManager,
+    });
+
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    // Attempt the session. The server-side handler should throw, clean up,
+    // and return 500 (headers not yet sent) — key assertion: limiter counter
+    // must be zero after the failure.
+    const res = await fetch(`${url}/sse`).catch((err) => ({
+      ok: false,
+      status: 0,
+      err,
+    }));
+    // The response may be 500 (caught in the outer try) or the stream may
+    // end abruptly depending on when the error lands; either way we care
+    // about the limiter state afterwards.
+    if ("body" in res && res.body) {
+      await (res.body as ReadableStream).cancel().catch(() => {});
+    }
+
+    // Wait a tick for the cleanup chain to settle.
+    await new Promise((r) => setTimeout(r, 20));
+
+    // Dual-stack loopback can surface the socket peer as either "127.0.0.1"
+    // or "::ffff:127.0.0.1" depending on how Node bound the listener. A
+    // hardcoded assertion on one form would pass vacuously if the limiter
+    // actually keyed under the other form — leaving the real leak invisible.
+    // Asserting both covers either resolution path.
+    expect(limiter.getSessionCount("127.0.0.1")).toBe(0);
+    expect(limiter.getSessionCount("::ffff:127.0.0.1")).toBe(0);
+    consoleErrSpy.mockRestore();
+  });
+
+  it("reaper invokes ipLimiter.remove and workspaceManager.cleanup for reaped SSE sessions (ownership fix)", async () => {
+    // R2 finding 1: the reaper schedules transport.close() via microtask, then
+    // synchronously deletes sseTransports[sid] BEFORE close runs. When onclose
+    // eventually fires, the handler's cleanup() guard (`if sseTransports[sid]`)
+    // sees the entry already gone and bails — skipping ipLimiter.remove and
+    // workspaceManager.cleanup permanently. The reaper must own cleanup for
+    // the server-timeout path.
+    const { reapIdleSseSessions } = await import("../sse-handlers.js");
+
+    const limiter = new IpSessionLimiter(5);
+    // Manually insert a counter entry so we can observe reaper-driven cleanup.
+    limiter.tryAdd("203.0.113.1", "stale-sid");
+    expect(limiter.getSessionCount("203.0.113.1")).toBe(1);
+
+    const workspaceCleanup = vi.fn();
+    const workspaceManager = {
+      ensureSession: vi.fn(),
+      cleanup: workspaceCleanup,
+      cleanupAll: vi.fn(),
+    };
+
+    const sseTransports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+
+    // transport.close resolves asynchronously so the race is observable.
+    sseTransports["stale-sid"] = {
+      close: () => new Promise((resolve) => setTimeout(resolve, 5)),
+    };
+    sessionLastActivity["stale-sid"] = Date.now() - 10 * 60 * 1000;
+
+    const reaped = reapIdleSseSessions({
+      sseTransports: sseTransports as unknown as Parameters<
+        typeof reapIdleSseSessions
+      >[0]["sseTransports"],
+      sessionLastActivity,
+      ttlMs: 5 * 60 * 1000,
+      ipLimiter: limiter,
+      workspaceManager:
+        workspaceManager as unknown as Parameters<
+          typeof reapIdleSseSessions
+        >[0]["workspaceManager"],
+    });
+
+    expect(reaped).toEqual(["stale-sid"]);
+    // The reaper must inline-clean counters + workspace BEFORE returning, even
+    // though transport.close() is async. Otherwise the cleanup leaks.
+    expect(limiter.getSessionCount("203.0.113.1")).toBe(0);
+    expect(workspaceCleanup).toHaveBeenCalledWith("stale-sid");
+
+    // Let the async close resolve to avoid open-handle warnings.
+    await new Promise((r) => setTimeout(r, 20));
+  });
+
+  it("cleanup closure re-resolves workspaceManager getter lazily (late-binding fix)", async () => {
+    // R2 finding 2: sseGet resolves the getters ONCE at the top of the handler
+    // and the cleanup closure captures those locals. If the workspaceManager
+    // instance gets swapped out between request-entry and session-close
+    // (config reload, late startServer() binding, etc.), cleanup should use
+    // the CURRENT instance — otherwise it routes cleanup to a stale manager
+    // whose session map has nothing to clean, leaking real workspace state.
+    const limiter = new IpSessionLimiter(5);
+
+    const staleCleanup = vi.fn();
+    const freshCleanup = vi.fn();
+    let current:
+      | {
+          ensureSession: () => void;
+          cleanup: (sid: string) => void;
+          cleanupAll: () => void;
+        }
+      | undefined = {
+      ensureSession: () => {},
+      cleanup: staleCleanup,
+      cleanupAll: () => {},
+    };
+
+    const { app, deps } = buildApp({
+      ipLimiter: limiter,
+      // Getter returns the CURRENT workspace instance. The handler's top-of-
+      // function resolve snapshots the initial one; cleanup's re-resolve
+      // must see whatever `current` points at when close fires. The dep
+      // type admits a getter form directly, so no cast needed.
+      workspaceManager: () => current,
+    });
+
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+    expect(deps.sseTransports[sid]).toBeDefined();
+
+    // Swap the "current" workspace manager AFTER handler entry but BEFORE
+    // close. A stale capture would still call staleCleanup; a lazy re-resolve
+    // routes to freshCleanup.
+    current = {
+      ensureSession: () => {},
+      cleanup: freshCleanup,
+      cleanupAll: () => {},
+    };
+
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(freshCleanup).toHaveBeenCalledWith(sid);
+    expect(staleCleanup).not.toHaveBeenCalled();
+  });
+
+  it("POST /messages returns a descriptive reason + log for missing sessionId", async () => {
+    // R2 finding 3: /messages 404 branches previously returned no reason code
+    // and emitted no log. Operators debugging reaper/client races couldn't
+    // tell "client never sent a sessionId" from "session was reaped".
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const { app } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/messages`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("missing-session-id");
+
+    const logged = consoleWarnSpy.mock.calls.some((call) =>
+      call.some(
+        (arg) =>
+          typeof arg === "string" &&
+          arg.includes("missing-session-id") &&
+          arg.includes("/messages"),
+      ),
+    );
+    expect(logged).toBe(true);
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("POST /messages returns a descriptive reason + log for unknown sessionId", async () => {
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const { app } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const bogus = randomUUID();
+    const res = await fetch(`${url}/messages?sessionId=${bogus}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "ping" }),
+    });
+
+    expect(res.status).toBe(404);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.reason).toBe("unknown-session-id");
+
+    const logged = consoleWarnSpy.mock.calls.some((call) =>
+      call.some(
+        (arg) =>
+          typeof arg === "string" &&
+          arg.includes("unknown-session-id") &&
+          arg.includes(bogus.slice(0, 8)),
+      ),
+    );
+    expect(logged).toBe(true);
+    consoleWarnSpy.mockRestore();
+  });
+
+  it("429 Retry-After header is clamped to the same ceiling as the JSON body", async () => {
+    // R2 finding 4: oversized retryAfterSeconds (e.g. SESSION_TTL of 30
+    // minutes) must be clamped to the shared ceiling (300s) BEFORE being
+    // written to the header. The JSON body clamps via buildRateLimitPayload;
+    // the header was previously unclamped, so clients saw conflicting
+    // hints (header: 1800, body: 300).
+    const limiter = new IpSessionLimiter(1);
+    const { app } = buildApp({
+      ipLimiter: limiter,
+      rateLimitRetryAfterSeconds: 1800,
+    });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const first = await fetch(`${url}/sse`);
+    expect(first.status).toBe(200);
+
+    const second = await fetch(`${url}/sse`);
+    expect(second.status).toBe(429);
+    expect(second.headers.get("retry-after")).toBe("300");
+    const body = (await second.json()) as Record<string, unknown>;
+    expect(body.retryAfterSeconds).toBe(300);
+
+    await first.body?.cancel();
+  });
+
+  it("cleanup is per-step resilient: a failing ipLimiter.remove still lets workspace.cleanup run", async () => {
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const limiter = new IpSessionLimiter(5);
+    const workspaceCleanup = vi.fn();
+    const workspaceManager = {
+      ensureSession: vi.fn(),
+      cleanup: workspaceCleanup,
+      cleanupAll: vi.fn(),
+    };
+
+    // Wrap limiter.remove so it throws once. Per-step try/catch in cleanup
+    // must prevent this throw from skipping workspaceManager.cleanup.
+    const origRemove = limiter.remove.bind(limiter);
+    vi.spyOn(limiter, "remove").mockImplementation((sid: string) => {
+      origRemove(sid);
+      throw new Error("limiter-remove-boom");
+    });
+
+    const { app, deps } = buildApp({
+      ipLimiter: limiter,
+      workspaceManager,
+    });
+
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+    expect(deps.sseTransports[sid]).toBeDefined();
+
+    await reader.cancel();
+
+    // Wait for server-side close → cleanup.
+    await new Promise((r) => setTimeout(r, 60));
+
+    // The throw inside limiter.remove must not have skipped workspace.cleanup.
+    expect(workspaceCleanup).toHaveBeenCalledWith(sid);
+    consoleErrSpy.mockRestore();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Round 3 — sessionStateManager plumbing, pre-register-before-onclose
+// ordering, and disconnect-before-setup recovery.
+// ---------------------------------------------------------------------------
+
+describe("SSE transport hardening (Round 3)", () => {
+  let server: Server | undefined;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    await closeServer(server);
+    server = undefined;
+  });
+
+  it("SSE cleanup closure invokes sessionStateManager.cleanup when the client disconnects", async () => {
+    // R3 finding 2: /mcp cleans up sessionStateManager on transport.onclose
+    // but the SSE handler did not. SSE sessions using bash tools with
+    // `session_state: true` leaked per-session shell state indefinitely
+    // until server restart. The handler's client-disconnect cleanup closure
+    // must call sessionStateManager.cleanup(sid).
+    const sessionStateCleanup = vi.fn();
+    const { app, deps } = buildApp({
+      sessionStateManager: { cleanup: sessionStateCleanup },
+    });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+    expect(deps.sseTransports[sid]).toBeDefined();
+
+    // Close the client side to trigger the handler's cleanup closure.
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(sessionStateCleanup).toHaveBeenCalledWith(sid);
+  });
+
+  it("SSE cleanup closure re-resolves sessionStateManager lazily (late-binding fix)", async () => {
+    // Same late-binding concern as workspaceManager: cleanup must re-resolve
+    // the sessionStateManager getter when close fires, not snapshot it at
+    // handler entry. server.ts late-binds the sessionStateManager instance
+    // the same way it does workspaceManager.
+    const staleCleanup = vi.fn();
+    const freshCleanup = vi.fn();
+    let current: { cleanup: (sid: string) => void } | undefined = {
+      cleanup: staleCleanup,
+    };
+    const { app, deps } = buildApp({
+      sessionStateManager: () => current,
+    });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+    expect(deps.sseTransports[sid]).toBeDefined();
+
+    // Swap the "current" manager AFTER handler entry, BEFORE close.
+    current = { cleanup: freshCleanup };
+
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(freshCleanup).toHaveBeenCalledWith(sid);
+    expect(staleCleanup).not.toHaveBeenCalled();
+  });
+
+  it("sessionStateManager.cleanup throw does not skip ipLimiter.remove or workspaceManager.cleanup", async () => {
+    // Per-step try/catch: a failing sessionStateManager.cleanup must not
+    // short-circuit the rest of the cleanup chain, mirroring the /mcp
+    // handler's behavior and the existing Round 2 assertion for
+    // ipLimiter.remove throwing.
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const limiter = new IpSessionLimiter(5);
+    const workspaceCleanup = vi.fn();
+    const workspaceManager = {
+      ensureSession: vi.fn(),
+      cleanup: workspaceCleanup,
+      cleanupAll: vi.fn(),
+    };
+    const sessionStateManager = {
+      cleanup: vi.fn(() => {
+        throw new Error("session-state-boom");
+      }),
+    };
+    const { app, deps } = buildApp({
+      ipLimiter: limiter,
+      workspaceManager,
+      sessionStateManager,
+    });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+    expect(deps.sseTransports[sid]).toBeDefined();
+
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 60));
+
+    expect(sessionStateManager.cleanup).toHaveBeenCalledWith(sid);
+    // limiter.remove would already have run before sessionState.cleanup in
+    // the chain, but workspaceManager.cleanup runs AFTER session state in
+    // our ordering — so asserting workspaceManager is the important check.
+    // Actually in current ordering sessionState is last; both earlier steps
+    // must still have run. Check both.
+    expect(workspaceCleanup).toHaveBeenCalledWith(sid);
+    expect(limiter.getSessionCount("127.0.0.1")).toBe(0);
+    expect(limiter.getSessionCount("::ffff:127.0.0.1")).toBe(0);
+
+    consoleErrSpy.mockRestore();
+  });
+
+  it("reaper invokes sessionStateManager.cleanup for reaped SSE sessions", async () => {
+    // R3 finding 2: the reaper must own sessionState cleanup for the
+    // server-timeout path, same as it owns ipLimiter.remove and
+    // workspaceManager.cleanup. Without this, any SSE session that's idle-
+    // reaped while holding bash shell state leaks that state forever.
+    const { reapIdleSseSessions } = await import("../sse-handlers.js");
+
+    const sessionStateCleanup = vi.fn();
+    const sseTransports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+
+    sseTransports["stale-sid"] = {
+      close: async () => {},
+    };
+    sessionLastActivity["stale-sid"] = Date.now() - 10 * 60 * 1000;
+
+    const reaped = reapIdleSseSessions({
+      sseTransports: sseTransports as unknown as Parameters<
+        typeof reapIdleSseSessions
+      >[0]["sseTransports"],
+      sessionLastActivity,
+      ttlMs: 5 * 60 * 1000,
+      sessionStateManager: { cleanup: sessionStateCleanup },
+    });
+
+    expect(reaped).toEqual(["stale-sid"]);
+    expect(sessionStateCleanup).toHaveBeenCalledWith("stale-sid");
+
+    // Let the scheduled close microtask resolve.
+    await new Promise((r) => setTimeout(r, 10));
+  });
+
+  it("reaper continues cleanup chain when sessionStateManager.cleanup throws", async () => {
+    const { reapIdleSseSessions } = await import("../sse-handlers.js");
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const limiterRemove = vi.fn();
+    const workspaceCleanup = vi.fn();
+    const sessionStateCleanup = vi.fn(() => {
+      throw new Error("session-state-boom");
+    });
+
+    const sseTransports: Record<string, { close: () => Promise<void> }> = {};
+    const sessionLastActivity: Record<string, number> = {};
+
+    sseTransports["stale-sid"] = {
+      close: async () => {},
+    };
+    sessionLastActivity["stale-sid"] = Date.now() - 10 * 60 * 1000;
+
+    reapIdleSseSessions({
+      sseTransports: sseTransports as unknown as Parameters<
+        typeof reapIdleSseSessions
+      >[0]["sseTransports"],
+      sessionLastActivity,
+      ttlMs: 5 * 60 * 1000,
+      ipLimiter: { remove: limiterRemove },
+      workspaceManager: { cleanup: workspaceCleanup },
+      sessionStateManager: { cleanup: sessionStateCleanup },
+    });
+
+    // All three must have been attempted despite the throw in one of them.
+    expect(limiterRemove).toHaveBeenCalledWith("stale-sid");
+    expect(workspaceCleanup).toHaveBeenCalledWith("stale-sid");
+    expect(sessionStateCleanup).toHaveBeenCalledWith("stale-sid");
+
+    await new Promise((r) => setTimeout(r, 10));
+    consoleErrSpy.mockRestore();
+  });
+
+  it("aborts early when res is already destroyed before tryAdd runs (no counter/workspace leak)", async () => {
+    // R3 finding 1: if the client disconnects in the narrow window between
+    // `new SSEServerTransport(...)` and `res.on("close", cleanup)`, the
+    // res 'close' event has already passed — a listener registered AFTER
+    // the event will never fire. Without an active post-wiring check, the
+    // handler would proceed to ipLimiter.tryAdd + workspaceManager.ensureSession
+    // against a dead response and leak both counters permanently.
+    //
+    // Drive the handler directly with a pre-destroyed mock response. Avoids
+    // racing the real socket close event and makes the leak window
+    // deterministic.
+    const limiter = new IpSessionLimiter(5);
+    const ensureSession = vi.fn();
+    const workspaceCleanup = vi.fn();
+    const tryAddSpy = vi.spyOn(limiter, "tryAdd");
+
+    const { getHandler } = createSseHandlers({
+      sseTransports: {},
+      sessionLastActivity: {},
+      ipLimiter: limiter,
+      workspaceManager: { ensureSession, cleanup: workspaceCleanup },
+      createMcpServer: () =>
+        ({
+          connect: vi.fn(async () => {}),
+        }) as unknown as ReturnType<SseHandlerDeps["createMcpServer"]>,
+    });
+    // The handler array is [bearerMiddleware, sseGet]; we want to invoke
+    // sseGet directly (bypass auth) since the mock req isn't fully formed.
+    const sseGet = getHandler[1] as (
+      req: unknown,
+      res: unknown,
+      next: unknown,
+    ) => Promise<void>;
+
+    // Minimal Request stub — enough for clientIp + transport constructor.
+    const req = {
+      ip: "127.0.0.1",
+      socket: { remoteAddress: "127.0.0.1" },
+      connection: { remoteAddress: "127.0.0.1" },
+      headers: {},
+      query: {},
+      on: vi.fn(),
+      once: vi.fn(),
+    };
+
+    // Response stub that reports destroyed=true post-construction. The
+    // SSEServerTransport constructor inspects `res` but doesn't fail fast
+    // on a destroyed socket; it's the handler's job to observe the state.
+    // Also capture writes/statuses to prove no 200/500 payload lands.
+    const closeListeners: Array<() => void> = [];
+    const res = {
+      destroyed: true,
+      writableEnded: false,
+      headersSent: false,
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+      setHeader: vi.fn(),
+      writeHead: vi.fn().mockReturnThis(),
+      write: vi.fn(),
+      end: vi.fn(),
+      on: (event: string, cb: () => void) => {
+        if (event === "close") closeListeners.push(cb);
+        return res;
+      },
+      once: vi.fn(),
+      emit: vi.fn(),
+    };
+
+    await sseGet(req, res, undefined);
+
+    // The early-abort path must skip tryAdd and ensureSession entirely.
+    expect(tryAddSpy).not.toHaveBeenCalled();
+    expect(ensureSession).not.toHaveBeenCalled();
+    // The counter must be zero — no leak from a session we never owned.
+    expect(limiter.getSessionCount("127.0.0.1")).toBe(0);
+    expect(limiter.getSessionCount("::ffff:127.0.0.1")).toBe(0);
+  });
+
+  it("registers sessionId in sseTransports BEFORE wiring res.on('close') — disconnect mid-setup still tears down", async () => {
+    // R3 finding 1 (continued): the ordering fix. Even without an explicit
+    // post-wiring destroyed check, the handler should pre-register into
+    // sseTransports so the cleanup closure's guard passes when onclose
+    // eventually fires. If someone reverted the ordering and put
+    // `res.on("close", cleanup)` BEFORE `sseTransports[sid] = transport`,
+    // a synchronous close firing between the two would no-op cleanup and
+    // leak a counter entry.
+    //
+    // Assert the invariant via the live handler: after a successful session
+    // the sessionId is present in the map at the moment onclose fires.
+    // We observe this by wrapping cleanup indirectly — assert that after
+    // the stream opens, the map entry exists.
+    const { app, deps } = buildApp();
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`, {
+      headers: { Accept: "text/event-stream" },
+    });
+    const reader = res.body!.getReader();
+    const decoder = new TextDecoder();
+    let buffer = "";
+    while (!buffer.includes("event: endpoint")) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+    }
+    const sid = buffer.match(/sessionId=([0-9a-f-]+)/)![1];
+
+    // Invariant: the session is registered in the map by the time the
+    // endpoint event is emitted (which happens inside server.connect()
+    // AFTER the ordering-sensitive pre-registration window).
+    expect(deps.sseTransports[sid]).toBeDefined();
+
+    await reader.cancel();
+    await new Promise((r) => setTimeout(r, 60));
+
+    // And it's torn down after close — proving the onclose guard saw the
+    // entry and ran.
+    expect(deps.sseTransports[sid]).toBeUndefined();
+  });
+});
+
+describe("SSE transport hardening (Round 4)", () => {
+  let server: Server | undefined;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleLogSpy.mockRestore();
+    await closeServer(server);
+    server = undefined;
+  });
+
+  it("/sse race-fallback calls transport.close() on the rejected transport", async () => {
+    // R4 finding 1: /sse race-fallback wrote a 429 body and deleted map
+    // entries but never called transport.close(). The SDK's
+    // SSEServerTransport may hold timers, listeners, and file handles — all
+    // leaked per rejected race. Mirror /mcp race-fallback: schedule
+    // transport.close() on a microtask and log any async rejection.
+    //
+    // To exercise the race path deterministically, inject a limiter whose
+    // pre-check passes (under cap) but whose tryAdd() returns false — this
+    // is the race window between pre-check and atomic tryAdd.
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const raceLimiter = {
+      isAllowlisted: vi.fn().mockReturnValue(false),
+      getSessionCount: vi.fn().mockReturnValue(0),
+      getMax: vi.fn().mockReturnValue(5),
+      // tryAdd returns false → triggers race-fallback.
+      tryAdd: vi.fn().mockReturnValue(false),
+      remove: vi.fn(),
+    } as unknown as IpSessionLimiter;
+
+    // Spy on SSEServerTransport.close via prototype — every transport
+    // constructed in-handler will share this prototype method.
+    const { SSEServerTransport } = await import(
+      "@modelcontextprotocol/sdk/server/sse.js"
+    );
+    const closeSpy = vi
+      .spyOn(SSEServerTransport.prototype, "close")
+      .mockImplementation(async function () {
+        // No-op: the real close() writes to res which may already be ended.
+      });
+
+    const { app, deps } = buildApp({ ipLimiter: raceLimiter });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`);
+    expect(res.status).toBe(429);
+    await res.body?.cancel();
+
+    // Wait a tick so the microtask-scheduled close() runs.
+    await new Promise((r) => setTimeout(r, 30));
+
+    // The transport constructed in-handler must have had close() called
+    // exactly once as part of the race-fallback teardown.
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+
+    // Map entries must be cleared (they were registered pre-race-fallback).
+    expect(Object.keys(deps.sseTransports).length).toBe(0);
+    expect(Object.keys(deps.sessionLastActivity).length).toBe(0);
+
+    closeSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrSpy.mockRestore();
+  });
+
+  it("/sse race-fallback logs async transport.close() rejections instead of leaving them unhandled", async () => {
+    // Mirrors the /mcp race-fallback: transport.close() is scheduled on a
+    // microtask with a .catch() handler so an async rejection lands in
+    // console.error instead of surfacing as an unhandled rejection.
+    const consoleWarnSpy = vi
+      .spyOn(console, "warn")
+      .mockImplementation(() => {});
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const raceLimiter = {
+      isAllowlisted: vi.fn().mockReturnValue(false),
+      getSessionCount: vi.fn().mockReturnValue(0),
+      getMax: vi.fn().mockReturnValue(5),
+      tryAdd: vi.fn().mockReturnValue(false),
+      remove: vi.fn(),
+    } as unknown as IpSessionLimiter;
+
+    const { SSEServerTransport } = await import(
+      "@modelcontextprotocol/sdk/server/sse.js"
+    );
+    const closeSpy = vi
+      .spyOn(SSEServerTransport.prototype, "close")
+      .mockImplementation(async function () {
+        throw new Error("close-boom");
+      });
+
+    const { app } = buildApp({ ipLimiter: raceLimiter });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`);
+    expect(res.status).toBe(429);
+    await res.body?.cancel();
+
+    // Wait for microtask + async rejection handler to fire.
+    await new Promise((r) => setTimeout(r, 30));
+
+    const errCalls = consoleErrSpy.mock.calls.map((c) => String(c[0]));
+    const hit = errCalls.find(
+      (m) => m.includes("SSE race-fallback") && m.includes("transport.close"),
+    );
+    expect(hit).toBeDefined();
+
+    closeSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+    consoleErrSpy.mockRestore();
+  });
+
+  it("/sse ensureSession throw: full rollback (counters, maps, transport.close, 503)", async () => {
+    // R4 finding 2: handler must wrap workspaceManager.ensureSession in
+    // try/catch and run the full rollback chain when it throws —
+    // ipLimiter.remove + sessionStateManager.cleanup + map deletion +
+    // transport.close + 503 JSON response. Matches handleSessionInitAccept
+    // semantics in server.ts.
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+
+    const limiter = new IpSessionLimiter(3);
+    const workspaceManager = {
+      ensureSession: vi.fn(() => {
+        throw new Error("ensure-boom");
+      }),
+      cleanup: vi.fn(),
+    };
+    const sessionStateCleanup = vi.fn();
+
+    const { SSEServerTransport } = await import(
+      "@modelcontextprotocol/sdk/server/sse.js"
+    );
+    const closeSpy = vi
+      .spyOn(SSEServerTransport.prototype, "close")
+      .mockImplementation(async function () {});
+
+    const { app, deps } = buildApp({
+      ipLimiter: limiter,
+      workspaceManager,
+      sessionStateManager: { cleanup: sessionStateCleanup },
+    });
+    server = await startServer(app);
+    const url = baseUrlOf(server);
+
+    const res = await fetch(`${url}/sse`);
+    expect(res.status).toBe(503);
+    const body = (await res.json()) as Record<string, unknown>;
+    expect(body.error).toBeDefined();
+
+    // Let async rollback settle.
+    await new Promise((r) => setTimeout(r, 30));
+
+    // Limiter counter is 0 in both normalized forms (dual-stack loopback).
+    expect(limiter.getSessionCount("127.0.0.1")).toBe(0);
+    expect(limiter.getSessionCount("::ffff:127.0.0.1")).toBe(0);
+    // Map entries cleared.
+    expect(Object.keys(deps.sseTransports).length).toBe(0);
+    expect(Object.keys(deps.sessionLastActivity).length).toBe(0);
+    // sessionStateManager.cleanup called as part of rollback.
+    expect(sessionStateCleanup).toHaveBeenCalledTimes(1);
+    // transport.close called to drop transport-held resources.
+    expect(closeSpy).toHaveBeenCalledTimes(1);
+    // workspaceManager.cleanup was NOT called during rollback (symmetric to
+    // handleSessionInitAccept: ensureSession-throw means the workspace
+    // didn't acquire state worth cleaning; we only roll back ipLimiter +
+    // sessionStateManager + transport).
+    expect(workspaceManager.cleanup).not.toHaveBeenCalled();
+
+    closeSpy.mockRestore();
+    consoleErrSpy.mockRestore();
+  });
+
+  it("disconnect between registration and tryAdd: cleanup.remove tolerates unknown sid", async () => {
+    // R4 finding 3: handler registers sseTransports[sid] BEFORE calling
+    // ipLimiter.tryAdd. If the client disconnects in that window, the
+    // res.on('close') cleanup closure fires with a populated map entry and
+    // calls ipLimiter.remove(sid) — but tryAdd never ran, so the sid was
+    // never associated with an IP. The limiter's remove() must no-op on an
+    // unknown sid rather than throw, and the counter must remain consistent.
+    const limiter = new IpSessionLimiter(3);
+
+    // Prime the limiter for a different, legitimately-added sid so we can
+    // assert the cleanup path for the unknown sid doesn't disturb it.
+    limiter.tryAdd("203.0.113.99", "some-other-sid");
+    expect(limiter.getSessionCount("203.0.113.99")).toBe(1);
+
+    // The unknown sid path — this is what the cleanup closure hits when
+    // the disconnect fires post-registration but pre-tryAdd.
+    expect(() => limiter.remove("never-added-sid")).not.toThrow();
+
+    // Counter for the legitimately-added sid must not have been disturbed.
+    expect(limiter.getSessionCount("203.0.113.99")).toBe(1);
   });
 });

--- a/src/__tests__/sse-transport.test.ts
+++ b/src/__tests__/sse-transport.test.ts
@@ -692,10 +692,9 @@ describe("SSE transport hardening (Round 2)", () => {
       sessionLastActivity,
       ttlMs: 5 * 60 * 1000,
       ipLimiter: limiter,
-      workspaceManager:
-        workspaceManager as unknown as Parameters<
-          typeof reapIdleSseSessions
-        >[0]["workspaceManager"],
+      workspaceManager: workspaceManager as unknown as Parameters<
+        typeof reapIdleSseSessions
+      >[0]["workspaceManager"],
     });
 
     expect(reaped).toEqual(["stale-sid"]);
@@ -1304,9 +1303,8 @@ describe("SSE transport hardening (Round 4)", () => {
 
     // Spy on SSEServerTransport.close via prototype — every transport
     // constructed in-handler will share this prototype method.
-    const { SSEServerTransport } = await import(
-      "@modelcontextprotocol/sdk/server/sse.js"
-    );
+    const { SSEServerTransport } =
+      await import("@modelcontextprotocol/sdk/server/sse.js");
     const closeSpy = vi
       .spyOn(SSEServerTransport.prototype, "close")
       .mockImplementation(async function () {
@@ -1356,9 +1354,8 @@ describe("SSE transport hardening (Round 4)", () => {
       remove: vi.fn(),
     } as unknown as IpSessionLimiter;
 
-    const { SSEServerTransport } = await import(
-      "@modelcontextprotocol/sdk/server/sse.js"
-    );
+    const { SSEServerTransport } =
+      await import("@modelcontextprotocol/sdk/server/sse.js");
     const closeSpy = vi
       .spyOn(SSEServerTransport.prototype, "close")
       .mockImplementation(async function () {
@@ -1406,9 +1403,8 @@ describe("SSE transport hardening (Round 4)", () => {
     };
     const sessionStateCleanup = vi.fn();
 
-    const { SSEServerTransport } = await import(
-      "@modelcontextprotocol/sdk/server/sse.js"
-    );
+    const { SSEServerTransport } =
+      await import("@modelcontextprotocol/sdk/server/sse.js");
     const closeSpy = vi
       .spyOn(SSEServerTransport.prototype, "close")
       .mockImplementation(async function () {});

--- a/src/__tests__/tool-config.test.ts
+++ b/src/__tests__/tool-config.test.ts
@@ -62,7 +62,14 @@ describe("CollectToolConfigSchema", () => {
         rating: { type: "enum" as const, values: [], required: true },
       },
     };
-    expect(CollectToolConfigSchema.safeParse(config).success).toBe(false);
+    const result = CollectToolConfigSchema.safeParse(config);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = result.error.issues.map((i) => i.message);
+      expect(
+        messages.some((m) => m.includes("non-empty values array")),
+      ).toBe(true);
+    }
   });
 
   it("rejects unknown field type", () => {
@@ -397,6 +404,131 @@ describe("ServerConfigSchema", () => {
     };
     const result = ServerConfigSchema.safeParse(config);
     expect(result.success).toBe(false);
+  });
+
+  describe("server.allowlist", () => {
+    const baseTools = [
+      {
+        name: "explore",
+        type: "bash" as const,
+        description: "Explore",
+        sources: ["docs"],
+      },
+    ];
+
+    it("accepts a plain-IP allowlist entry", () => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          allowlist: ["160.79.106.35"],
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts a CIDR allowlist entry", () => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          allowlist: ["160.79.106.0/24", "2001:db8::/32"],
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+    });
+
+    it("accepts an empty allowlist", () => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          allowlist: [],
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+    });
+
+    it("rejects a malformed allowlist entry (not an IP or CIDR)", () => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          allowlist: ["not-an-ip"],
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an allowlist with an invalid CIDR suffix", () => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          allowlist: ["10.0.0.0/99"],
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    // Edge cases in allowlist-entry validation. The schema has a defensive
+    // regex pre-check (in src/types.ts) plus ipaddr.parseCIDR / ipaddr.parse
+    // as the semantic validator. Each of these entries must be rejected —
+    // if any start passing, either the regex or ipaddr.js has drifted and
+    // the allowlist could be bypassed.
+    it.each([
+      ["negative suffix", "10.0.0.0/-1"],
+      ["non-numeric suffix", "10.0.0.0/abc"],
+      ["empty suffix", "10.0.0.0/"],
+      ["leading whitespace", " 10.0.0.1"],
+      ["trailing whitespace", "10.0.0.0/24 "],
+      ["internal whitespace", "10.0.0. 1"],
+      ["invalid characters (SQL-ish)", "10.0.0.1;DROP"],
+      ["invalid characters (letters in octet)", "10.0.0.1abc"],
+      ["IPv6 out-of-range suffix", "2001:db8::/129"],
+      // Schema-level prefix-length bounds. These MUST be rejected at the
+      // schema boundary (by the regex pre-check), not diffused through
+      // ipaddr.js with a vaguer error. An operator typing "/999" should see a
+      // CIDR-range-out-of-bounds style error, not a generic parse failure.
+      ["IPv4 prefix above 32", "10.0.0.0/33"],
+      ["IPv6 prefix at 129", "::1/129"],
+      ["absurdly large IPv4 prefix", "0.0.0.0/999"],
+      ["absurdly large IPv6 prefix", "::1/999"],
+    ])("rejects an allowlist with %s (%s)", (_label, entry) => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          allowlist: [entry],
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects an allowlist that is not an array", () => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          allowlist: "160.79.106.35",
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
   });
 });
 

--- a/src/__tests__/tool-config.test.ts
+++ b/src/__tests__/tool-config.test.ts
@@ -66,9 +66,9 @@ describe("CollectToolConfigSchema", () => {
     expect(result.success).toBe(false);
     if (!result.success) {
       const messages = result.error.issues.map((i) => i.message);
-      expect(
-        messages.some((m) => m.includes("non-empty values array")),
-      ).toBe(true);
+      expect(messages.some((m) => m.includes("non-empty values array"))).toBe(
+        true,
+      );
     }
   });
 

--- a/src/ip-limiter.ts
+++ b/src/ip-limiter.ts
@@ -97,8 +97,7 @@ function parseAllowlist(entries: AllowlistEntry[]): ParsedAllowlist {
       if (entry.includes("/")) {
         const [addr, rawPrefix] = ipaddr.parseCIDR(entry);
         const wasMapped =
-          addr.kind() === "ipv6" &&
-          (addr as ipaddr.IPv6).isIPv4MappedAddress();
+          addr.kind() === "ipv6" && (addr as ipaddr.IPv6).isIPv4MappedAddress();
         const normalized = normalizeMapped(addr);
         let effectivePrefix = rawPrefix;
         // If we collapsed an IPv4-mapped IPv6 CIDR into IPv4 space, the
@@ -125,8 +124,12 @@ function parseAllowlist(entries: AllowlistEntry[]): ParsedAllowlist {
         let effective: ipaddr.IPv4 | ipaddr.IPv6 = normalized;
         const networkBase =
           normalized.kind() === "ipv4"
-            ? ipaddr.IPv4.networkAddressFromCIDR(`${normalized.toNormalizedString()}/${effectivePrefix}`)
-            : ipaddr.IPv6.networkAddressFromCIDR(`${normalized.toNormalizedString()}/${effectivePrefix}`);
+            ? ipaddr.IPv4.networkAddressFromCIDR(
+                `${normalized.toNormalizedString()}/${effectivePrefix}`,
+              )
+            : ipaddr.IPv6.networkAddressFromCIDR(
+                `${normalized.toNormalizedString()}/${effectivePrefix}`,
+              );
         if (
           normalized.toNormalizedString() !== networkBase.toNormalizedString()
         ) {

--- a/src/ip-limiter.ts
+++ b/src/ip-limiter.ts
@@ -1,29 +1,352 @@
+import ipaddr from "ipaddr.js";
+
+/**
+ * An allowlist entry — either a plain IPv4/IPv6 address ("160.79.106.35") or
+ * a CIDR range ("160.79.106.0/24", "2001:db8::/32").
+ */
+export type AllowlistEntry = string;
+
+/**
+ * Discriminated result of tryAddWithReason — distinguishes the per-IP cap
+ * being hit from a sid-collision across IPs. Callers that need to surface
+ * different 429 reasons (rate-limit exhaustion vs transport-level sid reuse)
+ * should switch on `reason`. The legacy boolean `tryAdd` wraps this and
+ * returns `result.ok`.
+ */
+export type TryAddResult =
+  | { ok: true }
+  | { ok: false; reason: "rate-limit" | "sid-collision" };
+
+export interface IpSessionLimiterOptions {
+  /**
+   * IPs / CIDR ranges that bypass the per-IP session cap entirely.
+   * Allowlisted sessions are NOT tracked in the per-IP counters.
+   *
+   * Use sparingly — intended for trusted crawlers (e.g. the Anthropic
+   * Assistant crawler 160.79.106.35) and internal health probes.
+   */
+  allowlist?: AllowlistEntry[];
+}
+
+type ParsedAllowlist = Array<
+  | { kind: "ip"; addr: ipaddr.IPv4 | ipaddr.IPv6 }
+  | { kind: "cidr"; range: [ipaddr.IPv4 | ipaddr.IPv6, number] }
+>;
+
+/**
+ * Normalize an IPv4-mapped IPv6 address (e.g. ::ffff:127.0.0.1) to its IPv4
+ * form. Node's dual-stack sockets often report remote addresses in the mapped
+ * form; operators naturally write either form in YAML. Collapse to IPv4 up
+ * front so family comparisons later are consistent.
+ */
+function normalizeMapped(
+  addr: ipaddr.IPv4 | ipaddr.IPv6,
+): ipaddr.IPv4 | ipaddr.IPv6 {
+  if (addr.kind() === "ipv6") {
+    const v6 = addr as ipaddr.IPv6;
+    if (v6.isIPv4MappedAddress()) return v6.toIPv4Address();
+  }
+  return addr;
+}
+
+/**
+ * Normalize an IP string to its canonical form for use as a Map key.
+ * Specifically collapses IPv4-mapped IPv6 (::ffff:a.b.c.d) to IPv4 so that
+ * dual-stack bindings which sometimes emit the mapped form and sometimes the
+ * plain form don't double-bucket the same physical client (which would
+ * silently double the per-IP cap).
+ *
+ * Non-parseable inputs (e.g. "unknown" from clientIp(), empty string) are
+ * returned unchanged to preserve existing fall-through bucketing.
+ */
+function normalizeIp(ip: string): string {
+  try {
+    const parsed = ipaddr.parse(ip);
+    return normalizeMapped(parsed).toNormalizedString();
+  } catch {
+    return ip;
+  }
+}
+
+/**
+ * Parse allowlist entries once at construction time. Invalid entries are
+ * logged and skipped — schema validation in src/types.ts is the primary
+ * gate, but we belt-and-suspenders here so a bad entry can't crash the
+ * limiter at request time.
+ *
+ * Correctness notes for operators reading this:
+ *   - IPv4 entries match IPv4 requests only and IPv6 entries match IPv6
+ *     requests only. `127.0.0.0/8` does NOT cover native `::1` requests;
+ *     if you want both loopback families, allowlist both `127.0.0.0/8` and
+ *     `::1/128` explicitly. We deliberately do NOT auto-expand — magic could
+ *     mask operator intent in non-loopback configurations.
+ *   - CIDR entries with non-zero host bits (e.g. `10.0.0.1/24`) are accepted
+ *     and normalized to the network address (`10.0.0.0/24`) with a warning.
+ *     The entry still matches the whole /24; the warning exists so an
+ *     operator who meant "just 10.0.0.1" can fix the typo.
+ *
+ * If EVERY provided entry fails to parse, escalate from per-entry warn to a
+ * summary error — an "allowlist effectively disabled" state silently turns
+ * the rate limiter on for IPs the operator explicitly meant to exempt.
+ */
+function parseAllowlist(entries: AllowlistEntry[]): ParsedAllowlist {
+  const out: ParsedAllowlist = [];
+  let invalidCount = 0;
+  for (const entry of entries) {
+    try {
+      if (entry.includes("/")) {
+        const [addr, rawPrefix] = ipaddr.parseCIDR(entry);
+        const wasMapped =
+          addr.kind() === "ipv6" &&
+          (addr as ipaddr.IPv6).isIPv4MappedAddress();
+        const normalized = normalizeMapped(addr);
+        let effectivePrefix = rawPrefix;
+        // If we collapsed an IPv4-mapped IPv6 CIDR into IPv4 space, the
+        // original prefix is measured in the 128-bit IPv6 space; the first
+        // 96 bits are the ::ffff:0:0 mapping prefix and the last 32 bits are
+        // the IPv4 portion. So "::ffff:10.0.0.0/104" = IPv4 10.0.0.0/8.
+        // Prefix <= 96 covers IPv6 space beyond the mapped block, which does
+        // NOT cleanly reduce to any IPv4 CIDR — reject with a warning.
+        if (wasMapped && normalized.kind() === "ipv4") {
+          if (rawPrefix < 96) {
+            console.warn(
+              `[mcp] ignoring allowlist entry ${JSON.stringify(entry)}: IPv4-mapped IPv6 CIDR prefix /${rawPrefix} is <96 and does not map cleanly to IPv4 space. If you want IPv4 coverage, use a plain IPv4 CIDR (e.g. 10.0.0.0/8).`,
+            );
+            invalidCount++;
+            continue;
+          }
+          effectivePrefix = rawPrefix - 96;
+        }
+        // Detect non-zero host bits. ipaddr.js doesn't reject e.g.
+        // "10.0.0.1/24", but an entry whose address isn't already the network
+        // base is almost always an operator typo. Normalize to the network
+        // address (so the match set still covers what the operator wrote) and
+        // warn so the misconfig is visible.
+        let effective: ipaddr.IPv4 | ipaddr.IPv6 = normalized;
+        const networkBase =
+          normalized.kind() === "ipv4"
+            ? ipaddr.IPv4.networkAddressFromCIDR(`${normalized.toNormalizedString()}/${effectivePrefix}`)
+            : ipaddr.IPv6.networkAddressFromCIDR(`${normalized.toNormalizedString()}/${effectivePrefix}`);
+        if (
+          normalized.toNormalizedString() !== networkBase.toNormalizedString()
+        ) {
+          console.warn(
+            `[mcp] allowlist entry ${JSON.stringify(entry)} has non-zero host bits — normalizing to ${networkBase.toNormalizedString()}/${effectivePrefix}. If you meant a single host, drop the /${effectivePrefix} suffix.`,
+          );
+          effective = networkBase;
+        }
+        out.push({ kind: "cidr", range: [effective, effectivePrefix] });
+      } else {
+        out.push({ kind: "ip", addr: normalizeMapped(ipaddr.parse(entry)) });
+      }
+    } catch (err) {
+      invalidCount++;
+      console.warn(
+        `[mcp] ignoring invalid allowlist entry ${JSON.stringify(entry)}: ${String(err)}`,
+      );
+    }
+  }
+  if (entries.length > 0 && out.length === 0) {
+    // All-invalid is a correctness cliff: the allowlist is now EMPTY, so
+    // traffic the operator meant to exempt (e.g. crawler IPs) will be
+    // rate-limited instead. Escalate to error — do not fail startup because
+    // the deployment may still want to come up with degraded protection.
+    console.error(
+      `[mcp] ERROR: ${invalidCount} of ${entries.length} allowlist entries failed to parse — allowlist is now EMPTY, rate limiting will apply to every IP including the ones you intended to allowlist. Check YAML config.`,
+    );
+  }
+  return out;
+}
+
+/** Info log is throttled per IP to avoid flooding on repeated bypasses. */
+const ALLOWLIST_LOG_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+/**
+ * Cap on the cooldown-log map size. Without a cap, a large CIDR allowlist
+ * (e.g. 10.0.0.0/8) combined with diverse source IPs could grow the map to
+ * millions of entries over the process lifetime.
+ */
+const ALLOWLIST_LOG_MAX_ENTRIES = 1000;
+
 export class IpSessionLimiter {
   private maxPerIp: number;
   private ipToSessions = new Map<string, Set<string>>();
   private sessionToIp = new Map<string, string>();
+  private allowlist: ParsedAllowlist;
+  private lastAllowlistLog = new Map<string, number>();
 
-  constructor(maxPerIp: number) {
+  constructor(maxPerIp: number, options: IpSessionLimiterOptions = {}) {
+    // Defense-in-depth: the upstream Zod schema already requires
+    // max_sessions_per_ip to be a positive integer, but IpSessionLimiter is a
+    // public export — a direct consumer could still hand in 0, a negative
+    // number, NaN, or a fraction. Accepting those silently turns tryAdd() into
+    // "reject every non-allowlisted session" (cap check `sessions.size >= 0`
+    // fails immediately) with no signal — indistinguishable from a DoS. Fail
+    // loudly at construction so misuse is visible.
+    if (!Number.isInteger(maxPerIp) || maxPerIp < 1) {
+      throw new TypeError(
+        `IpSessionLimiter: maxPerIp must be a positive integer (got ${String(maxPerIp)})`,
+      );
+    }
     this.maxPerIp = maxPerIp;
+    this.allowlist = parseAllowlist(options.allowlist ?? []);
   }
 
-  tryAdd(ip: string, sessionId: string): boolean {
-    const sessions = this.ipToSessions.get(ip);
-    if (sessions && sessions.size >= this.maxPerIp) return false;
+  /**
+   * True when the given IP matches any allowlist entry. Returns false for
+   * unknown / malformed inputs (e.g. "unknown" from clientIp()).
+   */
+  isAllowlisted(ip: string): boolean {
+    if (!ip || this.allowlist.length === 0) return false;
+    let parsed: ipaddr.IPv4 | ipaddr.IPv6;
+    try {
+      parsed = ipaddr.parse(ip);
+    } catch {
+      return false;
+    }
+    parsed = normalizeMapped(parsed);
+    for (const entry of this.allowlist) {
+      if (entry.kind === "ip") {
+        if (entry.addr.kind() !== parsed.kind()) continue;
+        if (entry.addr.toNormalizedString() === parsed.toNormalizedString()) {
+          return true;
+        }
+      } else {
+        const [rangeAddr] = entry.range;
+        if (rangeAddr.kind() !== parsed.kind()) continue;
+        // Branch on the narrowed family — both IPv4.match and IPv6.match
+        // accept the [addr, prefix] tuple; narrowing here keeps the call
+        // type-safe without any `as` intersection cast. The family-match
+        // guard above means .match() receives a same-family tuple and
+        // cannot throw in practice, so no defensive try/catch is warranted.
+        const matched =
+          parsed.kind() === "ipv4"
+            ? (parsed as ipaddr.IPv4).match(
+                entry.range as [ipaddr.IPv4, number],
+              )
+            : (parsed as ipaddr.IPv6).match(
+                entry.range as [ipaddr.IPv6, number],
+              );
+        if (matched) return true;
+      }
+    }
+    return false;
+  }
+
+  private maybeLogBypass(ip: string): void {
+    // Normalize at the map-key boundary so a dual-stack client alternating
+    // between "127.0.0.1" and "::ffff:127.0.0.1" shares ONE cooldown slot
+    // instead of two. Without this, the log throttle would be halved and the
+    // bounded LRU map would waste entries on what is really the same
+    // physical client.
+    const key = normalizeIp(ip);
+    const now = Date.now();
+    const last = this.lastAllowlistLog.get(key) ?? 0;
+
+    // Check cooldown FIRST. The 99% hot path for high-volume allowlisted
+    // traffic (a crawler hammering the endpoint) is "already logged
+    // recently, nothing to do" — that path must NOT pay the O(n) sweep.
+    if (now - last < ALLOWLIST_LOG_COOLDOWN_MS) return;
+
+    // About to actually log — now bound the map size. Sweep old entries and
+    // only if the sweep didn't free space, drop the LRU-oldest entry.
+    if (this.lastAllowlistLog.size >= ALLOWLIST_LOG_MAX_ENTRIES) {
+      const cutoff = now - ALLOWLIST_LOG_COOLDOWN_MS * 2;
+      for (const [k, v] of this.lastAllowlistLog) {
+        if (v < cutoff) this.lastAllowlistLog.delete(k);
+      }
+      if (this.lastAllowlistLog.size >= ALLOWLIST_LOG_MAX_ENTRIES) {
+        const oldest = this.lastAllowlistLog.keys().next().value;
+        if (oldest !== undefined) this.lastAllowlistLog.delete(oldest);
+      }
+    }
+
+    // True-LRU insertion: Map.set on an existing key does NOT reinsert at
+    // the tail, so a frequently-touched entry would get evicted as cold
+    // traffic churns in. Delete-then-set moves this entry to the tail, so
+    // eviction (oldest key) really is least-recently-used.
+    this.lastAllowlistLog.delete(key);
+    this.lastAllowlistLog.set(key, now);
+    console.info(`[mcp] IP ${key} on allowlist, bypassing session limit`);
+  }
+
+  /**
+   * Attempt to admit a new session for the given IP.
+   *
+   * Returns a discriminated result so callers can distinguish per-IP cap
+   * exhaustion ("rate-limit") from transport-level session id reuse across
+   * IPs ("sid-collision"). Allowlisted traffic always returns `{ ok: true }`.
+   *
+   * Callers that only need a pass/fail signal should prefer the boolean
+   * overload `tryAdd`, which delegates to this method.
+   */
+  tryAddWithReason(ip: string, sessionId: string): TryAddResult {
+    // Allowlisted traffic bypasses the per-IP session CAP but still consumes
+    // transport/session resources normally. Operators must rely on upstream
+    // rate-limits or resource quotas for crawler traffic. Allowlisted
+    // sessions are intentionally NOT tracked in the per-IP counter so a
+    // remove() call for one of them never affects a non-allowlisted IP.
+    if (this.isAllowlisted(ip)) {
+      this.maybeLogBypass(ip);
+      return { ok: true };
+    }
+
+    // Normalize at the map-key boundary so dual-stack dual-form (plain IPv4
+    // vs ::ffff:IPv4) requests from the same physical client bucket into the
+    // SAME counter. Without this, a client alternating forms would silently
+    // double the per-IP cap.
+    const key = normalizeIp(ip);
+
+    // Guard against sid collision across IPs. If the caller hands us the
+    // same sid twice from different source IPs, accepting the second call
+    // would orphan the first IP's counter entry (remove() later cleans the
+    // second IP only, leaving the first permanently inflated). Be
+    // conservative: idempotent-accept on the same IP, warn + reject on a
+    // different IP. Compare normalized forms so an IP reported as two
+    // different forms is recognized as the same client.
+    const existingIp = this.sessionToIp.get(sessionId);
+    if (existingIp !== undefined) {
+      if (existingIp === key) return { ok: true };
+      // Session ids are bearer-equivalent secrets (whoever holds the sid can
+      // drive the session). Mask to the first 8 chars — same discipline as
+      // the /messages handler in sse-handlers.ts — so stdout/aggregator
+      // exfiltration of logs can't escalate to session hijack.
+      console.warn(
+        `[mcp] session ${sessionId.slice(0, 8)} re-added from different IP (was ${existingIp}, now ${key}); ignoring`,
+      );
+      return { ok: false, reason: "sid-collision" };
+    }
+
+    const sessions = this.ipToSessions.get(key);
+    if (sessions && sessions.size >= this.maxPerIp) {
+      return { ok: false, reason: "rate-limit" };
+    }
 
     if (!sessions) {
-      this.ipToSessions.set(ip, new Set([sessionId]));
+      this.ipToSessions.set(key, new Set([sessionId]));
     } else {
       sessions.add(sessionId);
     }
-    this.sessionToIp.set(sessionId, ip);
-    return true;
+    this.sessionToIp.set(sessionId, key);
+    return { ok: true };
+  }
+
+  /**
+   * Boolean shim over `tryAddWithReason` — preserves the pre-R4 call
+   * signature so existing callers (server.ts, sse-handlers.ts) don't have
+   * to migrate in the same PR. New callers that need to distinguish
+   * rate-limit exhaustion from sid-collision should prefer
+   * `tryAddWithReason`.
+   */
+  tryAdd(ip: string, sessionId: string): boolean {
+    return this.tryAddWithReason(ip, sessionId).ok;
   }
 
   remove(sessionId: string): void {
     const ip = this.sessionToIp.get(sessionId);
     if (!ip) return;
     this.sessionToIp.delete(sessionId);
+    // `ip` here is the normalized form we stored at tryAdd() time, so no
+    // re-normalization is needed. (The Map lookup is safe by key equality.)
     const sessions = this.ipToSessions.get(ip);
     if (sessions) {
       sessions.delete(sessionId);
@@ -32,7 +355,8 @@ export class IpSessionLimiter {
   }
 
   getSessionCount(ip: string): number {
-    return this.ipToSessions.get(ip)?.size ?? 0;
+    // Normalize so callers can ask about the same client in either form.
+    return this.ipToSessions.get(normalizeIp(ip))?.size ?? 0;
   }
 
   getMax(): number {

--- a/src/ip-util.ts
+++ b/src/ip-util.ts
@@ -1,0 +1,42 @@
+import type { Request } from "express";
+
+/**
+ * Extract the client IP for rate-limiting, tracing, and analytics purposes.
+ *
+ * Security model — this helper is load-bearing for the IP allowlist in the
+ * per-IP session limiter, so it MUST NOT be fooled by a client-supplied
+ * `X-Forwarded-For` header. An attacker who could spoof XFF could trivially
+ * claim to be an allowlisted crawler IP (e.g. 160.79.106.35) and bypass the
+ * rate limit entirely.
+ *
+ * The decision of whether to honor `X-Forwarded-For` is delegated to Express
+ * via `app.set("trust proxy", …)` (see server.ts). When trustProxy is true,
+ * Express walks the XFF chain and assigns the result to `req.ip`; we simply
+ * return that. When trustProxy is false, we ignore XFF entirely and trust
+ * only the socket's peer address — which cannot be spoofed at the HTTP layer.
+ *
+ * Operators should only enable trust_proxy when the deployment sits behind a
+ * reverse proxy that strips and rewrites the incoming `X-Forwarded-For`
+ * header. Railway's edge does this correctly; a bare `node` process exposed
+ * directly to the public internet does not.
+ */
+export function clientIp(req: Request, trustProxy: boolean): string {
+  // NOTE: we use `||` rather than `??` throughout so the empty string also
+  // falls through to the next candidate. An empty `remoteAddress` can show
+  // up after abrupt disconnects, in some HTTP/2 upgrade paths, and in test
+  // mocks; `??` would preserve it and every such request would then bucket
+  // into a single "" counter in the per-IP rate limiter, letting one
+  // client DoS every other client in that state. `||` treats "" the same
+  // as undefined/null and keeps walking the fallback chain.
+  if (trustProxy) {
+    // Express populates req.ip from the XFF chain when `trust proxy` is set.
+    // Fall back to the socket if the framework somehow didn't resolve one
+    // (or left an empty string), and to "unknown" only as a last resort so
+    // logs/counters stay sortable.
+    return req.ip || req.socket?.remoteAddress || "unknown";
+  }
+  // Hardened path: ignore X-Forwarded-For (and req.ip, which could also have
+  // been populated from XFF by a mis-configured upstream). Trust only the
+  // TCP peer address.
+  return req.socket?.remoteAddress || "unknown";
+}

--- a/src/rate-limit-response.ts
+++ b/src/rate-limit-response.ts
@@ -1,0 +1,146 @@
+/**
+ * Shared rejection payloads for the per-IP session rate limiter.
+ *
+ * Used by both the SSE transport (src/sse-handlers.ts) and the
+ * Streamable-HTTP /mcp transport (src/server.ts) so that rate-limited clients
+ * get a consistent, descriptive error instead of a silent disconnect or a
+ * bare "Too many sessions" string.
+ */
+
+/** Support contact surfaced in every rejection so operators can reach us. */
+export const RATE_LIMIT_CONTACT = "oss@copilotkit.ai";
+
+/**
+ * JSON-RPC server-error-range code for rate-limit rejections.
+ *
+ * The MCP spec reserves -32000..-32099 for implementation-defined server
+ * errors; we use -32005 as a stable, documented value clients can match
+ * against for rate-limit handling.
+ */
+export const JSONRPC_RATE_LIMIT_CODE = -32005;
+
+export interface RateLimitPayload {
+  error: "rate_limited";
+  reason: string;
+  limit: number;
+  currentCount: number;
+  retryAfterSeconds: number;
+  contact: string;
+}
+
+export interface RateLimitInputs {
+  limit: number;
+  currentCount: number;
+  retryAfterSeconds: number;
+}
+
+/**
+ * Minimum Retry-After hint, in seconds.
+ *
+ * Per RFC 7231, Retry-After is the minimum reasonable interval before retry.
+ * Anything shorter would ask clients to hammer us faster than the limiter can
+ * clear state.
+ */
+const RETRY_AFTER_MIN_SECONDS = 1;
+
+/**
+ * Maximum Retry-After hint, in seconds.
+ *
+ * Session-idle TTLs (30m+) are far too long to hand back as a retry hint —
+ * idle sessions clear well before TTL and active ones never do. 5 minutes is
+ * a conservative upper bound that keeps clients backing off without
+ * stranding them on a value that no longer reflects reality.
+ */
+const RETRY_AFTER_MAX_SECONDS = 300;
+
+/**
+ * Default Retry-After hint, in seconds, used when the caller passes NaN,
+ * a non-finite value, zero, or a negative number.
+ */
+const RETRY_AFTER_DEFAULT_SECONDS = 60;
+
+/**
+ * Normalize an arbitrary caller-supplied Retry-After hint into a sane integer
+ * in [RETRY_AFTER_MIN_SECONDS, RETRY_AFTER_MAX_SECONDS].
+ *
+ * - Non-finite / NaN / values <= 0 fall back to RETRY_AFTER_DEFAULT_SECONDS.
+ * - Positive values are floored so the wire value is always an integer.
+ * - Positive values < 1s (which floor to 0) are clamped up to the minimum
+ *   (RETRY_AFTER_MIN_SECONDS = 1), not defaulted.
+ * - Values above the ceiling are clamped down to RETRY_AFTER_MAX_SECONDS.
+ *
+ * Exported so HTTP callers (e.g. the `Retry-After` header in src/server.ts
+ * and src/sse-handlers.ts) can apply the same clamp as the JSON body,
+ * keeping the header and body values in lockstep.
+ */
+export function clampRetryAfterSeconds(input: number): number {
+  if (!Number.isFinite(input) || input <= 0) {
+    return RETRY_AFTER_DEFAULT_SECONDS;
+  }
+  const floored = Math.floor(input);
+  if (floored < RETRY_AFTER_MIN_SECONDS) {
+    return RETRY_AFTER_MIN_SECONDS;
+  }
+  if (floored > RETRY_AFTER_MAX_SECONDS) {
+    return RETRY_AFTER_MAX_SECONDS;
+  }
+  return floored;
+}
+
+/**
+ * Build the shared descriptive rejection body.
+ *
+ * Shape is intentionally flat and serialization-safe so both HTTP bodies and
+ * JSON-RPC error.data frames carry the same fields.
+ *
+ * `retryAfterSeconds` is defensively clamped here so every caller (HTTP
+ * `Retry-After` header, JSON-RPC error data, human-readable reason) sees the
+ * same sanitized integer — even if upstream passes a SESSION_TTL-derived
+ * value or an accidental NaN/negative.
+ */
+export function buildRateLimitPayload(
+  inputs: RateLimitInputs,
+): RateLimitPayload {
+  const { limit, currentCount } = inputs;
+  const retryAfterSeconds = clampRetryAfterSeconds(inputs.retryAfterSeconds);
+  return {
+    error: "rate_limited",
+    reason:
+      `This IP already has ${currentCount} active MCP session${currentCount === 1 ? "" : "s"}, ` +
+      `at the configured per-IP limit of ${limit}. ` +
+      `Retry after ~${retryAfterSeconds} second${retryAfterSeconds === 1 ? "" : "s"} once an existing session idles out.`,
+    limit,
+    currentCount,
+    retryAfterSeconds,
+    contact: RATE_LIMIT_CONTACT,
+  };
+}
+
+export interface JsonRpcRateLimitFrame {
+  jsonrpc: "2.0";
+  id: string | number | null;
+  error: {
+    code: number;
+    message: string;
+    data: RateLimitPayload;
+  };
+}
+
+/**
+ * Build a JSON-RPC 2.0 error frame suitable for writing to the /mcp response
+ * when the client's initialize request is rejected by the IP limiter.
+ */
+export function jsonRpcRateLimitError(
+  id: string | number | null,
+  inputs: RateLimitInputs,
+): JsonRpcRateLimitFrame {
+  return {
+    jsonrpc: "2.0",
+    id,
+    error: {
+      code: JSONRPC_RATE_LIMIT_CODE,
+      message: "Rate limited: too many sessions from this IP",
+      data: buildRateLimitPayload(inputs),
+    },
+  };
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,6 +38,12 @@ import { BashTelemetry } from "./mcp/tools/bash-telemetry.js";
 import { insertCollectedData } from "./db/queries.js";
 import { IpSessionLimiter } from "./ip-limiter.js";
 import {
+  jsonRpcRateLimitError,
+  clampRetryAfterSeconds,
+} from "./rate-limit-response.js";
+import { clientIp } from "./ip-util.js";
+import ipaddr from "ipaddr.js";
+import {
   protectedResourceHandler,
   authorizationServerHandler,
   registerHandler,
@@ -236,10 +242,10 @@ app.use(express.urlencoded({ extended: false }));
 // auth-flow bug and should not fire in general deployments.
 if (process.env.PATHFINDER_TRACE_CLAUDE_AI === "1") {
   app.use((req, _res, next) => {
-    const ip =
-      (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
-      req.socket?.remoteAddress ||
-      "unknown";
+    // Route through the shared helper so tracing, rate limiting, and
+    // analytics dev-bypass all agree on the resolved IP (and all share
+    // the same X-Forwarded-For spoof protection when trust_proxy=false).
+    const ip = clientIp(req, trustProxy);
     if (
       ip.startsWith("160.79.106") ||
       ip.startsWith("104.192.205") ||
@@ -279,92 +285,672 @@ let SESSION_TTL_MS = 30 * 60 * 1000; // 30 minutes default, overridden by config
 let ipLimiter: IpSessionLimiter | undefined;
 let workspaceManager: WorkspaceManager | undefined;
 
-// Session reaper tick — started from startServer() so importing this module
-// (including from tests) doesn't leak a 5-minute setInterval into the loop.
-function reapIdleSessionsTick(): void {
-  const now = Date.now();
-  let reaped = 0;
-  for (const sid of Object.keys(sessionLastActivity)) {
-    // Skip SSE-owned sessions — they're reaped by reapIdleSseSessions below.
-    if (sseTransports[sid]) continue;
-    if (now - sessionLastActivity[sid] > SESSION_TTL_MS) {
+/**
+ * Single source of truth for the pre-clamp Retry-After hint derived from
+ * SESSION_TTL_MS. Each /mcp rate-limit rejection path (pre-check, sync-race
+ * tryAdd fail, race-fallback inside onsessioninitialized) used to duplicate
+ * `Math.max(1, Math.round(SESSION_TTL_MS / 1000))` inline — four copies
+ * diverging silently whenever one got refactored. Centralising it here keeps
+ * header + body in lockstep; final clamping still happens inside
+ * `clampRetryAfterSeconds` so the documented ceiling (300s) is enforced
+ * regardless of how large SESSION_TTL_MS grows.
+ */
+export function retryAfterSecondsFromTtl(): number {
+  return Math.max(1, Math.round(SESSION_TTL_MS / 1000));
+}
+
+/**
+ * Short-lived set of session IDs that were rejected mid-init (race fallback
+ * from handleSessionInitRaceFallback, or ensureSession-throw rollback from
+ * handleSessionInitAccept). Both rejection paths already ran the full cleanup
+ * chain inline AND called transport.close(). The SDK then fires
+ * transport.onclose asynchronously for the now-dead transport — without this
+ * marker, onclose would re-run sessionStateManager.cleanup/ipLimiter.remove/
+ * workspaceManager.cleanup for a sid that never became a real session AND
+ * emit a misleading "Session X closed (N active)" log.
+ *
+ * We add on rejection, consult in onclose to branch, and drain in onclose so
+ * the Set never grows unbounded. A sid never re-appears here because
+ * onsessioninitialized fires exactly once per transport.
+ */
+const rejectedSids = new Set<string>();
+
+/**
+ * Test-only: mark a sid as rejected (so onclose suppresses its cleanup
+ * chain). Production code calls this internally from the race-fallback /
+ * accept-rollback paths; exported so tests can verify both the marker
+ * machinery and the suppression behavior independently.
+ */
+export function markSessionRejectedForTesting(sid: string): void {
+  rejectedSids.add(sid);
+}
+
+/**
+ * Test-only: query whether a sid was marked rejected (for assertions in
+ * server-round2.test.ts). Does not mutate.
+ */
+export function wasSessionRejectedForTesting(sid: string): boolean {
+  return rejectedSids.has(sid);
+}
+
+/**
+ * Test-only: clear the rejected-sids set. Tests that want isolation across
+ * cases can reset this in beforeEach so stale state from one test can't
+ * influence another.
+ */
+export function __resetRejectedSidsForTesting(): void {
+  rejectedSids.clear();
+}
+
+/**
+ * Drain the rejected-sid marker for paths that tore the session down inline
+ * and early-return from the /mcp init handler WITHOUT ever wiring
+ * `transport.onclose`. Those paths (sync-race tryAdd-fail +
+ * handleSessionInitAccept ensureSession-throw rollback) still call
+ * `rejectedSids.add(sid)` inside the helper so that if onclose WERE wired, it
+ * would suppress double-cleanup. But when no onclose handler is attached, the
+ * marker would otherwise accumulate forever under rate-limit hammering /
+ * workspace-init failures.
+ *
+ * Calling this immediately before the early-return guarantees the Set stays
+ * bounded without racing the SDK's async onclose. Exported so tests can
+ * assert the drain happens deterministically instead of dragging in the full
+ * Express handler.
+ */
+export function drainRejectedSidForInlineRollback(sid: string): void {
+  rejectedSids.delete(sid);
+}
+
+/**
+ * Pure reaper for the Streamable-HTTP transport map. Exported so tests can
+ * drive it without spinning up the full server. Mirrors
+ * `reapIdleSseSessions` in sse-handlers.ts.
+ *
+ * Behavior contract:
+ * - Closes the transport via `transport.close()` so listeners/timers inside
+ *   the transport don't leak. The promise is attached via Promise.resolve +
+ *   `.catch` so async rejections land in `console.error` instead of the
+ *   process's unhandled-rejection stream.
+ * - Coalesces `sessionLastActivity[sid] ?? 0` before the age check. Without
+ *   this, a session with no recorded activity ({@link SESSION_TTL_MS}
+ *   arithmetic on `undefined`) evaluates to `NaN > ttlMs`, which is always
+ *   false — the session would never be reaped.
+ * - Deletes map entries itself. The caller is responsible for cross-map
+ *   cleanup (ipLimiter, workspace, session state) because those dependencies
+ *   don't belong in a pure reaper.
+ */
+export function reapIdleStreamableSessions(opts: {
+  transports: Record<string, { close: () => Promise<void> | void }>;
+  sessionLastActivity: Record<string, number>;
+  ttlMs: number;
+  now?: number;
+}): string[] {
+  const { transports, sessionLastActivity, ttlMs } = opts;
+  const now = opts.now ?? Date.now();
+  const reaped: string[] = [];
+  for (const sid of Object.keys(transports)) {
+    const last = sessionLastActivity[sid] ?? 0;
+    if (now - last > ttlMs) {
+      const transport = transports[sid];
+      // Async rejections must land in console.error, not the unhandled-
+      // rejection stream. `void transport.close()` only catches synchronous
+      // throws.
+      Promise.resolve()
+        .then(() => transport.close())
+        .catch((e) =>
+          console.error(
+            `[mcp] Streamable close failed for ${sid.slice(0, 8)}:`,
+            e,
+          ),
+        );
       delete transports[sid];
       delete sessionLastActivity[sid];
-      try {
-        sessionStateManager.cleanup(sid);
-      } catch (e) {
-        console.error(
-          `[mcp] Session state cleanup failed for ${sid.slice(0, 8)}:`,
-          e,
-        );
-      }
-      try {
-        ipLimiter?.remove(sid);
-      } catch (e) {
-        console.error(`[mcp] IP limiter cleanup failed:`, e);
-      }
-      try {
-        workspaceManager?.cleanup(sid);
-      } catch (e) {
-        console.error(
-          `[mcp] Workspace cleanup failed for ${sid.slice(0, 8)}:`,
-          e,
-        );
-      }
-      reaped++;
+      reaped.push(sid);
     }
   }
-  if (reaped > 0) {
-    console.log(
-      `[mcp] Reaped ${reaped} idle sessions (${Object.keys(transports).length} active)`,
-    );
-  }
+  return reaped;
+}
 
-  // Reap idle SSE sessions. reapIdleSseSessions closes the transport (which
-  // triggers our onclose → removes from sseTransports, ipLimiter, workspace)
-  // and also defensively clears the maps itself.
-  const reapedSse = reapIdleSseSessions({
-    sseTransports,
-    sessionLastActivity,
-    ttlMs: SESSION_TTL_MS,
+/**
+ * Parametric reaper tick — all dependencies injected so tests can drive this
+ * without module-scope state. The production tick below closes over module
+ * state and delegates here.
+ *
+ * SSE ownership (R3 #1): reapIdleSseSessions now owns the full cleanup chain
+ * inline — ipLimiter.remove, workspaceManager.cleanup, AND
+ * sessionStateManager.cleanup. This supersedes the earlier "onclose-driven
+ * cleanup" model: the reaper schedules transport.close() on a microtask, so
+ * by the time SDK-side onclose fires, the map entry has already been deleted
+ * and the handler's onclose closure no-ops. Calling cleanup only from the
+ * handler onclose would leave ipLimiter counters, workspace state, AND
+ * per-session shell state leaking for every reaped SSE session. See
+ * sse-handlers.ts reapIdleSseSessions JSDoc for the full contract; this
+ * function is purely the plumbing that hands our module-scope deps to that
+ * reaper.
+ */
+export function reapIdleSessionsTickForTesting(opts: {
+  transports: Record<string, { close: () => Promise<void> | void }>;
+  sseTransports: Record<string, { close: () => Promise<void> | void }>;
+  sessionLastActivity: Record<string, number>;
+  ttlMs: number;
+  now?: number;
+  ipLimiter?: { remove: (sid: string) => void };
+  workspaceManager?: { cleanup: (sid: string) => void };
+  sessionStateManager?: { cleanup: (sid: string) => void };
+}): void {
+  const now = opts.now ?? Date.now();
+  // Filter out SSE-owned sessions — they're reaped by reapIdleSseSessions
+  // below and share the sessionLastActivity map. Build a shallow snapshot
+  // view so the pure reaper sees only streamable-HTTP entries.
+  const streamableOnly: Record<string, { close: () => Promise<void> | void }> =
+    {};
+  for (const sid of Object.keys(opts.transports)) {
+    if (!opts.sseTransports[sid]) streamableOnly[sid] = opts.transports[sid];
+  }
+  const reapedStreamable = reapIdleStreamableSessions({
+    transports: streamableOnly,
+    sessionLastActivity: opts.sessionLastActivity,
+    ttlMs: opts.ttlMs,
     now,
   });
-  for (const sid of reapedSse) {
+  for (const sid of reapedStreamable) {
+    // Propagate the delete back to the canonical map. The reaper already
+    // deleted from the snapshot.
+    delete opts.transports[sid];
     try {
-      ipLimiter?.remove(sid);
-    } catch (e) {
-      console.error(`[mcp] SSE IP limiter cleanup failed:`, e);
-    }
-    try {
-      workspaceManager?.cleanup(sid);
+      opts.sessionStateManager?.cleanup(sid);
     } catch (e) {
       console.error(
-        `[mcp] SSE workspace cleanup failed for ${sid.slice(0, 8)}:`,
+        `[mcp] Session state cleanup failed for ${sid.slice(0, 8)}:`,
+        e,
+      );
+    }
+    try {
+      opts.ipLimiter?.remove(sid);
+    } catch (e) {
+      console.error(`[mcp] IP limiter cleanup failed:`, e);
+    }
+    try {
+      opts.workspaceManager?.cleanup(sid);
+    } catch (e) {
+      console.error(
+        `[mcp] Workspace cleanup failed for ${sid.slice(0, 8)}:`,
         e,
       );
     }
   }
+  if (reapedStreamable.length > 0) {
+    console.log(
+      `[mcp] Reaped ${reapedStreamable.length} idle sessions (${Object.keys(opts.transports).length} active)`,
+    );
+  }
+
+  // Reap idle SSE sessions. Ownership (see sse-handlers.ts
+  // reapIdleSseSessions JSDoc): the reaper deletes map entries synchronously
+  // AND runs the full cleanup chain (ipLimiter.remove, workspaceManager.
+  // cleanup, sessionStateManager.cleanup) inline before scheduling
+  // transport.close() on a microtask. We intentionally do NOT duplicate any
+  // of those cleanup calls here — a single inline owner keeps state
+  // transitions auditable and avoids double-free when onclose later fires
+  // against an already-deleted map entry. This reverses the previous
+  // "onclose-driven" model that was silently leaking per-session state for
+  // every reaped SSE session (the close() microtask raced ahead of the
+  // handler's `if (sseTransports[sid])` guard, so onclose saw a deleted
+  // entry and no-opped — leaving limiter counters, workspace state, and
+  // shell state stranded).
+  const reapedSse = reapIdleSseSessions({
+    sseTransports: opts.sseTransports,
+    sessionLastActivity: opts.sessionLastActivity,
+    ttlMs: opts.ttlMs,
+    now,
+    ipLimiter: opts.ipLimiter,
+    workspaceManager: opts.workspaceManager,
+    sessionStateManager: opts.sessionStateManager,
+  });
   if (reapedSse.length > 0) {
     console.log(
-      `[mcp] Reaped ${reapedSse.length} idle SSE sessions (${Object.keys(sseTransports).length} SSE active)`,
+      `[mcp] Reaped ${reapedSse.length} idle SSE sessions (${Object.keys(opts.sseTransports).length} SSE active)`,
+    );
+  }
+}
+
+// Session reaper tick — started from startServer() so importing this module
+// (including from tests) doesn't leak a 5-minute setInterval into the loop.
+// Thin closure over module state that delegates to the parametric form.
+function reapIdleSessionsTick(): void {
+  reapIdleSessionsTickForTesting({
+    transports,
+    sseTransports,
+    sessionLastActivity,
+    ttlMs: SESSION_TTL_MS,
+    ipLimiter,
+    workspaceManager,
+    sessionStateManager,
+  });
+}
+
+/**
+ * Race-fallback handler for the /mcp `onsessioninitialized` callback. When
+ * the IP limiter rejects inside onsessioninitialized (rare: the pre-check
+ * above should have caught it, but two concurrent inits from the same IP
+ * can still race between pre-check and counter increment), we must:
+ *
+ * 1. Best-effort emit a JSON-RPC error frame on the transport so the client
+ *    sees a descriptive rejection reason instead of a silent disconnect.
+ * 2. Close the transport.
+ * 3. Delete transports[sid] / sessionLastActivity[sid] INLINE — we cannot
+ *    rely on onclose firing for this sid since the transport is torn down
+ *    mid-stream-setup.
+ *
+ * Asymmetry note (vs /sse race fallback in src/sse-handlers.ts):
+ *   /sse race-fallback returns a 429 JSON body to the client — the SSE
+ *   handler still has a response object in hand at that point. /mcp
+ *   race-fallback, by contrast, fires inside the SDK's
+ *   `onsessioninitialized` callback AFTER the transport has taken ownership
+ *   of the response stream and BEFORE the stream controller is wired
+ *   (`transport.send()` throws "Not connected"). We cannot write a JSON
+ *   body here, so the losing client sees a silent TCP close. The loud
+ *   `console.warn` below is the operator-side compensation.
+ *
+ *   TODO: revisit this asymmetry if/when the MCP SDK exposes a way to
+ *   emit a protocol-level error frame during onsessioninitialized — at
+ *   that point both transports can converge on the same "descriptive
+ *   rejection" shape and this helper can stop being the quiet one.
+ *
+ * Note on step 1: the MCP SDK's `StreamableHTTPServerTransport.send()`
+ * requires a live SSE stream (see node_modules/.../webStandardStreamableHttp
+ * where send throws "Not connected" without one). Inside
+ * `onsessioninitialized`, the enclosing `handleRequest` call has not yet
+ * wired the stream controller — `send()` would throw "Not connected" and
+ * the rejected promise would surface as an unhandled rejection. Rather
+ * than emit a JSON-RPC error the client can't possibly see, we accept the
+ * silent-disconnect footgun as documented SDK behavior and compensate
+ * with:
+ *   - A loud `console.warn` that includes the sid prefix, IP, counter, AND
+ *     the clamped retry-after hint so operators can correlate client
+ *     disconnects with rate-limit trips and know how long clients were
+ *     told to back off.
+ *   - The outer pre-check catches the common case (non-race) with a proper
+ *     429 + `Retry-After` + structured body, so this fallback path only
+ *     fires for genuine concurrent-init races.
+ *
+ * Exported so tests can exercise this directly without driving the full
+ * Express app + SDK lifecycle.
+ */
+export function handleSessionInitRaceFallback(opts: {
+  transport: { close: () => Promise<void> | void };
+  sid: string;
+  ip: string;
+  transports: Record<string, unknown>;
+  sessionLastActivity: Record<string, number>;
+  limit: number;
+  currentCount: number;
+  retryAfterSeconds: number;
+}): void {
+  const {
+    transport,
+    sid,
+    ip,
+    transports: tMap,
+    sessionLastActivity: lastActivityMap,
+    limit,
+    currentCount,
+  } = opts;
+  // Clamp to the same ceiling the JSON body uses so the log hint matches
+  // what clients would have received on the happy (pre-check) path.
+  const retryAfterSeconds = clampRetryAfterSeconds(opts.retryAfterSeconds);
+  // Loud log — this path is the "silent disconnect" case; the log is the
+  // only signal operators get that a client was rejected. Shape mirrors
+  // the pre-check log so both surfaces are greppable together, and carries
+  // the retry-after hint so ops can correlate disconnects with the backoff
+  // window.
+  console.warn(
+    `[mcp] IP rate limit exceeded for ${ip} (${currentCount}/${limit}), closing session ${sid.slice(0, 8)} (race fallback, retry-after: ${retryAfterSeconds}s)`,
+  );
+  // Close the transport. Async rejections land in console.error instead of
+  // the unhandled-rejection stream.
+  Promise.resolve()
+    .then(() => transport.close())
+    .catch((err) => {
+      console.error(
+        `[mcp] race-fallback close failed for ${sid.slice(0, 8)}:`,
+        err,
+      );
+    });
+  // Inline map deletion — do NOT wait for onclose. The onclose handler
+  // tolerates already-deleted entries (see transport.onclose in the POST
+  // /mcp route).
+  delete tMap[sid];
+  delete lastActivityMap[sid];
+  // Mark sid as rejected so the SDK-scheduled transport.onclose (fires once
+  // transport.close() resolves) suppresses its cleanup chain + misleading
+  // "Session closed (N active)" log — the session was never opened, so the
+  // counters should reflect the pre-increment rollback and nothing more.
+  rejectedSids.add(sid);
+}
+
+/**
+ * Write a 429 rate-limited response (JSON-RPC error frame + `Retry-After`
+ * header) back to a caller whose /mcp init was rejected by the IP limiter
+ * pre-check. Exported so tests can drive the header/body parity directly
+ * without a full Express + SDK round-trip.
+ *
+ * Both the header and the JSON-body `retryAfterSeconds` flow through
+ * `clampRetryAfterSeconds`, so a raw SESSION_TTL-derived seed (e.g. 1800s
+ * from a 30-minute TTL) gets clamped to the documented ceiling (300s) on
+ * BOTH surfaces. Prior to this refactor the header was set from the raw
+ * input and the body was clamped in `buildRateLimitPayload`, producing a
+ * mismatch (header: 1800, body: 300) that confused clients.
+ */
+export function write429RateLimited(
+  res: Response,
+  inputs: {
+    id: string | number | null;
+    limit: number;
+    currentCount: number;
+    retryAfterSeconds: number;
+  },
+): void {
+  // Defensive guard: if a future refactor moves the pre-check after any write
+  // has happened, res.setHeader() would throw "Cannot set headers after they
+  // are sent" and escape as an unhandled error. Bail with a diagnostic log so
+  // operators can correlate, rather than crashing the request handler.
+  if (res.headersSent) {
+    console.error(
+      "[mcp] 429 after headers sent — cannot write rate-limit response body/header",
+    );
+    return;
+  }
+  const clamped = clampRetryAfterSeconds(inputs.retryAfterSeconds);
+  const frame = jsonRpcRateLimitError(inputs.id, {
+    limit: inputs.limit,
+    currentCount: inputs.currentCount,
+    retryAfterSeconds: clamped,
+  });
+  res.setHeader("Retry-After", String(clamped));
+  res.status(429).json(frame);
+}
+
+/**
+ * Post-accept handler for the /mcp `onsessioninitialized` callback. Extracted
+ * from the callback so we can (a) wrap the workspaceManager.ensureSession
+ * call in a try/catch that ROLLS BACK the ipLimiter counter and tears down
+ * transport state if ensureSession throws, and (b) test that rollback in
+ * isolation without driving a full SDK lifecycle.
+ *
+ * On ensureSession failure (ENOSPC, EACCES, corrupted workspace, DB error):
+ *   - Log the failure with sid-prefix + ip so operators can diagnose.
+ *   - Call ipLimiter.remove(sid) so the pre-increment doesn't leak and
+ *     permanently count against this IP until TTL reap.
+ *   - Delete transports[sid] / sessionLastActivity[sid] inline (same
+ *     mid-init teardown reasoning as handleSessionInitRaceFallback).
+ *   - Fire-and-forget transport.close() with Promise-wrapped error handling
+ *     so async rejections land in console.error rather than
+ *     unhandledRejection.
+ *   - Do NOT emit a JSON-RPC error frame — the MCP SDK lifecycle constraint
+ *     documented on handleSessionInitRaceFallback applies identically here
+ *     (`transport.send()` would throw "Not connected").
+ *
+ * Exported for tests; production callers wire this up via the POST /mcp
+ * onsessioninitialized callback.
+ */
+export function handleSessionInitAccept(opts: {
+  transport: { close: () => Promise<void> | void; sessionId?: string };
+  sid: string;
+  ip: string;
+  transports: Record<string, unknown>;
+  sessionLastActivity: Record<string, number>;
+  ipLimiter?: { remove: (sid: string) => void };
+  workspaceManager?: { ensureSession: (sid: string) => void };
+  /**
+   * Session state manager (bash tool per-session shell state). Optional so
+   * existing test fixtures keep working; the production caller always passes
+   * the module-scope instance. Rollback clears it alongside the ipLimiter
+   * counter so a subsequent ensureSession throw-path doesn't leak shell
+   * state if the accept handler ever starts registering state before the
+   * ensureSession call.
+   */
+  sessionStateManager?: { cleanup: (sid: string) => void };
+  /**
+   * Express response for the original /mcp init request. When provided AND
+   * headers haven't been sent yet, rollback writes a structured 503 body so
+   * the client sees a diagnostic error instead of a silent transport
+   * teardown. When res.headersSent is already true we can't write (the SDK
+   * may have begun streaming before the ensureSession throw — unlikely given
+   * the order — so we fall back to just closing the transport). Optional to
+   * preserve existing unit test call sites that don't care about the
+   * response shape.
+   */
+  res?: {
+    headersSent: boolean;
+    status: (code: number) => { json: (body: unknown) => unknown };
+  };
+}): boolean {
+  const {
+    transport,
+    sid,
+    ip,
+    transports: tMap,
+    sessionLastActivity: lastActivityMap,
+    ipLimiter: limiter,
+    workspaceManager: workspace,
+    sessionStateManager: sessionState,
+    res,
+  } = opts;
+  try {
+    workspace?.ensureSession(sid);
+  } catch (err) {
+    console.error(
+      `[mcp] workspaceManager.ensureSession failed for ${sid.slice(0, 8)} [${ip}]; rolling back session:`,
+      err,
+    );
+    // Roll back the ipLimiter counter — tryAdd incremented it immediately
+    // before this function ran, and without this rollback the counter
+    // would leak until SESSION_TTL reap. Guard the remove() call so a
+    // rollback throw doesn't mask the original ensureSession error.
+    try {
+      limiter?.remove(sid);
+    } catch (rollbackErr) {
+      console.error(
+        `[mcp] ipLimiter rollback failed for ${sid.slice(0, 8)}:`,
+        rollbackErr,
+      );
+    }
+    // sessionStateManager cleanup: currently a no-op because ensureSession
+    // runs before any session state registration, but add it to the rollback
+    // chain so a future reordering (e.g. registering shell state inside
+    // accept-handler) can't leak per-session state. Per-step try/catch
+    // matches the onclose / reaper pattern.
+    try {
+      sessionState?.cleanup(sid);
+    } catch (rollbackErr) {
+      console.error(
+        `[mcp] sessionStateManager rollback failed for ${sid.slice(0, 8)}:`,
+        rollbackErr,
+      );
+    }
+    // Inline map deletion — do NOT wait for onclose (the transport may
+    // never reach the wired-stream state after the mid-init failure).
+    delete tMap[sid];
+    delete lastActivityMap[sid];
+    // Mark the sid as rejected so the transport.onclose handler (which the
+    // SDK fires asynchronously once transport.close() completes) skips the
+    // cleanup chain + the misleading "Session closed (N active)" log — all
+    // of that work already ran inline above.
+    rejectedSids.add(sid);
+    // Fire-and-forget close; async rejections land in console.error.
+    // Direct .close() (no optional chaining): callers always provide a
+    // transport with .close(), and the optional chain obscured typing.
+    Promise.resolve()
+      .then(() => transport.close())
+      .catch((closeErr) => {
+        console.error(
+          `[mcp] transport.close after ensureSession failure threw for ${sid.slice(0, 8)}:`,
+          closeErr,
+        );
+      });
+    // Client-visible rejection: write a 503 JSON body when we still own the
+    // response stream. If headers were already sent (extremely unlikely at
+    // this point — ensureSession runs before the SDK wires the stream — but
+    // a paranoid guard prevents a throw from crashing the outer handler) we
+    // can't write a body, so the caller gets whatever Express does by
+    // default (empty response, eventual connection close).
+    if (res && !res.headersSent) {
+      res.status(503).json({
+        jsonrpc: "2.0",
+        error: {
+          code: -32003,
+          message:
+            "Server unavailable: failed to initialize session workspace",
+        },
+        id: null,
+      });
+    }
+    return false;
+  }
+  console.log(
+    `[mcp] New session ${sid.slice(0, 8)} (${Object.keys(tMap).length} active) [${ip}]`,
+  );
+  return true;
+}
+
+/**
+ * Drive `transport.handleRequest(req, res, body)` with defensive handling
+ * for the onsessioninitialized-race case. `onsessioninitialized` fires
+ * INSIDE `handleRequest`, so when the defensive race-fallback inside that
+ * callback closes the transport mid-flight the SDK's subsequent write
+ * attempts can throw ("Not connected", "Cannot set headers after sent",
+ * etc.). Before this helper existed the throw escaped to the outer `try`
+ * in the /mcp handler and produced a 500 write on top of the 429 the
+ * race-fallback had already streamed — a double response to the client.
+ *
+ * Contract:
+ *   - Always awaits handleRequest.
+ *   - If `initOutcome.rejected` is true when handleRequest throws, the throw
+ *     is swallowed (the race-fallback already handled the response
+ *     lifecycle) and a diagnostic `[mcp]` log records the suppression so
+ *     operators can still correlate. Resolves to undefined.
+ *   - If `initOutcome.rejected` is false, the throw is re-thrown so the
+ *     outer handler's catch-all produces its standard 500 JSON-RPC error.
+ *
+ * Exported for tests so the try/catch branching can be covered without a
+ * full Express+SDK round trip.
+ */
+export async function completeInitRequestSafely<
+  TReq,
+  TRes,
+  TBody,
+>(
+  transport: {
+    handleRequest: (req: TReq, res: TRes, body: TBody) => Promise<void>;
+  },
+  req: TReq,
+  res: TRes,
+  body: TBody,
+  initOutcome: { rejected: boolean },
+): Promise<void> {
+  try {
+    await transport.handleRequest(req, res, body);
+  } catch (err) {
+    if (initOutcome.rejected) {
+      // Race-fallback already closed the transport and wrote its own
+      // teardown path; the SDK's residual write attempt naturally throws
+      // on a closed socket. Suppress the throw so the outer catch-all
+      // doesn't pile a 500 on top of the 429.
+      console.warn(
+        "[mcp] handleRequest threw after race-fallback rejected session; suppressed:",
+        err,
+      );
+      return;
+    }
+    throw err;
+  }
+}
+
+/**
+ * Shutdown helper: closes every open transport (both Streamable-HTTP and
+ * legacy SSE), clears the backing maps, and logs per-transport failures.
+ * Extracted from the graceful-shutdown handler so tests can verify the
+ * close-and-clear semantics without starting the full server.
+ *
+ * Uses Promise.allSettled on each map so one slow/rejecting close doesn't
+ * stall subsequent closes — keeping shutdown within the orchestrator's
+ * kill-deadline even if a single transport misbehaves. Failures are logged
+ * with the sid prefix so operators can correlate.
+ */
+export async function closeAllSessions(opts: {
+  transports: Record<string, { close: () => Promise<void> | void }>;
+  sseTransports: Record<string, { close: () => Promise<void> | void }>;
+}): Promise<void> {
+  const { transports: tMap, sseTransports: sseMap } = opts;
+
+  const streamableSids = Object.keys(tMap);
+  const streamableResults = await Promise.allSettled(
+    streamableSids.map((sid) => Promise.resolve().then(() => tMap[sid].close())),
+  );
+  streamableResults.forEach((result, i) => {
+    const sid = streamableSids[i];
+    if (result.status === "rejected") {
+      console.error(
+        `[shutdown] Streamable-HTTP transport close failed for ${sid.slice(0, 8)}:`,
+        result.reason,
+      );
+    }
+    delete tMap[sid];
+  });
+  if (streamableSids.length > 0) {
+    console.log(
+      `[shutdown] Closed ${streamableSids.length} Streamable-HTTP transport${streamableSids.length === 1 ? "" : "s"}`,
+    );
+  }
+
+  const sseSids = Object.keys(sseMap);
+  const sseResults = await Promise.allSettled(
+    sseSids.map((sid) => Promise.resolve().then(() => sseMap[sid].close())),
+  );
+  sseResults.forEach((result, i) => {
+    const sid = sseSids[i];
+    if (result.status === "rejected") {
+      console.error(
+        `[shutdown] SSE transport close failed for ${sid.slice(0, 8)}:`,
+        result.reason,
+      );
+    }
+    delete sseMap[sid];
+  });
+  if (sseSids.length > 0) {
+    console.log(
+      `[shutdown] Closed ${sseSids.length} SSE transport${sseSids.length === 1 ? "" : "s"}`,
     );
   }
 }
 
 let sessionReaperInterval: ReturnType<typeof setInterval> | undefined;
 
-function clientIp(req: Request): string {
-  return (
-    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
-    req.socket.remoteAddress ||
-    "unknown"
-  );
+// Resolved during startServer() from server.trust_proxy in the loaded config.
+// Read by every IP-extraction site (trace middleware, /mcp, SSE handlers)
+// via `clientIp(req, trustProxy)`. Defaults to false: if startServer() hasn't
+// run yet, or the config omits the flag, we IGNORE X-Forwarded-For and fall
+// back to the socket address — matching the hardened, spoof-resistant
+// default documented in types.ts.
+let trustProxy = false;
+
+/**
+ * Test-only accessor for the module-level trustProxy flag. The flag is set
+ * by startServer() in production; tests that exercise isLocalhostReq and
+ * analyticsAuth behavior under `trust_proxy=true` without booting the full
+ * server use this setter to drive the exact code path. Always pair with a
+ * reset to `false` in an afterEach / finally so other tests don't inherit
+ * the stale value.
+ */
+export function __setTrustProxyForTesting(value: boolean): void {
+  trustProxy = value;
 }
 
 app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
   try {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
-    const ip = clientIp(req);
+    const ip = clientIp(req, trustProxy);
 
     // Existing session — route to its transport
     if (sessionId && transports[sessionId]) {
@@ -404,74 +990,230 @@ app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
 
     // New session — must be an initialize request
     if (!sessionId && isInitializeRequest(req.body)) {
+      // Pre-check the IP limiter BEFORE creating the transport. The previous
+      // flow created the transport, let onsessioninitialized run, then
+      // transport.close()'d — which produced a silent disconnect on the
+      // client side with no indication of why. Checking up front lets us
+      // write a structured JSON-RPC error + 429 response so the client
+      // can surface the rate-limit reason, the cap, the current count,
+      // and a retry-after hint. Allowlisted IPs skip the check entirely.
+      if (
+        ipLimiter &&
+        !ipLimiter.isAllowlisted(ip) &&
+        ipLimiter.getSessionCount(ip) >= ipLimiter.getMax()
+      ) {
+        const currentCount = ipLimiter.getSessionCount(ip);
+        const limit = ipLimiter.getMax();
+        const retryAfterSeconds = retryAfterSecondsFromTtl();
+        console.warn(
+          `[mcp] IP rate limit exceeded for ${ip} (${currentCount}/${limit}), rejecting /mcp init with JSON-RPC error`,
+        );
+        const reqId =
+          (req.body as { id?: string | number | null } | undefined)?.id ?? null;
+        // Header and JSON body flow through the same clampRetryAfterSeconds
+        // call via write429RateLimited so the two values stay in lockstep.
+        // Previously the header took the raw SESSION_TTL-derived seed while
+        // the body was clamped, producing a 1800/300 mismatch.
+        write429RateLimited(res, {
+          id: reqId,
+          limit,
+          currentCount,
+          retryAfterSeconds,
+        });
+        return;
+      }
+
+      // Pre-generate the session ID so we can run the ipLimiter.tryAdd +
+      // workspaceManager.ensureSession work SYNCHRONOUSLY BEFORE
+      // createMcpServer / server.connect / transport.handleRequest. The
+      // previous design ran that work inside the SDK's
+      // `onsessioninitialized` callback — which fires DURING handleRequest
+      // — so an ensureSession throw rolled back inline but the outer
+      // handler had no way to know, kept driving the now-torn-down
+      // transport, and (a) spun up an MCP server instance that immediately
+      // orphaned (finding H4) and (b) let the SDK attempt to write an init
+      // response on a closed transport. With the sid pre-generated here,
+      // `handleSessionInitAccept` returns a boolean and the outer handler
+      // can SKIP createMcpServer + server.connect + handleRequest on
+      // rollback.
+      const preSid = randomUUID();
+      // Flag captured by the onsessioninitialized closure so a race-fallback
+      // triggered ASYNC from inside the SDK (pre-check beat this sid but a
+      // concurrent request from the same IP won the atomic tryAdd — extremely
+      // rare after the pre-check refactor) can still signal the outer
+      // handler. The ensureSession rollback path now runs synchronously
+      // BEFORE handleRequest and sets this directly.
+      const initOutcome: { rejected: boolean } = { rejected: false };
       const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
+        sessionIdGenerator: () => preSid,
         onsessioninitialized: (sid) => {
+          // Registration moved here intentionally — we can't populate
+          // transports[sid] before the transport object exists, and the SDK
+          // expects the sid-to-transport mapping to be live by the time it
+          // dispatches subsequent messages for this session. tryAdd/
+          // ensureSession already ran synchronously below, so by the time
+          // this callback fires we've either (a) committed to the session
+          // (happy path; just register the maps) or (b) already rolled back
+          // (initOutcome.rejected=true; no-op here — the outer handler
+          // will skip handleRequest).
+          if (initOutcome.rejected) return;
           transports[sid] = transport;
           sessionLastActivity[sid] = Date.now();
-          if (ipLimiter && !ipLimiter.tryAdd(ip, sid)) {
-            // Rate limit exceeded — tear down immediately. Do NOT delete
-            // transports[sid] / sessionLastActivity[sid] inline here:
-            // transport.close() will fire onclose below, and onclose
-            // guards on `if (sid && transports[sid])` — a premature
-            // delete would make that guard false and skip
-            // sessionStateManager.cleanup / workspaceManager?.cleanup
-            // for this sid. Leave state intact so onclose handles it.
-            console.warn(
-              `[mcp] IP rate limit exceeded for ${ip}, closing session ${sid.slice(0, 8)}`,
-            );
-            // transport.close() is async on some transports; log rather
-            // than ignore so a close failure doesn't silently leak.
-            Promise.resolve(transport.close?.()).catch((err) => {
-              console.error(
-                `[mcp] transport close failed for ${sid.slice(0, 8)}:`,
-                err,
-              );
+          // Defensive: this branch is unreachable under Node's
+          // single-threaded execution — the synchronous tryAdd below has
+          // already counted this sid, so `getSessionCount(ip)` can be AT
+          // MOST `getMax()`, never strictly greater. tryAdd itself rejects
+          // at `>= getMax()`, meaning a successful tryAdd guarantees
+          // post-increment <= max. The branch stays as defense-in-depth
+          // against a future refactor that (a) introduces an async boundary
+          // between tryAdd and this callback, or (b) admits a second
+          // concurrent init from the same IP before this fires. `>` (not
+          // `>=`) is required: `>=` would incorrectly fire on the NORMAL
+          // last-allowed session (count exactly at cap after tryAdd) and
+          // reject legitimate traffic.
+          if (
+            ipLimiter &&
+            !ipLimiter.isAllowlisted(ip) &&
+            ipLimiter.getSessionCount(ip) > ipLimiter.getMax()
+          ) {
+            handleSessionInitRaceFallback({
+              transport,
+              sid,
+              ip,
+              transports,
+              sessionLastActivity,
+              limit: ipLimiter.getMax(),
+              currentCount: ipLimiter.getSessionCount(ip),
+              retryAfterSeconds: retryAfterSecondsFromTtl(),
             });
-            return;
+            initOutcome.rejected = true;
           }
-          workspaceManager?.ensureSession(sid);
-          console.log(
-            `[mcp] New session ${sid.slice(0, 8)} (${Object.keys(transports).length} active) [${ip}]`,
-          );
         },
       });
+
+      // Synchronous pre-flight: tryAdd the sid to the ipLimiter and
+      // ensureSession on the workspaceManager BEFORE spinning up the MCP
+      // server. Either can reject this init.
+      if (ipLimiter && !ipLimiter.tryAdd(ip, preSid)) {
+        // Atomic tryAdd failed — another concurrent init from the same IP
+        // beat us between the read-only pre-check and this increment.
+        // Delegate to the shared race-fallback helper (inline map delete,
+        // rejected-sid mark, loud log). Because the transport was just
+        // constructed and hasn't been connected, transport.close() is the
+        // only teardown needed.
+        transports[preSid] = transport;
+        sessionLastActivity[preSid] = Date.now();
+        handleSessionInitRaceFallback({
+          transport,
+          sid: preSid,
+          ip,
+          transports,
+          sessionLastActivity,
+          limit: ipLimiter.getMax(),
+          currentCount: ipLimiter.getSessionCount(ip),
+          retryAfterSeconds: retryAfterSecondsFromTtl(),
+        });
+        // Write the structured 429 inline here — the race-fallback helper
+        // can't write a body mid-SDK-lifecycle, but pre-connect we still
+        // own the response.
+        if (!res.headersSent) {
+          write429RateLimited(res, {
+            id:
+              (req.body as { id?: string | number | null } | undefined)?.id ??
+              null,
+            limit: ipLimiter.getMax(),
+            currentCount: ipLimiter.getSessionCount(ip),
+            retryAfterSeconds: retryAfterSecondsFromTtl(),
+          });
+        }
+        // The race-fallback + accept-rollback helpers intentionally seed
+        // rejectedSids so that IF `transport.onclose` were wired, it would
+        // suppress double-cleanup. But we early-return BEFORE wiring onclose
+        // on this path, so nothing will ever consume the marker. Drain it
+        // here to keep the Set bounded under rate-limit hammering.
+        drainRejectedSidForInlineRollback(preSid);
+        return;
+      }
+      // Register maps now so handleSessionInitAccept's rollback has
+      // something to delete + sessionStateManager cleanup runs against a
+      // live entry.
+      transports[preSid] = transport;
+      sessionLastActivity[preSid] = Date.now();
+      const accepted = handleSessionInitAccept({
+        transport,
+        sid: preSid,
+        ip,
+        transports,
+        sessionLastActivity,
+        ipLimiter,
+        workspaceManager,
+        sessionStateManager,
+        res,
+      });
+      if (!accepted) {
+        // Rollback already tore down the transport + wrote the 503 body (if
+        // headers weren't sent yet). Skip createMcpServer / server.connect /
+        // transport.handleRequest entirely — the transport is closed and
+        // creating an MCP server for it would immediately orphan. Drain the
+        // rejected-sid marker here for the same reason documented in the
+        // tryAdd-fail early return above: onclose never gets wired on this
+        // path, so the Set would otherwise leak forever.
+        drainRejectedSidForInlineRollback(preSid);
+        return;
+      }
       transport.onclose = () => {
         const sid = transport.sessionId;
-        if (sid && transports[sid]) {
-          delete transports[sid];
-          delete sessionLastActivity[sid];
-          // Per-operation try/catch so a throw from one cleanup step
-          // doesn't skip the others — this mirrors the reaper tick above
-          // and prevents ipLimiter / workspace state from drifting when
-          // sessionStateManager.cleanup throws (the original failure mode
-          // leaked IP-limiter counters, eventually rejecting new sessions
-          // from that IP).
-          try {
-            sessionStateManager.cleanup(sid);
-          } catch (e) {
-            console.error(
-              `[mcp] Session state cleanup failed for ${sid.slice(0, 8)}:`,
-              e,
-            );
-          }
-          try {
-            ipLimiter?.remove(sid);
-          } catch (e) {
-            console.error(`[mcp] IP limiter cleanup failed:`, e);
-          }
-          try {
-            workspaceManager?.cleanup(sid);
-          } catch (e) {
-            console.error(
-              `[mcp] Workspace cleanup failed for ${sid.slice(0, 8)}:`,
-              e,
-            );
-          }
+        if (!sid) return;
+        // Rejected-sid suppression (R3 #3 / H1): if the race-fallback or the
+        // ensureSession rollback already tore this session down inline, the
+        // cleanup chain + counters are already consistent. Running the chain
+        // again here would (a) emit a misleading "Session closed" log for a
+        // session that was never opened, and (b) risk double-cleanup on
+        // sessionStateManager/workspaceManager. Drain the marker here so the
+        // Set doesn't grow unbounded.
+        if (rejectedSids.has(sid)) {
+          rejectedSids.delete(sid);
           console.log(
-            `[mcp] Session ${sid.slice(0, 8)} closed (${Object.keys(transports).length} active)`,
+            `[mcp] Session ${sid.slice(0, 8)} rejected, cleanup skipped (already torn down inline)`,
+          );
+          return;
+        }
+        // Tolerate already-deleted entries: a benign race between a client
+        // disconnect and the reaper can leave an entry missing from the
+        // map. Run the cleanup chain regardless so ipLimiter/workspace
+        // state for this sid is released.
+        delete transports[sid];
+        delete sessionLastActivity[sid];
+        // Per-operation try/catch so a throw from one cleanup step
+        // doesn't skip the others — this mirrors the reaper tick above
+        // and prevents ipLimiter / workspace state from drifting when
+        // sessionStateManager.cleanup throws (the original failure mode
+        // leaked IP-limiter counters, eventually rejecting new sessions
+        // from that IP).
+        try {
+          sessionStateManager.cleanup(sid);
+        } catch (e) {
+          console.error(
+            `[mcp] Session state cleanup failed for ${sid.slice(0, 8)}:`,
+            e,
           );
         }
+        try {
+          ipLimiter?.remove(sid);
+        } catch (e) {
+          console.error(`[mcp] IP limiter cleanup failed:`, e);
+        }
+        try {
+          workspaceManager?.cleanup(sid);
+        } catch (e) {
+          console.error(
+            `[mcp] Workspace cleanup failed for ${sid.slice(0, 8)}:`,
+            e,
+          );
+        }
+        console.log(
+          `[mcp] Session ${sid.slice(0, 8)} closed (${Object.keys(transports).length} active)`,
+        );
       };
       const server = createMcpServer(
         bashInstances,
@@ -481,7 +1223,19 @@ app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
         workspaceManager,
       );
       await server.connect(transport);
-      await transport.handleRequest(req, res, req.body);
+      // completeInitRequestSafely swallows throws from handleRequest when
+      // onsessioninitialized's defensive race-fallback closed the transport
+      // mid-flight (initOutcome.rejected=true). The fallback already handled
+      // the response lifecycle; a naked await here would bubble the closed-
+      // transport throw into the outer catch-all and produce a 500 write on
+      // top of the 429 the fallback already streamed.
+      await completeInitRequestSafely(
+        transport,
+        req,
+        res,
+        req.body,
+        initOutcome,
+      );
       return;
     }
 
@@ -511,30 +1265,66 @@ app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
 // Returns 405 when no valid session — the SDK interprets this as
 // "server doesn't offer SSE at GET" which is the expected no-auth path.
 // Returning 400 instead would cause the SDK to throw and trigger auth flow.
+//
+// Intentionally NOT wrapped in `bearerMiddleware`. An unauthenticated
+// client that probes GET /mcp without a Mcp-Session-Id expects a
+// protocol-level 405 (Method Not Allowed); a 401 from bearer-auth would
+// cause the MCP SDK to kick off its auth dance against the wrong endpoint.
+// Authenticated GETs are gated by the Mcp-Session-Id — a session-scoped
+// secret already established through the bearer-gated POST /mcp path, so
+// there's no auth regression from skipping the middleware here.
 app.get("/mcp", async (req: Request, res: Response) => {
-  const sessionId = req.headers["mcp-session-id"] as string | undefined;
-  if (sessionId && transports[sessionId]) {
-    await transports[sessionId].handleRequest(req, res);
-  } else {
-    res.status(405).json({
-      jsonrpc: "2.0",
-      error: { code: -32000, message: "Method Not Allowed" },
-      id: null,
-    });
+  // Mirror POST /mcp's outer try/catch so a throw from handleRequest (stream
+  // teardown mid-flight, transport bug) lands in a structured 500 rather
+  // than escaping to Express's default error handler.
+  try {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+    if (sessionId && transports[sessionId]) {
+      await transports[sessionId].handleRequest(req, res);
+    } else {
+      res.status(405).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Method Not Allowed" },
+        id: null,
+      });
+    }
+  } catch (error) {
+    console.error("[MCP] Error handling GET request:", error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      });
+    }
   }
 });
 
 // Session termination
 app.delete("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
-  const sessionId = req.headers["mcp-session-id"] as string | undefined;
-  if (sessionId && transports[sessionId]) {
-    await transports[sessionId].handleRequest(req, res);
-  } else {
-    res.status(400).json({
-      jsonrpc: "2.0",
-      error: { code: -32000, message: "Invalid or missing session ID" },
-      id: null,
-    });
+  // Mirror POST /mcp's outer try/catch — transport.handleRequest can throw
+  // during teardown (closed stream, partial write) and we'd rather surface a
+  // structured 500 than leak the throw.
+  try {
+    const sessionId = req.headers["mcp-session-id"] as string | undefined;
+    if (sessionId && transports[sessionId]) {
+      await transports[sessionId].handleRequest(req, res);
+    } else {
+      res.status(400).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Invalid or missing session ID" },
+        id: null,
+      });
+    }
+  } catch (error) {
+    console.error("[MCP] Error handling DELETE request:", error);
+    if (!res.headersSent) {
+      res.status(500).json({
+        jsonrpc: "2.0",
+        error: { code: -32603, message: "Internal server error" },
+        id: null,
+      });
+    }
   }
 });
 
@@ -551,6 +1341,11 @@ const sseHandlers = createSseHandlers({
   sessionLastActivity,
   ipLimiter: () => ipLimiter,
   workspaceManager: () => workspaceManager,
+  // Late-bound via getter: trustProxy is resolved inside startServer() from
+  // the loaded config, after this handler factory has already been invoked
+  // at module-load time.
+  trustProxy: () => trustProxy,
+  rateLimitRetryAfterSeconds: () => retryAfterSecondsFromTtl(),
   createMcpServer: () => {
     let transportRef: SSEServerTransport | undefined;
     // The handler creates the transport first, then calls createMcpServer()
@@ -763,16 +1558,57 @@ export function __resetAnalyticsTokenForTesting(): void {
   autoGeneratedAnalyticsToken = null;
 }
 
-const LOCALHOST_IPS = new Set(["127.0.0.1", "::1", "::ffff:127.0.0.1"]);
-
 /**
  * Return true if the request originated from a loopback interface. Trusts
  * ONLY `req.socket.remoteAddress` (not `X-Forwarded-For` — that's client-
  * controlled and would let anyone forge "I'm localhost").
+ *
+ * Node's dual-stack sockets can report loopback in several forms:
+ * - `127.0.0.1` (IPv4)
+ * - `::1` (IPv6 loopback)
+ * - `::ffff:127.0.0.1` (IPv4-mapped IPv6, common)
+ * - `0:0:0:0:0:ffff:127.0.0.1` (same, unnormalized expanded form — seen in
+ *   some test harnesses and older runtimes)
+ *
+ * Rather than hardcode every textual form, we parse the address via
+ * ipaddr.js and compare against the canonical loopback ranges. Unparseable
+ * addresses (empty string, "unknown", etc.) return false so a malformed
+ * remote never accidentally counts as localhost.
  */
+// 127.0.0.0/8 base address used by isLocalhostReq's IPv4 loopback match.
+// Hoisted to a module-level constant so the per-request path doesn't re-parse
+// the same literal on every call (cheap individually, but /mcp can receive
+// it thousands of times/sec under load).
+const LOOPBACK_IPV4_BASE = ipaddr.IPv4.parse("127.0.0.0");
+
 function isLocalhostReq(req: Request): boolean {
+  // Fail-closed when the server trusts forwarded headers. With
+  // `trust_proxy=true` AND NODE_ENV=development AND a local reverse proxy
+  // (Docker sidecar, ngrok, localhost tunnel, k8s sidecar), every request's
+  // socket peer is 127.0.0.1 — so the dev bypass would effectively
+  // unauthenticate analytics for the entire public internet. We refuse the
+  // dev bypass entirely in that combo; operators who need it should drop
+  // trust_proxy or bind the dev server directly without a fronting proxy.
+  // A startup WARN is emitted from startServer() when both flags are set so
+  // this behavior isn't silent.
+  if (trustProxy) return false;
   const addr = req.socket?.remoteAddress ?? "";
-  return LOCALHOST_IPS.has(addr);
+  if (!addr) return false;
+  try {
+    let parsed = ipaddr.parse(addr);
+    if (parsed.kind() === "ipv6") {
+      const v6 = parsed as ipaddr.IPv6;
+      if (v6.isIPv4MappedAddress()) parsed = v6.toIPv4Address();
+    }
+    if (parsed.kind() === "ipv4") {
+      // 127.0.0.0/8 is the IPv4 loopback range.
+      return (parsed as ipaddr.IPv4).match([LOOPBACK_IPV4_BASE, 8]);
+    }
+    // IPv6 loopback is exactly ::1.
+    return (parsed as ipaddr.IPv6).toNormalizedString() === "0:0:0:0:0:0:0:1";
+  } catch {
+    return false;
+  }
 }
 
 /**
@@ -872,6 +1708,17 @@ export function analyticsAuth(
     return;
   }
 
+  // Message is conditional on nodeEnv so non-prod operators don't get a
+  // misleading "requires ANALYTICS_TOKEN in production" hint when the root
+  // cause is something else (e.g. a downstream config-read failure). The
+  // production copy still surfaces the concrete remediation step.
+  const prodTokenMsg =
+    "Analytics requires ANALYTICS_TOKEN in production (env var or analytics.token in config).";
+  const nonProdTokenMsg =
+    "Analytics token unavailable — check analytics config / logs.";
+  const tokenDescription =
+    config.nodeEnv === "production" ? prodTokenMsg : nonProdTokenMsg;
+
   let token: string | undefined;
   try {
     token = getAnalyticsToken();
@@ -881,8 +1728,7 @@ export function analyticsAuth(
     );
     res.status(503).json({
       error: "misconfigured",
-      error_description:
-        "Analytics requires ANALYTICS_TOKEN in production (env var or analytics.token in config).",
+      error_description: tokenDescription,
     });
     return;
   }
@@ -893,8 +1739,7 @@ export function analyticsAuth(
     console.error("[analytics] auth misconfigured: no token available");
     res.status(503).json({
       error: "misconfigured",
-      error_description:
-        "Analytics requires ANALYTICS_TOKEN in production (env var or analytics.token in config).",
+      error_description: tokenDescription,
     });
     return;
   }
@@ -1421,10 +2266,55 @@ export async function startServer(options?: ServerOptions): Promise<void> {
 
   const port = options?.port ?? cfg.port;
 
+  // Configure proxy trust BEFORE anything reads req.ip. When enabled,
+  // Express walks X-Forwarded-For and populates req.ip; when disabled,
+  // XFF is ignored entirely (see src/ip-util.ts for the security rationale
+  // — a blindly-trusted XFF lets any client claim an allowlisted IP and
+  // bypass the per-IP session limiter).
+  //
+  // Security semantics of `app.set("trust proxy", true)`:
+  //   Express's `trust proxy = true` does NOT set a hop count. It means
+  //   Express trusts EVERY address in the X-Forwarded-For chain and uses
+  //   the leftmost (client-supplied, potentially spoofable) entry as
+  //   `req.ip`. This is ONLY safe when the fronting reverse proxy
+  //   discards any client-supplied XFF header and sets its own trusted
+  //   value before the request reaches us. See the cautionary warning in
+  //   pathfinder.example.yaml next to `server.trust_proxy` and the Express
+  //   "trust proxy" docs (https://expressjs.com/en/guide/behind-proxies.html).
+  //   For tighter single-hop deployments, set a numeric hop count
+  //   (e.g. `app.set('trust proxy', 1)`) instead.
+  //
+  // We ALWAYS call app.set here (both branches) so a re-entry with a
+  // flipped config value doesn't leave Express's internal state stuck on
+  // the previous value — the module-level `trustProxy` var and Express
+  // must agree, always.
+  trustProxy = serverCfg.server.trust_proxy ?? false;
+  app.set("trust proxy", trustProxy);
+  if (trustProxy) {
+    console.log(
+      "[startup] trust_proxy=true — honoring X-Forwarded-For (reverse proxy must strip/rewrite this header)",
+    );
+    if (cfg.nodeEnv === "development") {
+      // Dev bypass and trust_proxy=true is an unsupported combination:
+      // isLocalhostReq fails closed so the dev bypass is effectively
+      // disabled, but operators should know the combo doesn't behave like
+      // either flag would alone.
+      console.warn(
+        "[startup] trust_proxy=true + NODE_ENV=development is unsupported — analytics dev bypass is DISABLED to prevent exposing the dashboard via a fronting proxy",
+      );
+    }
+  }
+
   // Configure session TTL and IP rate limiter from config
   const maxSessionsPerIp = serverCfg.server.max_sessions_per_ip ?? 20;
   SESSION_TTL_MS = (serverCfg.server.session_ttl_minutes ?? 30) * 60 * 1000;
-  ipLimiter = new IpSessionLimiter(maxSessionsPerIp);
+  const allowlist = serverCfg.server.allowlist ?? [];
+  ipLimiter = new IpSessionLimiter(maxSessionsPerIp, { allowlist });
+  if (allowlist.length > 0) {
+    console.log(
+      `[startup] IP allowlist: ${allowlist.length} entr${allowlist.length === 1 ? "y" : "ies"} (bypasses session cap)`,
+    );
+  }
 
   // Start the idle-session reaper. Running it from here (rather than at
   // module import) keeps test imports free of leaked timers.
@@ -1562,6 +2452,12 @@ export async function startServer(options?: ServerOptions): Promise<void> {
     console.log(`[health] http://localhost:${port}/health`);
   });
   server.on("error", (err: NodeJS.ErrnoException) => {
+    // Bypassing the graceful shutdown path on a server-level error (previously
+    // `process.exit(1)` inline) left telemetry unflushed, open transports
+    // abandoned, and the DB pool not closed. Route through the existing
+    // `shutdown` helper so the teardown sequence is consistent with
+    // SIGINT/SIGTERM. `shutdown` is hoisted below (function declaration, not
+    // a const) so the forward reference resolves.
     if (err.code === "EADDRINUSE") {
       console.error(
         `[startup] Port ${port} is already in use. Set PORT env var to use a different port.`,
@@ -1569,7 +2465,12 @@ export async function startServer(options?: ServerOptions): Promise<void> {
     } else {
       console.error(`[startup] Server error:`, err);
     }
-    process.exit(1);
+    // shutdown() calls process.exit(0) on completion; wrap in catch so a
+    // shutdown failure still terminates the process instead of hanging.
+    shutdown(`server-error:${err.code ?? "unknown"}`).catch((shutdownErr) => {
+      console.error("[startup] shutdown-on-error failed:", shutdownErr);
+      process.exit(1);
+    });
   });
 
   // -------------------------------------------------------------------
@@ -1597,24 +2498,17 @@ export async function startServer(options?: ServerOptions): Promise<void> {
     } catch (e) {
       console.error("[shutdown] Telemetry flush failed:", e);
     }
-    // Close all open SSE transports so hanging streams don't block exit.
-    // Run closes in parallel via Promise.allSettled: with serial `await`,
-    // one slow stream stalls every subsequent close and can push shutdown
-    // past the orchestrator's kill-deadline. allSettled also guarantees
-    // every transport is attempted even if earlier ones reject.
-    const sids = Object.keys(sseTransports);
-    const closeResults = await Promise.allSettled(
-      sids.map((sid) => sseTransports[sid].close()),
-    );
-    closeResults.forEach((result, i) => {
-      if (result.status === "rejected") {
-        console.error(
-          `[shutdown] SSE transport close failed for ${sids[i].slice(0, 8)}:`,
-          result.reason,
-        );
-      }
-      delete sseTransports[sids[i]];
-    });
+    // Close all open transports (both Streamable-HTTP and legacy SSE) so
+    // hanging streams don't block exit. Pre-R2 this loop only iterated
+    // `sseTransports`, leaving Streamable-HTTP sessions open past shutdown.
+    // closeAllSessions runs each map's closes in parallel via
+    // Promise.allSettled so one slow/rejecting stream doesn't stall the
+    // rest past the orchestrator's kill-deadline.
+    try {
+      await closeAllSessions({ transports, sseTransports });
+    } catch (e) {
+      console.error("[shutdown] closeAllSessions threw:", e);
+    }
     try {
       workspaceManager?.cleanupAll();
     } catch (e) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -800,8 +800,7 @@ export function handleSessionInitAccept(opts: {
         jsonrpc: "2.0",
         error: {
           code: -32003,
-          message:
-            "Server unavailable: failed to initialize session workspace",
+          message: "Server unavailable: failed to initialize session workspace",
         },
         id: null,
       });
@@ -836,11 +835,7 @@ export function handleSessionInitAccept(opts: {
  * Exported for tests so the try/catch branching can be covered without a
  * full Express+SDK round trip.
  */
-export async function completeInitRequestSafely<
-  TReq,
-  TRes,
-  TBody,
->(
+export async function completeInitRequestSafely<TReq, TRes, TBody>(
   transport: {
     handleRequest: (req: TReq, res: TRes, body: TBody) => Promise<void>;
   },
@@ -886,7 +881,9 @@ export async function closeAllSessions(opts: {
 
   const streamableSids = Object.keys(tMap);
   const streamableResults = await Promise.allSettled(
-    streamableSids.map((sid) => Promise.resolve().then(() => tMap[sid].close())),
+    streamableSids.map((sid) =>
+      Promise.resolve().then(() => tMap[sid].close()),
+    ),
   );
   streamableResults.forEach((result, i) => {
     const sid = streamableSids[i];

--- a/src/sse-handlers.ts
+++ b/src/sse-handlers.ts
@@ -29,8 +29,9 @@ export interface WorkspaceManagerLike {
 // structural shape. Using a function signature guarantees structural
 // compatibility without needing a cast. If the real class renames or
 // drops one of these methods, this line fails at compile time.
-type _WorkspaceManagerIsLike =
-  WorkspaceManager extends WorkspaceManagerLike ? true : never;
+type _WorkspaceManagerIsLike = WorkspaceManager extends WorkspaceManagerLike
+  ? true
+  : never;
 const _workspaceManagerIsLike: _WorkspaceManagerIsLike = true;
 void _workspaceManagerIsLike;
 
@@ -348,8 +349,7 @@ export function createSseHandlers(deps: SseHandlerDeps): {
         if (!res.headersSent) {
           res.status(503).json({
             error: "workspace_unavailable",
-            reason:
-              "Failed to initialize session workspace. Please try again.",
+            reason: "Failed to initialize session workspace. Please try again.",
           });
         }
         return;
@@ -381,9 +381,7 @@ export function createSseHandlers(deps: SseHandlerDeps): {
       // useful even without a session id to scope to.
       const trustProxy = resolve(deps.trustProxy ?? false) ?? false;
       const ip = clientIp(req, trustProxy);
-      console.warn(
-        `[mcp] /messages 404 reason=missing-session-id ip=${ip}`,
-      );
+      console.warn(`[mcp] /messages 404 reason=missing-session-id ip=${ip}`);
       res.status(404).json({
         error: "Session not found",
         reason: "missing-session-id",

--- a/src/sse-handlers.ts
+++ b/src/sse-handlers.ts
@@ -3,7 +3,46 @@ import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { bearerMiddleware } from "./oauth/handlers.js";
 import type { IpSessionLimiter } from "./ip-limiter.js";
+import {
+  buildRateLimitPayload,
+  clampRetryAfterSeconds,
+} from "./rate-limit-response.js";
 import type { WorkspaceManager } from "./workspace.js";
+import { clientIp } from "./ip-util.js";
+
+/**
+ * Minimal structural shape of WorkspaceManager that sse-handlers actually
+ * uses. Widening to a structural type (rather than the concrete class)
+ * lets tests pass stubs without casts.
+ *
+ * `ensureSession` return type is intentionally typed as `unknown` because
+ * the handler never consumes it — the real class returns a path string,
+ * test stubs return void. Typing the call-site as fire-and-forget keeps
+ * both callable as drop-in replacements.
+ */
+export interface WorkspaceManagerLike {
+  ensureSession: (sessionId: string) => unknown;
+  cleanup: (sessionId: string) => void;
+}
+
+// Type-level assertion: the real WorkspaceManager must satisfy the
+// structural shape. Using a function signature guarantees structural
+// compatibility without needing a cast. If the real class renames or
+// drops one of these methods, this line fails at compile time.
+type _WorkspaceManagerIsLike =
+  WorkspaceManager extends WorkspaceManagerLike ? true : never;
+const _workspaceManagerIsLike: _WorkspaceManagerIsLike = true;
+void _workspaceManagerIsLike;
+
+/**
+ * Minimal structural shape of SessionStateManager that sse-handlers needs.
+ * Only `cleanup` is called here — the full class lives in
+ * mcp/tools/bash-session.ts but we don't import it to keep this module
+ * decoupled and to let tests inject lightweight stubs.
+ */
+export interface SessionStateManagerLike {
+  cleanup: (sessionId: string) => void;
+}
 
 /**
  * Dependencies for the SSE endpoint handlers.
@@ -25,24 +64,44 @@ export interface SseHandlerDeps {
   createMcpServer: () => McpServer;
   /**
    * Workspace manager. Accepts either a direct instance or a getter to support
-   * late binding in server.ts.
+   * late binding in server.ts. Uses the structural `WorkspaceManagerLike`
+   * shape so tests can pass minimal stubs.
    */
   workspaceManager:
-    | WorkspaceManager
+    | WorkspaceManagerLike
     | undefined
-    | (() => WorkspaceManager | undefined);
+    | (() => WorkspaceManagerLike | undefined);
+  /**
+   * Session state manager (bash tool per-session shell state). Optional.
+   * Accepts either a direct instance or a getter for late binding, matching
+   * the other managers. When present, cleanup() is called from the SSE
+   * handler's client-disconnect closure AND from reapIdleSseSessions so
+   * per-session shell state doesn't leak when SSE sessions end.
+   */
+  sessionStateManager?:
+    | SessionStateManagerLike
+    | (() => SessionStateManagerLike | undefined);
+  /**
+   * Retry-After hint surfaced in rate-limit rejections. Optional — defaults
+   * to 60 seconds. Server.ts injects something derived from session TTL.
+   */
+  rateLimitRetryAfterSeconds?: number | (() => number);
+  /**
+   * Whether Express is configured to trust a reverse proxy's
+   * `X-Forwarded-For` header. Controls how `clientIp` resolves the caller:
+   * when true, we read `req.ip` (populated by Express from the XFF chain);
+   * when false, we ignore XFF and use the socket peer address so a client
+   * cannot spoof an allowlisted IP. Defaults to `false` when omitted.
+   *
+   * Accepts either a direct value or a getter for late binding — server.ts
+   * reads config during startServer() which runs after this handler
+   * factory is called.
+   */
+  trustProxy?: boolean | (() => boolean);
 }
 
 function resolve<T>(value: T | (() => T)): T {
   return typeof value === "function" ? (value as () => T)() : value;
-}
-
-function clientIp(req: Request): string {
-  return (
-    (req.headers["x-forwarded-for"] as string)?.split(",")[0]?.trim() ||
-    req.socket.remoteAddress ||
-    "unknown"
-  );
 }
 
 /**
@@ -60,42 +119,241 @@ export function createSseHandlers(deps: SseHandlerDeps): {
   const { sseTransports, sessionLastActivity, createMcpServer } = deps;
 
   const sseGet: RequestHandler = async (req: Request, res: Response) => {
-    const ip = clientIp(req);
-    const ipLimiter = resolve(deps.ipLimiter);
-    const workspaceManager = resolve(deps.workspaceManager);
-
     try {
+      // Resolve late-bound deps inside the try block so a getter throw (e.g.
+      // a config reload mid-request) is caught by the handler's own 500 path
+      // instead of escaping to Express's default error handler.
+      const trustProxy = resolve(deps.trustProxy ?? false) ?? false;
+      const ip = clientIp(req, trustProxy);
+      const ipLimiter = resolve(deps.ipLimiter);
+      const workspaceManager = resolve(deps.workspaceManager);
+
+      // Pre-check BEFORE constructing the transport. Mirrors the /mcp path's
+      // pattern: on a rate-limit rejection we should emit a descriptive
+      // payload + 429 and skip all transport/MCP-server wiring. The previous
+      // flow built the transport first, which burned a sessionId on every
+      // rejected request and exposed a race where the transport could
+      // accumulate state before we knew we'd reject.
+      if (
+        ipLimiter &&
+        !ipLimiter.isAllowlisted(ip) &&
+        ipLimiter.getSessionCount(ip) >= ipLimiter.getMax()
+      ) {
+        const currentCount = ipLimiter.getSessionCount(ip);
+        const limit = ipLimiter.getMax();
+        console.warn(
+          `[mcp] IP rate limit exceeded for ${ip} (${currentCount}/${limit}), rejecting SSE session`,
+        );
+        // Clamp once so the Retry-After header agrees with the JSON body.
+        // buildRateLimitPayload also clamps defensively, but the header is
+        // the authoritative signal for standards-compliant clients — it
+        // must carry the same sanitized integer as the body.
+        const retryAfterSeconds = clampRetryAfterSeconds(
+          resolve(deps.rateLimitRetryAfterSeconds ?? 60) ?? 60,
+        );
+        const payload = buildRateLimitPayload({
+          limit,
+          currentCount,
+          retryAfterSeconds,
+        });
+        res.setHeader("Retry-After", String(retryAfterSeconds));
+        res.status(429).json(payload);
+        return;
+      }
+
       // Create transport. sessionId is assigned in the constructor.
       const transport = new SSEServerTransport("/messages", res);
       const sessionId = transport.sessionId;
 
-      // IP rate limit — same counter as /mcp.
-      if (ipLimiter && !ipLimiter.tryAdd(ip, sessionId)) {
-        console.warn(
-          `[mcp] IP rate limit exceeded for ${ip}, rejecting SSE session`,
-        );
-        res.status(429).json({ error: "Too many sessions from this IP" });
-        return;
-      }
-
-      sseTransports[sessionId] = transport;
-      sessionLastActivity[sessionId] = Date.now();
-      workspaceManager?.ensureSession(sessionId);
-
-      // Wire cleanup before connect() so a start() failure still fires it.
+      // Cleanup closure — idempotent via the `sseTransports[sessionId]`
+      // guard below.
+      //
+      // Ownership split:
+      //   - CLIENT-DISCONNECT path: this closure runs via onclose /
+      //     res.on("close"), sees the session still in the map, and owns
+      //     the full cleanup (ipLimiter.remove + workspaceManager.cleanup +
+      //     sessionStateManager.cleanup + map deletion).
+      //   - SERVER-TIMEOUT path: reapIdleSseSessions deletes the map entry
+      //     AND calls the cleanup chain inline BEFORE invoking
+      //     transport.close(). When the SDK later fires onclose, this
+      //     closure's guard sees the entry already gone and short-circuits
+      //     — no double-cleanup.
+      //
+      // The guard is the handshake. Do not weaken it.
+      //
+      // Per-step try/catch mirrors the /mcp path so a throw from one step
+      // doesn't skip the others (e.g. ipLimiter.remove throwing must not
+      // prevent workspaceManager.cleanup or sessionStateManager.cleanup
+      // from running).
+      //
+      // The closure re-resolves ipLimiter / workspaceManager /
+      // sessionStateManager from deps on every invocation. Capturing the
+      // top-of-handler locals was a bug: if the handler factory was
+      // registered at module load (before startServer constructed the real
+      // instances), those captured locals stayed `undefined` for the entire
+      // lifetime of the session, silently dropping cleanup. Re-resolving
+      // picks up whatever the caller has wired up by the time the session
+      // actually closes.
       const cleanup = () => {
         if (sseTransports[sessionId]) {
           delete sseTransports[sessionId];
           delete sessionLastActivity[sessionId];
-          ipLimiter?.remove(sessionId);
-          workspaceManager?.cleanup(sessionId);
+          try {
+            resolve(deps.ipLimiter)?.remove(sessionId);
+          } catch (e) {
+            console.error(`[mcp] SSE IP limiter cleanup failed:`, e);
+          }
+          try {
+            resolve(deps.workspaceManager)?.cleanup(sessionId);
+          } catch (e) {
+            console.error(
+              `[mcp] SSE workspace cleanup failed for ${sessionId.slice(0, 8)}:`,
+              e,
+            );
+          }
+          try {
+            resolve(deps.sessionStateManager)?.cleanup(sessionId);
+          } catch (e) {
+            console.error(
+              `[mcp] SSE session state cleanup failed for ${sessionId.slice(0, 8)}:`,
+              e,
+            );
+          }
           console.log(
             `[mcp] SSE session ${sessionId.slice(0, 8)} closed (${Object.keys(sseTransports).length} active)`,
           );
         }
       };
+
+      // Register in the map BEFORE wiring onclose handlers. If a close
+      // event fires between handler wiring and tryAdd/ensureSession below,
+      // cleanup()'s guard must see a valid map entry so it can drive the
+      // full teardown — otherwise cleanup no-ops and the subsequent steps
+      // run against a dead response, leaking ipLimiter counters and
+      // workspace allocations that nothing will tear down.
+      sseTransports[sessionId] = transport;
+      sessionLastActivity[sessionId] = Date.now();
+
       transport.onclose = cleanup;
       res.on("close", cleanup);
+
+      // Recovery for the narrow window between transport construction and
+      // the `res.on("close")` registration above: if the client already
+      // disconnected (socket destroyed or response ended), neither onclose
+      // nor the res 'close' listener will ever fire — the event already
+      // passed. Actively invoke cleanup so the map entry we just
+      // registered is released, and bail before doing any more work. This
+      // prevents ipLimiter.tryAdd and workspaceManager.ensureSession from
+      // running against a response we can no longer write to.
+      if (res.destroyed || res.writableEnded) {
+        cleanup();
+        return;
+      }
+
+      // Race-fallback: the pre-check above should have caught overflow, but
+      // two concurrent /sse requests from the same IP could still slip one
+      // through between pre-check and counter increment. tryAdd returning
+      // false here means the second request lost the race — reject with
+      // 429 + payload, same shape as the pre-check.
+      if (ipLimiter && !ipLimiter.tryAdd(ip, sessionId)) {
+        const currentCount = ipLimiter.getSessionCount(ip);
+        const limit = ipLimiter.getMax();
+        console.warn(
+          `[mcp] IP rate limit exceeded for ${ip} (${currentCount}/${limit}), rejecting SSE session (race fallback)`,
+        );
+        // Same clamp as the pre-check path so header and body agree.
+        const retryAfterSeconds = clampRetryAfterSeconds(
+          resolve(deps.rateLimitRetryAfterSeconds ?? 60) ?? 60,
+        );
+        const payload = buildRateLimitPayload({
+          limit,
+          currentCount,
+          retryAfterSeconds,
+        });
+        // Clean up the map entries we pre-registered. The transport was
+        // never connected, so onclose will NOT drive a clean tear-down —
+        // which is exactly why we must call transport.close() explicitly
+        // below. SSEServerTransport holds timers/listeners/file handles
+        // from its constructor; skipping close leaks them per rejected race.
+        delete sseTransports[sessionId];
+        delete sessionLastActivity[sessionId];
+        res.setHeader("Retry-After", String(retryAfterSeconds));
+        res.status(429).json(payload);
+        // Mirror the /mcp race-fallback pattern in server.ts: schedule
+        // transport.close() on a microtask so sync throws AND async
+        // rejections are both logged instead of surfacing as unhandled.
+        Promise.resolve()
+          .then(() => transport.close())
+          .catch((e) =>
+            console.error(
+              `[mcp] SSE race-fallback transport.close rejected for ${sessionId.slice(0, 8)}:`,
+              e,
+            ),
+          );
+        return;
+      }
+
+      // Wrap ensureSession in try/catch so a synchronous throw (ENOSPC,
+      // EACCES, corrupted workspace, etc.) runs the full rollback chain
+      // inline instead of relying on the outer catch + res.on('close') to
+      // eventually clean up. Without this, ipLimiter.tryAdd above already
+      // incremented the counter AND we registered map entries — the outer
+      // catch writes 500 but there's no guarantee the close listener
+      // actually fires on an unconnected transport, so counters + workspace
+      // state leak against the IP's cap until TTL reap (30m default).
+      //
+      // Semantics mirror handleSessionInitAccept in server.ts: rollback
+      // clears ipLimiter + sessionStateManager + map entries, closes the
+      // transport on a microtask, and writes a structured 503 body when
+      // headers haven't been sent. workspaceManager.cleanup is NOT called
+      // here because ensureSession threw — nothing to clean.
+      try {
+        workspaceManager?.ensureSession(sessionId);
+      } catch (ensureErr) {
+        console.error(
+          `[mcp] SSE workspaceManager.ensureSession failed for ${sessionId.slice(0, 8)} [${ip}]; rolling back session:`,
+          ensureErr,
+        );
+        // Per-step try/catch so a rollback step failure doesn't mask the
+        // original ensureSession error or skip subsequent steps.
+        try {
+          resolve(deps.ipLimiter)?.remove(sessionId);
+        } catch (e) {
+          console.error(
+            `[mcp] SSE ensureSession-rollback ipLimiter.remove failed for ${sessionId.slice(0, 8)}:`,
+            e,
+          );
+        }
+        try {
+          resolve(deps.sessionStateManager)?.cleanup(sessionId);
+        } catch (e) {
+          console.error(
+            `[mcp] SSE ensureSession-rollback sessionState.cleanup failed for ${sessionId.slice(0, 8)}:`,
+            e,
+          );
+        }
+        // Delete map entries BEFORE scheduling close so the onclose guard
+        // (`if sseTransports[sessionId]`) short-circuits when the SDK
+        // eventually fires onclose for the now-closed transport.
+        delete sseTransports[sessionId];
+        delete sessionLastActivity[sessionId];
+        Promise.resolve()
+          .then(() => transport.close())
+          .catch((e) =>
+            console.error(
+              `[mcp] SSE ensureSession-rollback transport.close rejected for ${sessionId.slice(0, 8)}:`,
+              e,
+            ),
+          );
+        if (!res.headersSent) {
+          res.status(503).json({
+            error: "workspace_unavailable",
+            reason:
+              "Failed to initialize session workspace. Please try again.",
+          });
+        }
+        return;
+      }
 
       // Attach a per-session MCP server. createMcpServer().connect() calls
       // transport.start() internally which writes SSE headers + the
@@ -117,12 +375,32 @@ export function createSseHandlers(deps: SseHandlerDeps): {
   const messagesPost: RequestHandler = async (req: Request, res: Response) => {
     const sessionId = req.query.sessionId;
     if (typeof sessionId !== "string" || !sessionId) {
-      res.status(404).json({ error: "Session not found" });
+      // Log the reason so operators debugging reaper/client races can see
+      // WHY /messages returned 404 without stitching timestamps across
+      // client + server logs. Tag the request origin so the signal is
+      // useful even without a session id to scope to.
+      const trustProxy = resolve(deps.trustProxy ?? false) ?? false;
+      const ip = clientIp(req, trustProxy);
+      console.warn(
+        `[mcp] /messages 404 reason=missing-session-id ip=${ip}`,
+      );
+      res.status(404).json({
+        error: "Session not found",
+        reason: "missing-session-id",
+      });
       return;
     }
     const transport = sseTransports[sessionId];
     if (!transport) {
-      res.status(404).json({ error: "Session not found" });
+      const trustProxy = resolve(deps.trustProxy ?? false) ?? false;
+      const ip = clientIp(req, trustProxy);
+      console.warn(
+        `[mcp] /messages 404 reason=unknown-session-id ip=${ip} sid=${sessionId.slice(0, 8)}`,
+      );
+      res.status(404).json({
+        error: "Session not found",
+        reason: "unknown-session-id",
+      });
       return;
     }
     sessionLastActivity[sessionId] = Date.now();
@@ -148,27 +426,107 @@ export function createSseHandlers(deps: SseHandlerDeps): {
 /**
  * Reap idle SSE sessions. Pure function for testability — server.ts calls
  * this from its periodic reaper alongside the existing Streamable-HTTP reaper.
+ *
+ * Cleanup ownership — the reaper is the authoritative cleaner for the
+ * server-timeout path:
+ *
+ *   1. Delete map entries FIRST (synchronous). This turns the handler's
+ *      `if (sseTransports[sessionId])` guard into a short-circuit when
+ *      onclose eventually fires, avoiding double-cleanup.
+ *   2. Call ipLimiter.remove + workspaceManager.cleanup +
+ *      sessionStateManager.cleanup INLINE — the reaper owns this work.
+ *      Prior design relied on transport.close() firing onclose synchronously,
+ *      but we wrap close in a microtask to capture async rejections; between
+ *      the microtask scheduling and the actual close, the handler's guard is
+ *      already false (map entry deleted), so onclose runs and no-ops. That
+ *      left ipLimiter counters, workspace sessions, AND per-session shell
+ *      state leaking on every reaped session.
+ *   3. Schedule transport.close() on a microtask so sync throws AND async
+ *      rejections are both logged instead of surfacing as unhandled.
+ *
+ * The client-disconnect path continues to be owned by the handler's cleanup
+ * closure (see sseGet above): res.on("close") / transport.onclose fire,
+ * the guard still sees the session registered, and the closure does the
+ * full cleanup chain.
  */
 export function reapIdleSseSessions(opts: {
   sseTransports: Record<string, { close: () => Promise<void> | void }>;
   sessionLastActivity: Record<string, number>;
   ttlMs: number;
   now?: number;
+  /**
+   * IP rate limiter — optional. When present the reaper calls
+   * `remove(sid)` inline so counters stay correct even if the transport's
+   * close() path skips the handler's cleanup closure.
+   */
+  ipLimiter?: { remove: (sessionId: string) => void };
+  /**
+   * Workspace manager — optional. When present the reaper calls
+   * `cleanup(sid)` inline so per-session workspace state is released even
+   * if the handler's onclose chain no-ops.
+   */
+  workspaceManager?: { cleanup: (sessionId: string) => void };
+  /**
+   * Session state manager (bash tool per-session shell state) — optional.
+   * When present the reaper calls `cleanup(sid)` inline so SSE sessions
+   * using bash tools with `session_state: true` don't leak shell state
+   * when idle-reaped. Mirrors the /mcp reaper behavior in server.ts.
+   */
+  sessionStateManager?: { cleanup: (sessionId: string) => void };
 }): string[] {
-  const { sseTransports, sessionLastActivity, ttlMs } = opts;
+  const {
+    sseTransports,
+    sessionLastActivity,
+    ttlMs,
+    ipLimiter,
+    workspaceManager,
+    sessionStateManager,
+  } = opts;
   const now = opts.now ?? Date.now();
   const reaped: string[] = [];
   for (const sid of Object.keys(sseTransports)) {
     const last = sessionLastActivity[sid] ?? 0;
     if (now - last > ttlMs) {
       const transport = sseTransports[sid];
-      try {
-        void transport.close();
-      } catch (e) {
-        console.error(`[mcp] SSE close failed for ${sid.slice(0, 8)}:`, e);
-      }
+      // Delete map entries FIRST so the handler's onclose guard
+      // short-circuits when close() eventually fires its callback.
       delete sseTransports[sid];
       delete sessionLastActivity[sid];
+      // Inline cleanup — the reaper owns this for the server-timeout path.
+      // Per-step try/catch so a failure in one step doesn't skip the others.
+      try {
+        ipLimiter?.remove(sid);
+      } catch (e) {
+        console.error(
+          `[mcp] SSE reaper ipLimiter.remove failed for ${sid.slice(0, 8)}:`,
+          e,
+        );
+      }
+      try {
+        workspaceManager?.cleanup(sid);
+      } catch (e) {
+        console.error(
+          `[mcp] SSE reaper workspace.cleanup failed for ${sid.slice(0, 8)}:`,
+          e,
+        );
+      }
+      try {
+        sessionStateManager?.cleanup(sid);
+      } catch (e) {
+        console.error(
+          `[mcp] SSE reaper sessionState.cleanup failed for ${sid.slice(0, 8)}:`,
+          e,
+        );
+      }
+      // Promise.resolve + .catch attaches a rejection handler even when
+      // transport.close() returns a bare rejected Promise. A plain
+      // `void transport.close()` only catches synchronous throws; an async
+      // rejection would otherwise surface as an unhandled rejection.
+      Promise.resolve()
+        .then(() => transport.close())
+        .catch((e) =>
+          console.error(`[mcp] SSE close failed for ${sid.slice(0, 8)}:`, e),
+        );
       reaped.push(sid);
     }
   }

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,6 +2,76 @@
 // Zod schemas provide runtime validation; TypeScript types are inferred from them.
 
 import { z } from "zod";
+import ipaddr from "ipaddr.js";
+
+/**
+ * Zod validator for a single allowlist entry: either a bare IPv4/IPv6 address
+ * ("160.79.106.35", "2001:db8::1") or a CIDR range ("160.79.106.0/24").
+ *
+ * Validation is two-layered:
+ *   1. Defensive regex pre-check (ALLOWLIST_ENTRY_REGEX below) — rejects
+ *      obviously malformed input before it reaches ipaddr.js.
+ *   2. ipaddr.parseCIDR / ipaddr.parse — the semantic validator that actually
+ *      confirms the address/CIDR is valid.
+ *
+ * The regex exists as defense-in-depth against ipaddr.js tolerance drift:
+ * if a future version of ipaddr.js relaxes what it accepts (e.g. starts
+ * tolerating whitespace, unusual characters, or empty CIDR suffixes), the
+ * regex still rejects those forms so the allowlist cannot be bypassed.
+ *
+ * The regexes reject:
+ *   - any whitespace (leading, trailing, or internal)
+ *   - characters outside the per-family allowed alphabet
+ *   - a negative or non-numeric CIDR suffix
+ *   - an empty CIDR suffix (e.g. "10.0.0.0/")
+ *   - a prefix length outside the per-family valid range (IPv4 0-32,
+ *     IPv6 0-128). Out-of-range prefixes still get rejected downstream by
+ *     ipaddr.js, but catching them at the schema boundary yields a cleaner,
+ *     family-aware error message for operators reading config-validation
+ *     output.
+ *
+ * Two separate regexes are used so that e.g. "10.0.0.0/33" fails with a clear
+ * "not a valid CIDR" message rather than being diffused through ipaddr.js. An
+ * entry matching neither regex is rejected up front.
+ */
+// IPv4 / IPv4-CIDR: decimal octet characters and optional /0–/32.
+const ALLOWLIST_IPV4_REGEX =
+  /^[0-9.]+(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
+// IPv6 / IPv6-CIDR: hex + colons, optional embedded IPv4 dotted-quad
+// (e.g. ::ffff:127.0.0.1), and optional /0–/128. The alphabet allows `.`
+// specifically for the embedded-v4 suffix form; ipaddr.js then does the real
+// semantic parse.
+const ALLOWLIST_IPV6_REGEX =
+  /^[0-9a-fA-F:.]+(\/([0-9]|[1-9][0-9]|1[0-1][0-9]|12[0-8]))?$/;
+
+const AllowlistEntrySchema = z.string().superRefine((val, ctx) => {
+  // An IPv4 entry never contains ':'; an IPv6 entry always does. Dispatch on
+  // that so each family gets its own prefix-range validation, and so an
+  // ambiguous-looking string can't slip past (e.g. "10.0.0.0/99" is rejected
+  // by ALLOWLIST_IPV4_REGEX and never evaluated as IPv6 because it has no
+  // ':').
+  const looksIpv6 = val.includes(":");
+  const regex = looksIpv6 ? ALLOWLIST_IPV6_REGEX : ALLOWLIST_IPV4_REGEX;
+  if (!regex.test(val)) {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Must be a valid IPv4/IPv6 address or CIDR range",
+    });
+    return;
+  }
+  try {
+    if (val.includes("/")) {
+      ipaddr.parseCIDR(val);
+    } else {
+      ipaddr.parse(val);
+    }
+  } catch {
+    ctx.addIssue({
+      code: z.ZodIssueCode.custom,
+      message: "Must be a valid IPv4/IPv6 address or CIDR range",
+    });
+  }
+});
 
 // ── Source configuration schemas ──────────────────────────────────────────────
 
@@ -239,6 +309,23 @@ export const ServerConfigSchema = z
       version: z.string().min(1),
       max_sessions_per_ip: z.number().int().positive().optional(),
       session_ttl_minutes: z.number().int().positive().optional(),
+      // IP/CIDR entries that bypass max_sessions_per_ip. Empty by default.
+      // Example: ["160.79.106.35"] to allowlist the Anthropic Assistant
+      // crawler, or ["10.0.0.0/8"] for an internal health probe range.
+      allowlist: z.array(AllowlistEntrySchema).optional(),
+      // When true, Express is configured with `app.set("trust proxy", true)`
+      // and will populate `req.ip` by walking the `X-Forwarded-For` chain.
+      // When false (the default), `X-Forwarded-For` is IGNORED entirely and
+      // the TCP peer address (`req.socket.remoteAddress`) is used for rate
+      // limiting, allowlist checks, tracing, and analytics.
+      //
+      // SECURITY: Only enable `trust_proxy: true` when this server runs
+      // behind a reverse proxy that strips or rewrites incoming
+      // `X-Forwarded-For` headers. Enabling it on a server directly exposed
+      // to the public internet lets any client spoof their source IP by
+      // sending an `X-Forwarded-For` header — which would let them claim
+      // to be an allowlisted IP and bypass the per-IP session limiter.
+      trust_proxy: z.boolean().optional().default(false),
     }),
     sources: z.array(SourceConfigSchema).min(1),
     tools: z.array(AnyToolConfigSchema).min(1),

--- a/src/types.ts
+++ b/src/types.ts
@@ -35,8 +35,7 @@ import ipaddr from "ipaddr.js";
  * entry matching neither regex is rejected up front.
  */
 // IPv4 / IPv4-CIDR: decimal octet characters and optional /0–/32.
-const ALLOWLIST_IPV4_REGEX =
-  /^[0-9.]+(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
+const ALLOWLIST_IPV4_REGEX = /^[0-9.]+(\/([0-9]|[1-2][0-9]|3[0-2]))?$/;
 // IPv6 / IPv6-CIDR: hex + colons, optional embedded IPv4 dotted-quad
 // (e.g. ::ffff:127.0.0.1), and optional /0–/128. The alphabet allows `.`
 // specifically for the embedded-v4 suffix form; ipaddr.js then does the real


### PR DESCRIPTION
## Summary

- Adds `server.allowlist` — a list of IPs/CIDRs that bypass `max_sessions_per_ip`. Motivated by the Anthropic Assistant crawler (`160.79.106.35`) currently getting throttled. Empty by default; operators opt in per deployment.
- Replaces the bare `{error: "Too many sessions from this IP"}` 429 on `/sse` and the silent `transport.close()` on `/mcp` init with a structured payload clients can actually react to: `{error, reason, limit, currentCount, retryAfterSeconds, contact}`. `/mcp` additionally sends a JSON-RPC 2.0 error frame at code `-32005`.
- CIDR parsing delegated to `ipaddr.js` (already in the transitive tree, now a direct dep). IPv4-mapped IPv6 addresses (`::ffff:127.0.0.1`) normalize to IPv4 so loopback/internal CIDRs match regardless of how the process binds.

## Why

Two separate pain points, one surface:
1. Anthropic's crawler can't complete its indexing when it exceeds the per-IP session cap, and we have no escape hatch for trusted crawlers or internal probes.
2. Non-allowlisted clients that hit the cap either see a cryptic one-line error or, on `/mcp`, a connection that just drops mid-init with no indication of why. Both make the limit painful to diagnose and impossible to self-remediate.

## Test plan

- [x] New unit tests in `src/__tests__/ip-limiter.test.ts` for plain-IP, CIDR (IPv4 and IPv6), non-match, logging throttle, `isAllowlisted()` return values, and malformed/unknown inputs.
- [x] Schema tests in `src/__tests__/tool-config.test.ts` accept plain IP + CIDR + empty list; reject non-IP strings, invalid CIDR suffixes, and non-array allowlists.
- [x] End-to-end tests in `src/__tests__/sse-transport.test.ts` assert the 429 body shape, `Retry-After` header, and allowlist bypass for loopback.
- [x] New `src/__tests__/rate-limit-response.test.ts` covers the shared payload and JSON-RPC error frame shape (code is in the `-32000..-32099` server-error range).
- [x] Full test suite: 2734 passing / 2734.
- [x] `tsc --noEmit` clean.
- [x] `npm run build` clean.

## Red -> green transcript

Before implementation (new tests failing against old code):
```
Test Files  4 failed (4)
     Tests  11 failed | 62 passed (73)
```

After implementation:
```
Test Files  4 passed (4)
     Tests  78 passed (78)
```

Full suite:
```
Test Files  176 passed (176)
     Tests  2734 passed (2734)
```