### PR TITLE
Drift cleanup from PR #42 CR rounds (sample)

### DIFF
--- a/deploy/pathfinder-docs.yaml
+++ b/deploy/pathfinder-docs.yaml
@@ -11,6 +11,7 @@ sources:
     url_derivation:
       strip_prefix: "docs/"
       strip_suffix: ".html"
+      strip_index: true
     file_patterns:
       - "**/*.html"
     chunk:

--- a/src/__tests__/faq-txt-endpoint.test.ts
+++ b/src/__tests__/faq-txt-endpoint.test.ts
@@ -1,0 +1,247 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+
+// Mock DB queries — getFaqChunks drives the per-source fetch that the handler
+// iterates. By making one call throw we simulate a single source failure.
+const mockGetFaqChunks = vi.fn();
+
+vi.mock("../db/queries.js", () => ({
+  getFaqChunks: (...args: unknown[]) => mockGetFaqChunks(...args),
+  // Unused by the FAQ endpoint but imported by server.ts — stub to silence.
+  getIndexStats: vi.fn(),
+  getAllChunksForLlms: vi.fn(),
+  insertCollectedData: vi.fn(),
+}));
+
+// Mock config so getServerConfig returns a stable set of FAQ sources.
+const mockGetServerConfig = vi.fn();
+
+vi.mock("../config.js", () => ({
+  getServerConfig: (...args: unknown[]) => mockGetServerConfig(...args),
+  getConfig: vi.fn().mockReturnValue({
+    port: 3001,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "x".repeat(32),
+  }),
+  getAnalyticsConfig: vi.fn().mockReturnValue(undefined),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import {
+  registerFaqRoute,
+  __resetFaqCacheForTesting,
+} from "../server.js";
+
+function buildTestApp(): express.Express {
+  const app = express();
+  registerFaqRoute(app);
+  return app;
+}
+
+function request(
+  server: http.Server,
+  method: string,
+  path: string,
+): Promise<{
+  status: number;
+  headers: http.IncomingHttpHeaders;
+  body: string;
+}> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      { hostname: "127.0.0.1", port: addr.port, path, method },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () =>
+          resolve({ status: res.statusCode!, headers: res.headers, body }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("GET /faq.txt — partial-failure handling", () => {
+  let server: http.Server;
+  let consoleSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    __resetFaqCacheForTesting();
+    consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    mockGetServerConfig.mockReturnValue({
+      server: { name: "Test FAQ Server" },
+      sources: [
+        {
+          name: "faq-good",
+          type: "slack",
+          category: "faq",
+          confidence_threshold: 0.7,
+        },
+        {
+          name: "faq-broken",
+          type: "slack",
+          category: "faq",
+          confidence_threshold: 0.8,
+        },
+      ],
+      tools: [],
+    });
+  });
+
+  afterEach(async () => {
+    consoleSpy.mockRestore();
+    __resetFaqCacheForTesting();
+    if (server?.listening) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  async function startApp(): Promise<void> {
+    await new Promise<void>((resolve) => {
+      const app = buildTestApp();
+      server = app.listen(0, () => resolve());
+    });
+  }
+
+  it("does not cache the partial response when a source fetch fails, and retries on the next request", async () => {
+    // faq-good returns chunks; faq-broken throws. Both calls should go
+    // through on the SECOND request because we refused to cache.
+    mockGetFaqChunks.mockImplementation(
+      async (sourceNames: string[]) => {
+        if (sourceNames.includes("faq-broken")) {
+          throw new Error("upstream timeout");
+        }
+        return [
+          {
+            source_name: "faq-good",
+            source_url: null,
+            title: "How do I X?",
+            content: "Q: How do I X?\n\nA: You X.",
+            chunk_index: 0,
+          },
+        ];
+      },
+    );
+
+    await startApp();
+
+    const res1 = await request(server, "GET", "/faq.txt");
+    expect(res1.status).toBe(200);
+    // Good source content is served
+    expect(res1.body).toContain("faq-good");
+    expect(res1.body).toContain("Q: How do I X?");
+    // Failure signalled via header
+    expect(res1.headers["x-partial-sources"]).toBe("faq-broken");
+    expect(res1.headers["cache-control"]).toBe("no-store");
+
+    // The partial-ness MUST NOT be cached: a second request re-fetches,
+    // so getFaqChunks is called again for every source.
+    const callsAfterFirst = mockGetFaqChunks.mock.calls.length;
+    expect(callsAfterFirst).toBe(2); // faq-good + faq-broken
+
+    const res2 = await request(server, "GET", "/faq.txt");
+    expect(res2.status).toBe(200);
+    // Still partial on retry (broken source still broken).
+    expect(res2.headers["x-partial-sources"]).toBe("faq-broken");
+    expect(res2.headers["cache-control"]).toBe("no-store");
+
+    // The critical assertion: the second request hit the fetch path again
+    // for every source. If the partial result had been cached, total calls
+    // would still be 2.
+    expect(mockGetFaqChunks.mock.calls.length).toBe(callsAfterFirst + 2);
+  });
+
+  it("caches normally when all sources succeed", async () => {
+    mockGetFaqChunks.mockResolvedValue([
+      {
+        source_name: "faq-good",
+        source_url: null,
+        title: "Hello",
+        content: "Q: Hello?\n\nA: Hi.",
+        chunk_index: 0,
+      },
+    ]);
+
+    await startApp();
+
+    const res1 = await request(server, "GET", "/faq.txt");
+    expect(res1.status).toBe(200);
+    expect(res1.headers["x-partial-sources"]).toBeUndefined();
+    // Default cache-control behaviour (not no-store).
+    expect(res1.headers["cache-control"]).not.toBe("no-store");
+
+    const callsAfterFirst = mockGetFaqChunks.mock.calls.length;
+    expect(callsAfterFirst).toBe(2); // one call per source
+
+    // Second request should be served from cache — no new fetches.
+    const res2 = await request(server, "GET", "/faq.txt");
+    expect(res2.status).toBe(200);
+    expect(mockGetFaqChunks.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("lists every failing source name in X-Partial-Sources when more than one fails", async () => {
+    mockGetServerConfig.mockReturnValue({
+      server: { name: "Test FAQ Server" },
+      sources: [
+        {
+          name: "faq-ok",
+          type: "slack",
+          category: "faq",
+          confidence_threshold: 0.7,
+        },
+        {
+          name: "faq-broken-a",
+          type: "slack",
+          category: "faq",
+          confidence_threshold: 0.7,
+        },
+        {
+          name: "faq-broken-b",
+          type: "slack",
+          category: "faq",
+          confidence_threshold: 0.7,
+        },
+      ],
+      tools: [],
+    });
+
+    mockGetFaqChunks.mockImplementation(
+      async (sourceNames: string[]) => {
+        if (sourceNames[0].startsWith("faq-broken")) {
+          throw new Error("boom");
+        }
+        return [];
+      },
+    );
+
+    await startApp();
+
+    const res = await request(server, "GET", "/faq.txt");
+    expect(res.status).toBe(200);
+    const header = res.headers["x-partial-sources"];
+    expect(typeof header).toBe("string");
+    // Order follows config order; both failed sources must be present.
+    expect(header).toBe("faq-broken-a,faq-broken-b");
+    expect(res.headers["cache-control"]).toBe("no-store");
+  });
+});

--- a/src/__tests__/faq-txt-endpoint.test.ts
+++ b/src/__tests__/faq-txt-endpoint.test.ts
@@ -42,10 +42,7 @@ vi.mock("../config.js", () => ({
   hasBashSemanticSearch: vi.fn().mockReturnValue(false),
 }));
 
-import {
-  registerFaqRoute,
-  __resetFaqCacheForTesting,
-} from "../server.js";
+import { registerFaqRoute, __resetFaqCacheForTesting } from "../server.js";
 
 function buildTestApp(): express.Express {
   const app = express();
@@ -126,22 +123,20 @@ describe("GET /faq.txt — partial-failure handling", () => {
   it("does not cache the partial response when a source fetch fails, and retries on the next request", async () => {
     // faq-good returns chunks; faq-broken throws. Both calls should go
     // through on the SECOND request because we refused to cache.
-    mockGetFaqChunks.mockImplementation(
-      async (sourceNames: string[]) => {
-        if (sourceNames.includes("faq-broken")) {
-          throw new Error("upstream timeout");
-        }
-        return [
-          {
-            source_name: "faq-good",
-            source_url: null,
-            title: "How do I X?",
-            content: "Q: How do I X?\n\nA: You X.",
-            chunk_index: 0,
-          },
-        ];
-      },
-    );
+    mockGetFaqChunks.mockImplementation(async (sourceNames: string[]) => {
+      if (sourceNames.includes("faq-broken")) {
+        throw new Error("upstream timeout");
+      }
+      return [
+        {
+          source_name: "faq-good",
+          source_url: null,
+          title: "How do I X?",
+          content: "Q: How do I X?\n\nA: You X.",
+          chunk_index: 0,
+        },
+      ];
+    });
 
     await startApp();
 
@@ -225,14 +220,12 @@ describe("GET /faq.txt — partial-failure handling", () => {
       tools: [],
     });
 
-    mockGetFaqChunks.mockImplementation(
-      async (sourceNames: string[]) => {
-        if (sourceNames[0].startsWith("faq-broken")) {
-          throw new Error("boom");
-        }
-        return [];
-      },
-    );
+    mockGetFaqChunks.mockImplementation(async (sourceNames: string[]) => {
+      if (sourceNames[0].startsWith("faq-broken")) {
+        throw new Error("boom");
+      }
+      return [];
+    });
 
     await startApp();
 

--- a/src/__tests__/health-endpoint.test.ts
+++ b/src/__tests__/health-endpoint.test.ts
@@ -1,0 +1,194 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+
+// Mock config so hasSearchTools() returns true (exercising the DB code path).
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({
+    server: { name: "test-server" },
+  }),
+  getAnalyticsConfig: vi.fn(),
+  getConfig: vi.fn().mockReturnValue({
+    port: 3001,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "x".repeat(32),
+  }),
+  // Force the /health handler down the DB-probing branch so we exercise
+  // the 503 error-response code path.
+  hasSearchTools: vi.fn().mockReturnValue(true),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import { registerHealthRoute } from "../server.js";
+
+// The exact sensitive message a failing DB driver might produce. The /health
+// 503 body must NOT expose any of the substrings asserted below.
+const SENSITIVE_MESSAGE =
+  "connection to database failed: postgresql://user:secret@10.0.0.5:5432/db";
+
+// ---------------------------------------------------------------------------
+// Helper: make HTTP requests to the test server (same pattern as
+// analytics-server.test.ts — we intentionally don't pull in supertest).
+// ---------------------------------------------------------------------------
+
+function request(
+  server: http.Server,
+  method: string,
+  path: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      { hostname: "127.0.0.1", port: addr.port, path, method },
+      (res) => {
+        let body = "";
+        res.on("data", (chunk) => (body += chunk));
+        res.on("end", () =>
+          resolve({ status: res.statusCode ?? 0, body }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("GET /health — 503 body must not leak DB error details", () => {
+  let server: http.Server;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // /health logs the full error server-side. Swallow it so failing-path
+    // tests don't pollute test output — we assert separately that it IS
+    // logged (so operators still get the detail).
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(async () => {
+    consoleErrorSpy.mockRestore();
+    if (server?.listening) {
+      await new Promise<void>((resolve) => server.close(() => resolve()));
+    }
+  });
+
+  function startApp(
+    getIndexStats: () => Promise<unknown>,
+  ): Promise<void> {
+    return new Promise((resolve) => {
+      const app = express();
+      registerHealthRoute(app, {
+        getIndexStats: getIndexStats as never,
+      });
+      server = app.listen(0, () => resolve());
+    });
+  }
+
+  it("returns 503 with a sanitized body when the DB health check throws", async () => {
+    const err = new Error(SENSITIVE_MESSAGE);
+    await startApp(() => Promise.reject(err));
+
+    const res = await request(server, "GET", "/health");
+
+    expect(res.status).toBe(503);
+
+    const body = JSON.parse(res.body);
+
+    // Shape assertions — the sanitized body exposes only these fields.
+    expect(body.status).toBe("degraded");
+    expect(body.server).toBe("test-server");
+    expect(typeof body.uptime_seconds).toBe("number");
+    expect(typeof body.started_at).toBe("string");
+    expect(body.index).toBe("unavailable");
+
+    // Sensitive-content assertions — verify against the RAW response body
+    // (not just the parsed JSON) so we catch leaks in any field, including
+    // a stray `error`, `details`, `cause`, stack, etc.
+    const rawBody = res.body;
+    const forbiddenSubstrings = [
+      "postgres", // matches "postgres", "postgresql", "postgres://"
+      "password",
+      "secret",
+      "10.0.0.5",
+      "5432",
+      SENSITIVE_MESSAGE,
+      "connection to database failed",
+    ];
+    for (const needle of forbiddenSubstrings) {
+      expect(
+        rawBody.toLowerCase(),
+        `/health 503 body must not contain "${needle}" — got: ${rawBody}`,
+      ).not.toContain(needle.toLowerCase());
+    }
+
+    // Operators still need the detail — confirm we logged the full error
+    // server-side. This pins the "log server-side, sanitize client-side"
+    // contract so a future refactor can't silently drop the log.
+    expect(consoleErrorSpy).toHaveBeenCalled();
+    const loggedArgs: unknown[] = consoleErrorSpy.mock.calls.flat();
+    const sawFullError = loggedArgs.some(
+      (arg: unknown) =>
+        arg instanceof Error && arg.message === SENSITIVE_MESSAGE,
+    );
+    expect(
+      sawFullError,
+      "Expected the full error (with sensitive message) to be logged via console.error",
+    ).toBe(true);
+  });
+
+  it("does not expose any 'error' / 'details' / 'cause' field on 503", async () => {
+    // Defense-in-depth: even if someone later adds an `error` field that
+    // happens not to contain the exact strings above, any freeform
+    // error-derived field is a leak risk on an unauthenticated endpoint.
+    // Pin the response shape explicitly.
+    await startApp(() => Promise.reject(new Error("anything at all")));
+
+    const res = await request(server, "GET", "/health");
+    expect(res.status).toBe(503);
+
+    const body = JSON.parse(res.body);
+    expect(body).not.toHaveProperty("error");
+    expect(body).not.toHaveProperty("details");
+    expect(body).not.toHaveProperty("cause");
+    expect(body).not.toHaveProperty("stack");
+    expect(body).not.toHaveProperty("message");
+
+    // Exact allowlist — fail loudly if a new field sneaks in.
+    expect(Object.keys(body).sort()).toEqual(
+      ["index", "server", "started_at", "status", "uptime_seconds"].sort(),
+    );
+  });
+
+  it("handles non-Error rejections (e.g. string throws) without leaking them", async () => {
+    // DB drivers sometimes reject with non-Error values. The pre-fix code
+    // would stringify these with `String(err)` into the response body —
+    // same leak class. Verify the sanitized body still holds.
+    await startApp(() =>
+      Promise.reject(
+        `internal: postgresql://admin:hunter2@db.internal:5432/prod`,
+      ),
+    );
+
+    const res = await request(server, "GET", "/health");
+    expect(res.status).toBe(503);
+
+    const rawBody = res.body.toLowerCase();
+    expect(rawBody).not.toContain("postgres");
+    expect(rawBody).not.toContain("hunter2");
+    expect(rawBody).not.toContain("db.internal");
+    expect(rawBody).not.toContain("5432");
+  });
+});

--- a/src/__tests__/health-endpoint.test.ts
+++ b/src/__tests__/health-endpoint.test.ts
@@ -56,9 +56,7 @@ function request(
       (res) => {
         let body = "";
         res.on("data", (chunk) => (body += chunk));
-        res.on("end", () =>
-          resolve({ status: res.statusCode ?? 0, body }),
-        );
+        res.on("end", () => resolve({ status: res.statusCode ?? 0, body }));
       },
     );
     req.on("error", reject);
@@ -85,9 +83,7 @@ describe("GET /health — 503 body must not leak DB error details", () => {
     }
   });
 
-  function startApp(
-    getIndexStats: () => Promise<unknown>,
-  ): Promise<void> {
+  function startApp(getIndexStats: () => Promise<unknown>): Promise<void> {
     return new Promise((resolve) => {
       const app = express();
       registerHealthRoute(app, {

--- a/src/server.ts
+++ b/src/server.ts
@@ -779,11 +779,7 @@ export function registerFaqRoute(
         }
       }
 
-      const body = generateFaqTxt(
-        allChunks,
-        serverCfg.server.name,
-        faqSources,
-      );
+      const body = generateFaqTxt(allChunks, serverCfg.server.name, faqSources);
 
       if (failedSources.length > 0) {
         // Partial result — serve once, do NOT cache, surface the failure

--- a/src/server.ts
+++ b/src/server.ts
@@ -695,10 +695,52 @@ app.get("/llms-full.txt", async (_req: Request, res: Response) => {
   }
 });
 
-app.get("/faq.txt", async (_req: Request, res: Response) => {
-  try {
-    if (!cachedFaqTxt) {
-      const serverCfg = getServerConfig();
+/**
+ * Deps hook for the /faq.txt handler. Lets tests swap the DB + config
+ * boundaries without reimplementing the handler. Mirrors the pattern used
+ * by registerAnalyticsRoutes().
+ */
+export interface FaqRouteDeps {
+  getFaqChunks?: typeof getFaqChunks;
+  getServerConfig?: typeof getServerConfig;
+}
+
+/**
+ * Reset the module-level /faq.txt cache. Test-only helper so suites can
+ * assert the retry-on-partial-failure behaviour (second request must
+ * re-enter the fetch path when the previous response was partial).
+ */
+export function __resetFaqCacheForTesting(): void {
+  cachedFaqTxt = null;
+}
+
+/**
+ * Register GET /faq.txt. Extracted so tests can mount the real handler
+ * against stubbed deps; the production call site in module init passes no
+ * deps and uses the imported getFaqChunks/getServerConfig.
+ *
+ * Partial-failure policy: if any per-source fetch throws, we serve the
+ * partial result ONCE with `Cache-Control: no-store` and
+ * `X-Partial-Sources: <failed names>` so operators/agents can detect the
+ * gap, and we do NOT populate `cachedFaqTxt`. The next request re-enters
+ * the fetch path. Previously the partial body was cached and served 200
+ * OK until the next reindex invalidation — hours of silent gaps.
+ */
+export function registerFaqRoute(
+  app: express.Express,
+  deps: FaqRouteDeps = {},
+): void {
+  const _getFaqChunks = deps.getFaqChunks ?? getFaqChunks;
+  const _getServerConfig = deps.getServerConfig ?? getServerConfig;
+
+  app.get("/faq.txt", async (_req: Request, res: Response) => {
+    try {
+      if (cachedFaqTxt) {
+        res.type("text/plain").send(cachedFaqTxt);
+        return;
+      }
+
+      const serverCfg = _getServerConfig();
       // Find FAQ sources: sources with category === 'faq'
       const faqSources = serverCfg.sources
         .filter((s) => "category" in s && s.category === "faq")
@@ -713,39 +755,58 @@ app.get("/faq.txt", async (_req: Request, res: Response) => {
 
       if (faqSources.length === 0) {
         cachedFaqTxt = generateFaqTxt([], serverCfg.server.name, []);
-      } else {
-        // Fetch FAQ chunks per source with its confidence threshold
-        const allChunks: FaqChunkResult[] = [];
-        for (const src of faqSources) {
-          try {
-            const chunks = await getFaqChunks(
-              [src.name],
-              src.confidenceThreshold,
-            );
-            allChunks.push(...chunks);
-          } catch (err) {
-            const msg = err instanceof Error ? err.message : String(err);
-            console.error(
-              `[faq.txt] Failed to fetch chunks for source "${src.name}": ${msg}`,
-            );
-          }
-        }
-        cachedFaqTxt = generateFaqTxt(
-          allChunks,
-          serverCfg.server.name,
-          faqSources,
-        );
+        res.type("text/plain").send(cachedFaqTxt);
+        return;
       }
+
+      // Fetch FAQ chunks per source. Track which sources failed so we can
+      // refuse to cache a partial result.
+      const allChunks: FaqChunkResult[] = [];
+      const failedSources: string[] = [];
+      for (const src of faqSources) {
+        try {
+          const chunks = await _getFaqChunks(
+            [src.name],
+            src.confidenceThreshold,
+          );
+          allChunks.push(...chunks);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          console.error(
+            `[faq.txt] Failed to fetch chunks for source "${src.name}": ${msg}`,
+          );
+          failedSources.push(src.name);
+        }
+      }
+
+      const body = generateFaqTxt(
+        allChunks,
+        serverCfg.server.name,
+        faqSources,
+      );
+
+      if (failedSources.length > 0) {
+        // Partial result — serve once, do NOT cache, surface the failure
+        // via headers so downstream can alert / filter.
+        res.setHeader("X-Partial-Sources", failedSources.join(","));
+        res.setHeader("Cache-Control", "no-store");
+        res.type("text/plain").send(body);
+        return;
+      }
+
+      cachedFaqTxt = body;
+      res.type("text/plain").send(cachedFaqTxt);
+    } catch (err) {
+      console.error("[faq.txt] Generation failed:", err);
+      res
+        .status(503)
+        .type("text/plain")
+        .send("# Service unavailable\nFAQ index not ready.");
     }
-    res.type("text/plain").send(cachedFaqTxt);
-  } catch (err) {
-    console.error("[faq.txt] Generation failed:", err);
-    res
-      .status(503)
-      .type("text/plain")
-      .send("# Service unavailable\nFAQ index not ready.");
-  }
-});
+  });
+}
+
+registerFaqRoute(app);
 
 // ---------------------------------------------------------------------------
 // skill.md — dynamically generated from server config

--- a/src/server.ts
+++ b/src/server.ts
@@ -581,61 +581,79 @@ app.post("/messages", ...sseHandlers.postHandler);
 // Health check
 // ---------------------------------------------------------------------------
 
-app.get("/health", async (_req: Request, res: Response) => {
-  const uptime = Math.floor((Date.now() - startedAt.getTime()) / 1000);
-  const needsDb =
-    hasSearchTools() ||
-    hasKnowledgeTools() ||
-    hasCollectTools() ||
-    hasBashSemanticSearch();
+export interface HealthRouteDeps {
+  getIndexStats?: typeof getIndexStats;
+}
 
-  if (!needsDb) {
-    res.json({
-      status: "ok",
-      server: getServerConfig().server.name,
-      uptime_seconds: uptime,
-      started_at: startedAt.toISOString(),
-      indexing: false,
-      index: "not_configured",
-    });
-    return;
-  }
+export function registerHealthRoute(
+  app: express.Express,
+  deps: HealthRouteDeps = {},
+): void {
+  const _getIndexStats = deps.getIndexStats ?? getIndexStats;
 
-  try {
-    const stats = await getIndexStats();
-    res.json({
-      status: "ok",
-      server: getServerConfig().server.name,
-      uptime_seconds: uptime,
-      started_at: startedAt.toISOString(),
-      indexing:
-        (orchestratorRef as IndexingOrchestrator | null)?.isIndexing() ?? false,
-      index: {
-        total_chunks: stats.totalChunks,
-        by_source: stats.bySource,
-        indexed_repos: stats.indexedRepos,
-        sources: stats.indexStates.map((s) => ({
-          type: s.source_type,
-          key: s.source_key,
-          status: s.status,
-          last_indexed: s.last_indexed_at,
-          commit: s.last_commit_sha?.slice(0, 8) ?? null,
-          error: s.error_message ?? null,
-        })),
-      },
-    });
-  } catch (err) {
-    console.error("[health] Database unavailable:", err);
-    res.status(503).json({
-      status: "degraded",
-      server: getServerConfig().server.name,
-      uptime_seconds: uptime,
-      started_at: startedAt.toISOString(),
-      index: "unavailable",
-      error: err instanceof Error ? err.message : String(err),
-    });
-  }
-});
+  app.get("/health", async (_req: Request, res: Response) => {
+    const uptime = Math.floor((Date.now() - startedAt.getTime()) / 1000);
+    const needsDb =
+      hasSearchTools() ||
+      hasKnowledgeTools() ||
+      hasCollectTools() ||
+      hasBashSemanticSearch();
+
+    if (!needsDb) {
+      res.json({
+        status: "ok",
+        server: getServerConfig().server.name,
+        uptime_seconds: uptime,
+        started_at: startedAt.toISOString(),
+        indexing: false,
+        index: "not_configured",
+      });
+      return;
+    }
+
+    try {
+      const stats = await _getIndexStats();
+      res.json({
+        status: "ok",
+        server: getServerConfig().server.name,
+        uptime_seconds: uptime,
+        started_at: startedAt.toISOString(),
+        indexing:
+          (orchestratorRef as IndexingOrchestrator | null)?.isIndexing() ??
+          false,
+        index: {
+          total_chunks: stats.totalChunks,
+          by_source: stats.bySource,
+          indexed_repos: stats.indexedRepos,
+          sources: stats.indexStates.map((s) => ({
+            type: s.source_type,
+            key: s.source_key,
+            status: s.status,
+            last_indexed: s.last_indexed_at,
+            commit: s.last_commit_sha?.slice(0, 8) ?? null,
+            error: s.error_message ?? null,
+          })),
+        },
+      });
+    } catch (err) {
+      // Log the full error server-side for operators, but never surface
+      // err.message in the response body: /health is unauthenticated and
+      // probed by every load balancer, and errors from the DB driver can
+      // contain DATABASE_URL fragments, table/schema names, and internal
+      // host:port info. Keep the response body to fixed, sanitized fields.
+      console.error("[health] Database unavailable:", err);
+      res.status(503).json({
+        status: "degraded",
+        server: getServerConfig().server.name,
+        uptime_seconds: uptime,
+        started_at: startedAt.toISOString(),
+        index: "unavailable",
+      });
+    }
+  });
+}
+
+registerHealthRoute(app);
 
 // ---------------------------------------------------------------------------
 // llms.txt and llms-full.txt — cached, invalidated on reindex


### PR DESCRIPTION
## Summary

Three deferred items from the PR #42 drift tracker. Independent of #42; can land before or after.

- `Sanitize /health 503 response body` — never expose raw DB error message (could leak DATABASE_URL, host:port, schema names to unauthenticated probes). Surfaced by CR R5 Slot 2.
- `Do not cache partial /faq.txt result when a per-source fetch fails` — previously cached a partial body on transient source failure; next reindex invalidated it, but meanwhile agents saw silent gaps. Now emits \`Cache-Control: no-store\` + \`X-Partial-Sources\` header and skips the cache write. Surfaced by CR R5 Slot 2 F17.
- `Add strip_index: true to pathfinder-docs url_derivation` — docs URLs canonicalize to \`/config\`, \`/deploy\`, etc., but without \`strip_index\` the derived URL was \`/config/index\`. Sibling \`copilotkit-docs.yaml\` already had it. Surfaced by CR R3/R5 Slot 7.

## Why

Each was surfaced during PR #42's review rounds but is independent of the rate-limit feature. Routed out of #42 to keep that PR scoped; tracked on Notion page \`3493aa38-1852-817b-8953-e60844fe0071\`.

## Test plan

- [x] \`npm test\` — 2710/2710 pass
- [x] \`npx tsc --noEmit\` clean
- [x] \`npm run build\` clean
- [x] \`npx prettier --check\` clean
- [x] Red-green tests for both behavioral changes (health sanitization: forbidden-substring assertions; faq partial-cache: no-cache on failure + retry on next call)

## Note on process

This branch was used as a sample run of an experimental fix-agent discipline (mini-CR-loop + provenance-citation). Three fix agents produced these three commits in per-agent worktrees. Results are captured in the drift tracker; protocol will iterate before graduating to internal-skills.