### PR TITLE
Pathfinder drift cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,9 @@
         "filesystem"
     ],
     "license": "Elastic-2.0",
+    "engines": {
+        "node": ">=20"
+    },
     "main": "dist/index.js",
     "bin": {
         "pathfinder": "dist/cli.js"

--- a/package.json
+++ b/package.json
@@ -69,10 +69,18 @@
         "zod": "^3.23.8"
     },
     "peerDependencies": {
-        "@xenova/transformers": "^2.17.0"
+        "@xenova/transformers": "^2.17.0",
+        "pdf-parse": "^1.1.0",
+        "mammoth": "^1.7.0"
     },
     "peerDependenciesMeta": {
         "@xenova/transformers": {
+            "optional": true
+        },
+        "pdf-parse": {
+            "optional": true
+        },
+        "mammoth": {
             "optional": true
         }
     },

--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -30,6 +30,22 @@ server:
   # When false (the default), X-Forwarded-For is ignored and the server
   # uses the TCP socket's peer address. Leave this false for any server
   # exposed directly to the public internet.
+  #
+  # Hosted note — Railway, Fly, Render, Heroku, Cloud Run, AWS App
+  # Runner, Vercel, and similar PaaS edges ALWAYS sit in front of your
+  # container and terminate TLS, so the socket peer the server sees is
+  # the platform proxy — never the real client. On these platforms you
+  # MUST set trust_proxy (to true, a hop count, or a trusted-proxy CIDR
+  # allowlist matching your platform's docs) or every rate-limit bucket
+  # and CIDR allowlist entry evaluates against the proxy IP instead of
+  # the real caller.
+  #
+  # Accepted values:
+  #   false             — ignore X-Forwarded-For (hardened default)
+  #   true              — trust every hop (only safe when the platform
+  #                       strips client-supplied X-Forwarded-For)
+  #   <integer>         — trust N hops (e.g. 1 for single-proxy Railway)
+  #   [<cidr>, ...]     — allowlist of trusted proxy CIDRs
   trust_proxy: false
 
 sources:

--- a/src/__tests__/activity-refresh-ordering.test.ts
+++ b/src/__tests__/activity-refresh-ordering.test.ts
@@ -1,0 +1,134 @@
+/**
+ * R4-3 — sessionLastActivity must be refreshed AFTER the transport handler
+ * returns successfully, not BEFORE it runs. Pre-refresh let a consistently-
+ * throwing transport keep bumping its stamp every failed call and evade the
+ * idle reaper (which treats recent activity as "session is healthy").
+ *
+ * This file covers both refresh sites: the /mcp existing-session path in
+ * server.ts and the /messages POST in sse-handlers.ts.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { Request, Response } from "express";
+
+const mockGetConfig = vi.fn();
+const mockGetServerConfig = vi.fn();
+const mockGetAnalyticsConfig = vi.fn();
+
+vi.mock("../config.js", () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  getServerConfig: (...args: unknown[]) => mockGetServerConfig(...args),
+  getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+beforeEach(() => {
+  mockGetConfig.mockReturnValue({
+    port: 0,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "e".repeat(64),
+  });
+  mockGetServerConfig.mockReturnValue({
+    server: { name: "pathfinder-test", version: "0.0.0" },
+    sources: [],
+    tools: [],
+  });
+  mockGetAnalyticsConfig.mockReturnValue(undefined);
+});
+
+describe("handleExistingSessionRequest refresh ordering (R4-3)", () => {
+  it("does not bump sessionLastActivity when the handler throws", async () => {
+    const { handleExistingSessionRequest } = await import("../server.js");
+    const sessionLastActivity: Record<string, number> = { sid1: 1000 };
+    const transport = {
+      handleRequest: vi.fn(async () => {
+        throw new Error("transport-boom");
+      }),
+    };
+    const before = sessionLastActivity["sid1"];
+    await expect(
+      handleExistingSessionRequest({
+        sid: "sid1",
+        transport,
+        req: { body: {} } as unknown as Request,
+        res: {} as unknown as Response,
+        sessionLastActivity,
+        now: () => 5000,
+      }),
+    ).rejects.toThrow("transport-boom");
+    // MUST remain at the pre-request value. A consistently-throwing
+    // transport otherwise bumps its stamp every call and the idle reaper
+    // never notices it.
+    expect(sessionLastActivity["sid1"]).toBe(before);
+  });
+
+  it("bumps sessionLastActivity after a successful handler call", async () => {
+    const { handleExistingSessionRequest } = await import("../server.js");
+    const sessionLastActivity: Record<string, number> = { sid1: 1000 };
+    const transport = { handleRequest: vi.fn(async () => {}) };
+    await handleExistingSessionRequest({
+      sid: "sid1",
+      transport,
+      req: { body: {} } as unknown as Request,
+      res: {} as unknown as Response,
+      sessionLastActivity,
+      now: () => 5000,
+    });
+    expect(sessionLastActivity["sid1"]).toBe(5000);
+  });
+});
+
+describe("SSE /messages refresh ordering (R4-3)", () => {
+  it("does not bump sessionLastActivity when handlePostMessage throws", async () => {
+    const { createSseHandlers } = await import("../sse-handlers.js");
+    const sessionLastActivity: Record<string, number> = { sid1: 1000 };
+    const transport = {
+      handlePostMessage: vi.fn(async () => {
+        throw new Error("post-boom");
+      }),
+    };
+    const { postHandler } = createSseHandlers({
+      sseTransports: { sid1: transport } as unknown as Parameters<
+        typeof createSseHandlers
+      >[0]["sseTransports"],
+      sessionLastActivity,
+      ipLimiter: undefined,
+      workspaceManager: undefined,
+      createMcpServer: () => ({}) as never,
+    });
+    const req = {
+      query: { sessionId: "sid1" },
+      body: {},
+      headers: {},
+      socket: { remoteAddress: "127.0.0.1" },
+    } as unknown as Request;
+    const res = {
+      headersSent: false,
+      status: vi.fn().mockReturnThis(),
+      json: vi.fn().mockReturnThis(),
+    } as unknown as Response;
+    const next = vi.fn();
+    const messagesPost = postHandler[postHandler.length - 1];
+    await (
+      messagesPost as unknown as (
+        r: Request,
+        s: Response,
+        n: () => void,
+      ) => Promise<void>
+    )(req, res, next);
+    expect(sessionLastActivity["sid1"]).toBe(1000);
+  });
+});

--- a/src/__tests__/analytics-auth-length-check.test.ts
+++ b/src/__tests__/analytics-auth-length-check.test.ts
@@ -1,0 +1,115 @@
+/**
+ * R4-18 — analyticsAuth's timingSafeEqual comparison works today, but the
+ * length check and the equality call are fused into a single boolean
+ * expression (`len !== len || !timingSafeEqual(...)`). That's correct but
+ * fragile: a future refactor that flips the || to && or reorders the
+ * operands would crash with an ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH thrown
+ * from timingSafeEqual (which REQUIRES same-length buffers). Split the
+ * check into a dedicated early return so the contract is explicit and
+ * self-documenting.
+ *
+ * This test asserts the observable behavior holds in both branches —
+ * the split shouldn't change response shape or status.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+
+vi.mock("../db/analytics.js", () => ({
+  getAnalyticsSummary: vi.fn(),
+  getTopQueries: vi.fn(),
+  getEmptyQueries: vi.fn(),
+  getToolCounts: vi.fn(),
+}));
+
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({ sources: [], tools: [] }),
+  getAnalyticsConfig: vi
+    .fn()
+    .mockReturnValue({ enabled: true, token: "correct-token-1234" }),
+  getConfig: vi.fn().mockReturnValue({ nodeEnv: "production" }),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+  assertDocumentPeerDepsForSources: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  registerAnalyticsRoutes,
+  __resetAnalyticsTokenForTesting,
+  __setTrustProxyForTesting,
+} from "../server.js";
+
+function httpGet(
+  server: http.Server,
+  p: string,
+  headers: Record<string, string> = {},
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path: p,
+        method: "GET",
+        headers,
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => resolve({ status: res.statusCode!, body }));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("analyticsAuth length-check early return (R4-18)", () => {
+  let server: http.Server;
+
+  beforeEach(async () => {
+    __resetAnalyticsTokenForTesting();
+    __setTrustProxyForTesting(false);
+    const app = express();
+    app.use(express.json());
+    registerAnalyticsRoutes(app, {
+      getAnalyticsSummary: async () => ({ total: 0 }) as never,
+      getTopQueries: async () => [],
+      getEmptyQueries: async () => [],
+      getToolCounts: async () => [],
+    });
+    server = http.createServer(app);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  });
+
+  afterEach(async () => {
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("returns 403 for a token of DIFFERENT length without throwing", async () => {
+    const res = await httpGet(server, "/api/analytics/summary", {
+      Authorization: "Bearer x", // 1 char vs 18-char correct token
+    });
+    expect(res.status).toBe(403);
+    const body = JSON.parse(res.body) as { error: string };
+    expect(body.error).toBe("forbidden");
+  });
+
+  it("returns 403 for a token of SAME length that differs byte-wise", async () => {
+    // "correct-token-1234" is 18 chars; "zzzzzzzzzzzzzzzzzz" is also 18.
+    const res = await httpGet(server, "/api/analytics/summary", {
+      Authorization: "Bearer zzzzzzzzzzzzzzzzzz",
+    });
+    expect(res.status).toBe(403);
+  });
+
+  it("accepts the correct token", async () => {
+    const res = await httpGet(server, "/api/analytics/summary", {
+      Authorization: "Bearer correct-token-1234",
+    });
+    expect(res.status).toBe(200);
+  });
+});

--- a/src/__tests__/analytics-auth.test.ts
+++ b/src/__tests__/analytics-auth.test.ts
@@ -230,4 +230,108 @@ describe("analyticsAuth 503 message prod vs non-prod", () => {
     // Non-prod message must NOT mention production — that'd be misleading.
     expect(body.error_description).not.toMatch(/production/i);
   });
+
+  // R4-16: the dev-bypass gate is `nodeEnv === "development" && isLocalhostReq`.
+  // Both halves are load-bearing: "test", "staging", or an unset env must NOT
+  // unlock the bypass, and production must always require a Bearer token even
+  // from loopback. Lock the full NODE_ENV truth table so a future refactor
+  // can't silently widen the gate by substring / prefix / .startsWith match.
+  describe("dev-bypass gate — NODE_ENV truth table (R4-16)", () => {
+    function cfgWithNodeEnv(nodeEnv: string) {
+      return {
+        port: 0,
+        databaseUrl: "",
+        openaiApiKey: "",
+        githubToken: "",
+        githubWebhookSecret: "",
+        nodeEnv,
+        logLevel: "info",
+        cloneDir: "",
+        slackBotToken: "",
+        slackSigningSecret: "",
+        discordBotToken: "",
+        discordPublicKey: "",
+        notionToken: "",
+        mcpJwtSecret: "e".repeat(64),
+      };
+    }
+
+    it("NODE_ENV=development + loopback grants the dev-bypass (no Bearer required)", async () => {
+      mockGetConfig.mockReturnValue(cfgWithNodeEnv("development"));
+      mockGetAnalyticsConfig.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+      });
+
+      server = await buildAndStart();
+      // No Authorization header. The bypass MUST fire, so the response
+      // cannot be 401. It may be 200/404/500 depending on downstream
+      // handler resolution in the test harness — we only assert the gate
+      // did not short-circuit to 401.
+      const res = await request(server, "/api/analytics/summary", {});
+      expect(res.status).not.toBe(401);
+    });
+
+    it("NODE_ENV=production + loopback still requires a Bearer token (no bypass)", async () => {
+      mockGetConfig.mockReturnValue(cfgWithNodeEnv("production"));
+      mockGetAnalyticsConfig.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "production-token-value",
+      });
+
+      server = await buildAndStart();
+      const res = await request(server, "/api/analytics/summary", {});
+      expect(res.status).toBe(401);
+    });
+
+    it("NODE_ENV=test + loopback does NOT grant dev-bypass (only the literal 'development' does)", async () => {
+      mockGetConfig.mockReturnValue(cfgWithNodeEnv("test"));
+      mockGetAnalyticsConfig.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "test-token-value",
+      });
+
+      server = await buildAndStart();
+      const res = await request(server, "/api/analytics/summary", {});
+      // "test" must not unlock the bypass even though it's non-production.
+      expect(res.status).toBe(401);
+    });
+
+    it("NODE_ENV=staging + loopback does NOT grant dev-bypass", async () => {
+      mockGetConfig.mockReturnValue(cfgWithNodeEnv("staging"));
+      mockGetAnalyticsConfig.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "staging-token-value",
+      });
+
+      server = await buildAndStart();
+      const res = await request(server, "/api/analytics/summary", {});
+      expect(res.status).toBe(401);
+    });
+
+    it("NODE_ENV='' (empty string) + loopback does NOT grant dev-bypass — only the literal 'development' does", async () => {
+      // Defense-in-depth: config.ts defaults `process.env.NODE_ENV || 'development'`
+      // so in practice an unset env resolves to 'development' at load. But if
+      // a caller injects a cfg with an explicitly empty string, the gate must
+      // still fail closed.
+      mockGetConfig.mockReturnValue(cfgWithNodeEnv(""));
+      mockGetAnalyticsConfig.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "any-token-value",
+      });
+
+      server = await buildAndStart();
+      const res = await request(server, "/api/analytics/summary", {});
+      expect(res.status).toBe(401);
+    });
+  });
 });

--- a/src/__tests__/analytics-endpoints.test.ts
+++ b/src/__tests__/analytics-endpoints.test.ts
@@ -828,4 +828,38 @@ describe("parsePositiveIntParam", () => {
   it("returns parsed number at max boundary", () => {
     expect(parsePositiveIntParam("100", 7, 100)).toBe(100);
   });
+
+  // R4-10: strict `/^\d+$/` guard before Number.parseInt so these inputs
+  // cannot be silently coerced by parseInt's permissive grammar.
+  it("rejects decimal strings (would parseInt-truncate to a positive int)", () => {
+    const res = parsePositiveIntParam("1.5", 7, 100);
+    expect(typeof res).toBe("object");
+    if (typeof res === "object") {
+      expect(res.error).toMatch(/positive integer/);
+    }
+  });
+
+  it("rejects scientific notation (would parseInt to 1)", () => {
+    const res = parsePositiveIntParam("1e3", 7, 100);
+    expect(typeof res).toBe("object");
+    if (typeof res === "object") {
+      expect(res.error).toMatch(/positive integer/);
+    }
+  });
+
+  it("rejects leading whitespace (would parseInt after implicit trim)", () => {
+    const res = parsePositiveIntParam(" 123", 7, 100);
+    expect(typeof res).toBe("object");
+    if (typeof res === "object") {
+      expect(res.error).toMatch(/positive integer/);
+    }
+  });
+
+  it("rejects mixed alphanumeric (would parseInt to leading digit run)", () => {
+    const res = parsePositiveIntParam("123abc", 7, 100);
+    expect(typeof res).toBe("object");
+    if (typeof res === "object") {
+      expect(res.error).toMatch(/positive integer/);
+    }
+  });
 });

--- a/src/__tests__/analytics-error-log-ip.test.ts
+++ b/src/__tests__/analytics-error-log-ip.test.ts
@@ -1,0 +1,121 @@
+/**
+ * R3 #7 — analytics error logs in the four handlers (summary / queries /
+ * empty-queries / tool-counts) must include the client IP so operators can
+ * correlate a 500 back to a specific caller. Without it, a single misbehaving
+ * IP hammering a broken query shows up as an anonymous stream of errors and
+ * the only mitigation is shutting the whole endpoint off.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+
+vi.mock("../db/analytics.js", () => ({
+  getAnalyticsSummary: vi.fn(),
+  getTopQueries: vi.fn(),
+  getEmptyQueries: vi.fn(),
+  getToolCounts: vi.fn(),
+}));
+
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({ sources: [], tools: [] }),
+  getAnalyticsConfig: vi.fn().mockReturnValue({ enabled: true, token: "t" }),
+  getConfig: vi.fn().mockReturnValue({ nodeEnv: "development" }),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+  assertDocumentPeerDepsForSources: vi.fn().mockResolvedValue(undefined),
+}));
+
+import {
+  registerAnalyticsRoutes,
+  __resetAnalyticsTokenForTesting,
+  __setTrustProxyForTesting,
+} from "../server.js";
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  __setTrustProxyForTesting(false);
+  registerAnalyticsRoutes(app, {
+    getAnalyticsSummary: async () => {
+      throw new Error("db boom");
+    },
+    getTopQueries: async () => {
+      throw new Error("db boom");
+    },
+    getEmptyQueries: async () => {
+      throw new Error("db boom");
+    },
+    getToolCounts: async () => {
+      throw new Error("db boom");
+    },
+  });
+  return app;
+}
+
+function httpGet(
+  server: http.Server,
+  path: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path,
+        method: "GET",
+        headers: { Authorization: "Bearer t" },
+      },
+      (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => resolve({ status: res.statusCode!, body }));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("analytics handler error logs include client IP (R3 #7)", () => {
+  let server: http.Server;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(async () => {
+    __resetAnalyticsTokenForTesting();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const app = buildApp();
+    server = http.createServer(app);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  });
+
+  afterEach(async () => {
+    consoleErrorSpy.mockRestore();
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  async function assertLogContainsIp(path: string) {
+    const res = await httpGet(server, path);
+    expect(res.status).toBe(500);
+    const joined = consoleErrorSpy.mock.calls.flat().map(String).join(" ");
+    expect(joined).toMatch(/ip=/);
+  }
+
+  it("includes ip= in /api/analytics/summary 500 error log", async () => {
+    await assertLogContainsIp("/api/analytics/summary");
+  });
+
+  it("includes ip= in /api/analytics/queries 500 error log", async () => {
+    await assertLogContainsIp("/api/analytics/queries");
+  });
+
+  it("includes ip= in /api/analytics/empty-queries 500 error log", async () => {
+    await assertLogContainsIp("/api/analytics/empty-queries");
+  });
+
+  it("includes ip= in /api/analytics/tool-counts 500 error log", async () => {
+    await assertLogContainsIp("/api/analytics/tool-counts");
+  });
+});

--- a/src/__tests__/analytics-sendfile-correlation.test.ts
+++ b/src/__tests__/analytics-sendfile-correlation.test.ts
@@ -1,0 +1,101 @@
+/**
+ * R3 #8 — when /analytics sendFile fails with a non-ENOENT error, the 500
+ * body is "analytics dashboard unavailable" with no correlation ID. An
+ * operator who gets a user report ("the dashboard is broken") has no way
+ * to grep logs for THIS failure — only the generic string that every
+ * failure shares. Inject a correlation ID into both the log line and the
+ * response body so operators can match them 1:1.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import express from "express";
+import http from "node:http";
+import path from "node:path";
+import { writeFileSync, unlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+
+vi.mock("../db/analytics.js", () => ({
+  getAnalyticsSummary: vi.fn(),
+  getTopQueries: vi.fn(),
+  getEmptyQueries: vi.fn(),
+  getToolCounts: vi.fn(),
+}));
+
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({ sources: [], tools: [] }),
+  getAnalyticsConfig: vi.fn().mockReturnValue({ enabled: true, token: "t" }),
+  getConfig: vi.fn().mockReturnValue({ nodeEnv: "development" }),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+  assertDocumentPeerDepsForSources: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { registerAnalyticsRoutes } from "../server.js";
+
+function httpGet(
+  server: http.Server,
+  p: string,
+): Promise<{ status: number; body: string }> {
+  return new Promise((resolve, reject) => {
+    const addr = server.address() as { port: number };
+    const req = http.request(
+      { hostname: "127.0.0.1", port: addr.port, path: p, method: "GET" },
+      (res) => {
+        let body = "";
+        res.on("data", (c) => (body += c));
+        res.on("end", () => resolve({ status: res.statusCode!, body }));
+      },
+    );
+    req.on("error", reject);
+    req.end();
+  });
+}
+
+describe("/analytics sendFile 500 correlation ID (R3 #8)", () => {
+  let server: http.Server;
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let htmlPath: string;
+
+  beforeEach(async () => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const app = express();
+    // Point sendFile at an empty directory so sendFile fails with
+    // EISDIR (which is NOT ENOENT, so it hits the 500 branch).
+    htmlPath = path.join(tmpdir(), `pf-test-${Date.now()}`);
+    writeFileSync(htmlPath, ""); // placeholder; we'll delete then test
+    registerAnalyticsRoutes(app, { analyticsHtmlPath: tmpdir() });
+    server = http.createServer(app);
+    await new Promise<void>((r) => server.listen(0, "127.0.0.1", r));
+  });
+
+  afterEach(async () => {
+    consoleErrorSpy.mockRestore();
+    try {
+      unlinkSync(htmlPath);
+    } catch {
+      /* already gone */
+    }
+    await new Promise<void>((r) => server.close(() => r()));
+  });
+
+  it("returns a correlation ID in the 500 body and logs it", async () => {
+    const res = await httpGet(server, "/analytics");
+    // Expect 500 because sendFile on a directory (tmpdir) fails with
+    // EISDIR, which is not ENOENT, so we hit the 500 branch.
+    expect(res.status).toBe(500);
+    const body = JSON.parse(res.body) as {
+      error: string;
+      correlationId?: string;
+    };
+    expect(body.error).toMatch(/unavailable/);
+    expect(body.correlationId).toBeTruthy();
+    expect(typeof body.correlationId).toBe("string");
+    expect(body.correlationId!.length).toBeGreaterThan(4);
+
+    // The same correlation ID must appear in the log line so an
+    // operator can grep from a user-reported ID to the failing stack.
+    const joined = consoleErrorSpy.mock.calls.flat().map(String).join(" ");
+    expect(joined).toContain(body.correlationId!);
+  });
+});

--- a/src/__tests__/analytics-sendfile-correlation.test.ts
+++ b/src/__tests__/analytics-sendfile-correlation.test.ts
@@ -86,16 +86,16 @@ describe("/analytics sendFile 500 correlation ID (R3 #8)", () => {
     expect(res.status).toBe(500);
     const body = JSON.parse(res.body) as {
       error: string;
-      correlationId?: string;
+      correlation_id?: string;
     };
     expect(body.error).toMatch(/unavailable/);
-    expect(body.correlationId).toBeTruthy();
-    expect(typeof body.correlationId).toBe("string");
-    expect(body.correlationId!.length).toBeGreaterThan(4);
+    expect(body.correlation_id).toBeTruthy();
+    expect(typeof body.correlation_id).toBe("string");
+    expect(body.correlation_id!.length).toBeGreaterThan(4);
 
     // The same correlation ID must appear in the log line so an
     // operator can grep from a user-reported ID to the failing stack.
     const joined = consoleErrorSpy.mock.calls.flat().map(String).join(" ");
-    expect(joined).toContain(body.correlationId!);
+    expect(joined).toContain(body.correlation_id!);
   });
 });

--- a/src/__tests__/analytics-token-startup.test.ts
+++ b/src/__tests__/analytics-token-startup.test.ts
@@ -1,0 +1,85 @@
+/**
+ * R4-8 — assertAnalyticsTokenConfigured.
+ *
+ * When analytics is enabled AND nodeEnv=production AND no token is configured
+ * (via analytics.token config or ANALYTICS_TOKEN env var), the server MUST
+ * fail loudly at startup instead of auto-generating a process-ephemeral
+ * token. Multi-replica deployments with per-replica auto-generated tokens
+ * caused dashboards to intermittently 401 when their session landed on a
+ * different replica than the one that minted the token.
+ */
+import { describe, it, expect } from "vitest";
+
+describe("assertAnalyticsTokenConfigured (R4-8)", () => {
+  it("throws when analytics.enabled && production && no token anywhere", async () => {
+    const { assertAnalyticsTokenConfigured } = await import("../server.js");
+    expect(() =>
+      assertAnalyticsTokenConfigured({
+        nodeEnv: "production",
+        analyticsEnabled: true,
+        configuredToken: undefined,
+        envToken: undefined,
+      }),
+    ).toThrow(/ANALYTICS_TOKEN/);
+  });
+
+  it("passes when configured via analytics.token", async () => {
+    const { assertAnalyticsTokenConfigured } = await import("../server.js");
+    expect(() =>
+      assertAnalyticsTokenConfigured({
+        nodeEnv: "production",
+        analyticsEnabled: true,
+        configuredToken: "abc123",
+        envToken: undefined,
+      }),
+    ).not.toThrow();
+  });
+
+  it("passes when ANALYTICS_TOKEN env var is set", async () => {
+    const { assertAnalyticsTokenConfigured } = await import("../server.js");
+    expect(() =>
+      assertAnalyticsTokenConfigured({
+        nodeEnv: "production",
+        analyticsEnabled: true,
+        configuredToken: undefined,
+        envToken: "env-secret",
+      }),
+    ).not.toThrow();
+  });
+
+  it("passes when analytics is disabled in production (nothing to auth)", async () => {
+    const { assertAnalyticsTokenConfigured } = await import("../server.js");
+    expect(() =>
+      assertAnalyticsTokenConfigured({
+        nodeEnv: "production",
+        analyticsEnabled: false,
+        configuredToken: undefined,
+        envToken: undefined,
+      }),
+    ).not.toThrow();
+  });
+
+  it("passes in development without a token (auto-generation still allowed)", async () => {
+    const { assertAnalyticsTokenConfigured } = await import("../server.js");
+    expect(() =>
+      assertAnalyticsTokenConfigured({
+        nodeEnv: "development",
+        analyticsEnabled: true,
+        configuredToken: undefined,
+        envToken: undefined,
+      }),
+    ).not.toThrow();
+  });
+
+  it("treats empty-string tokens as not configured (production fail)", async () => {
+    const { assertAnalyticsTokenConfigured } = await import("../server.js");
+    expect(() =>
+      assertAnalyticsTokenConfigured({
+        nodeEnv: "production",
+        analyticsEnabled: true,
+        configuredToken: "",
+        envToken: "",
+      }),
+    ).toThrow(/ANALYTICS_TOKEN/);
+  });
+});

--- a/src/__tests__/bash-refresh-atomic.test.ts
+++ b/src/__tests__/bash-refresh-atomic.test.ts
@@ -1,0 +1,237 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Bash } from "just-bash";
+
+// ---------------------------------------------------------------------------
+// Mocks — registered BEFORE importing server.js so vi.mock hoisting sees the
+// factories. We mock bash-fs so we can make `rebuildBashInstance` succeed or
+// throw on demand, and we mock config.js so refreshBashInstances() sees a
+// deterministic tool/source set without spinning up the full server.
+// ---------------------------------------------------------------------------
+
+const { rebuildBashInstanceMock } = vi.hoisted(() => ({
+  rebuildBashInstanceMock: vi.fn(),
+}));
+
+vi.mock("../mcp/tools/bash-fs.js", () => ({
+  rebuildBashInstance: rebuildBashInstanceMock,
+  // buildBashFilesMap is imported at the top of server.ts but not exercised
+  // on the refresh path; provide a stub so the import doesn't blow up.
+  buildBashFilesMap: vi.fn().mockResolvedValue({}),
+}));
+
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({
+    server: { name: "test-server" },
+    sources: [
+      {
+        name: "src-a",
+        type: "markdown",
+        path: "/tmp/a",
+        file_patterns: ["**/*.md"],
+        chunk: { target_tokens: 600, overlap_tokens: 50 },
+      },
+      {
+        name: "src-b",
+        type: "markdown",
+        path: "/tmp/b",
+        file_patterns: ["**/*.md"],
+        chunk: { target_tokens: 600, overlap_tokens: 50 },
+      },
+      {
+        name: "src-c",
+        type: "markdown",
+        path: "/tmp/c",
+        file_patterns: ["**/*.md"],
+        chunk: { target_tokens: 600, overlap_tokens: 50 },
+      },
+    ],
+    tools: [
+      { type: "bash", name: "tool-a", sources: ["src-a"] },
+      { type: "bash", name: "tool-b", sources: ["src-b"] },
+      { type: "bash", name: "tool-c", sources: ["src-c"] },
+    ],
+  }),
+  getAnalyticsConfig: vi.fn(),
+  getConfig: vi.fn().mockReturnValue({
+    port: 3001,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "x".repeat(32),
+  }),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+// Import AFTER mocks are in place.
+import {
+  refreshBashInstances,
+  __getBashInstancesForTesting,
+  __setBashInstanceForTesting,
+  __clearBashInstancesForTesting,
+} from "../server.js";
+
+function emptyBash(): Bash {
+  return new Bash({ files: {}, cwd: "/" });
+}
+
+describe("refreshBashInstances — atomic all-or-nothing semantics", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+  let consoleLogSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    rebuildBashInstanceMock.mockReset();
+    __clearBashInstancesForTesting();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+  });
+
+  it("rolls back completely when one tool rebuild throws mid-iteration", async () => {
+    // Seed `bashInstances` with three "old" Bash objects so we can assert
+    // identity preservation (no tool got swapped to a new instance).
+    const oldA = emptyBash();
+    const oldB = emptyBash();
+    const oldC = emptyBash();
+    __setBashInstanceForTesting("tool-a", oldA);
+    __setBashInstanceForTesting("tool-b", oldB);
+    __setBashInstanceForTesting("tool-c", oldC);
+
+    // tool-a and tool-c rebuild fine. tool-b throws — simulating a network
+    // failure, ENOSPC, embedding error, etc.
+    rebuildBashInstanceMock.mockImplementation(
+      async (sources: Array<{ name: string }>) => {
+        const sourceName = sources[0]?.name;
+        if (sourceName === "src-b") {
+          throw new Error("simulated rebuild failure for src-b");
+        }
+        return { bash: emptyBash(), fileCount: 42 };
+      },
+    );
+
+    await expect(
+      refreshBashInstances(["src-a", "src-b", "src-c"], "test"),
+    ).rejects.toThrow("simulated rebuild failure for src-b");
+
+    // Every live instance must be untouched — same object identity as before.
+    const live = __getBashInstancesForTesting();
+    expect(live.get("tool-a")).toBe(oldA);
+    expect(live.get("tool-b")).toBe(oldB);
+    expect(live.get("tool-c")).toBe(oldC);
+
+    // The failure log must identify the failing tool and the triggering
+    // source(s) so monitors and `.catch(...)` callers can act on it.
+    const errorCalls = consoleErrorSpy.mock.calls
+      .map((c: unknown[]) => c.map(String).join(" "))
+      .join("\n");
+    expect(errorCalls).toContain("tool-b");
+    expect(errorCalls).toContain("src-a");
+    expect(errorCalls).toContain("src-b");
+    expect(errorCalls).toContain("src-c");
+    expect(errorCalls).toContain("[test]");
+  });
+
+  it("atomically updates every affected tool when all rebuilds succeed", async () => {
+    const oldA = emptyBash();
+    const oldB = emptyBash();
+    const oldC = emptyBash();
+    __setBashInstanceForTesting("tool-a", oldA);
+    __setBashInstanceForTesting("tool-b", oldB);
+    __setBashInstanceForTesting("tool-c", oldC);
+
+    const newA = emptyBash();
+    const newB = emptyBash();
+    const newC = emptyBash();
+    rebuildBashInstanceMock.mockImplementation(
+      async (sources: Array<{ name: string }>) => {
+        const sourceName = sources[0]?.name;
+        if (sourceName === "src-a") return { bash: newA, fileCount: 1 };
+        if (sourceName === "src-b") return { bash: newB, fileCount: 2 };
+        if (sourceName === "src-c") return { bash: newC, fileCount: 3 };
+        throw new Error(`unexpected source: ${sourceName}`);
+      },
+    );
+
+    await refreshBashInstances(["src-a", "src-b", "src-c"], "test");
+
+    const live = __getBashInstancesForTesting();
+    expect(live.get("tool-a")).toBe(newA);
+    expect(live.get("tool-b")).toBe(newB);
+    expect(live.get("tool-c")).toBe(newC);
+  });
+
+  it("leaves unaffected tools untouched on partial source-set refresh", async () => {
+    // Seed all three tools with "old" instances.
+    const oldA = emptyBash();
+    const oldB = emptyBash();
+    const oldC = emptyBash();
+    __setBashInstanceForTesting("tool-a", oldA);
+    __setBashInstanceForTesting("tool-b", oldB);
+    __setBashInstanceForTesting("tool-c", oldC);
+
+    const newA = emptyBash();
+    rebuildBashInstanceMock.mockImplementation(
+      async (sources: Array<{ name: string }>) => {
+        const sourceName = sources[0]?.name;
+        if (sourceName === "src-a") return { bash: newA, fileCount: 1 };
+        throw new Error(`unexpected source: ${sourceName}`);
+      },
+    );
+
+    // Refresh triggered by src-a only — tool-b/tool-c should stay on their
+    // old instances since they aren't affected.
+    await refreshBashInstances(["src-a"], "test");
+
+    const live = __getBashInstancesForTesting();
+    expect(live.get("tool-a")).toBe(newA);
+    expect(live.get("tool-b")).toBe(oldB);
+    expect(live.get("tool-c")).toBe(oldC);
+  });
+
+  it("rolls back even when the failure is on the LAST affected tool", async () => {
+    // Guards against a naive implementation that updates entries as it
+    // iterates and only "commits" at the end — such a bug would leak
+    // tool-a and tool-b's new instances into `bashInstances` even though
+    // tool-c blew up.
+    const oldA = emptyBash();
+    const oldB = emptyBash();
+    const oldC = emptyBash();
+    __setBashInstanceForTesting("tool-a", oldA);
+    __setBashInstanceForTesting("tool-b", oldB);
+    __setBashInstanceForTesting("tool-c", oldC);
+
+    rebuildBashInstanceMock.mockImplementation(
+      async (sources: Array<{ name: string }>) => {
+        const sourceName = sources[0]?.name;
+        if (sourceName === "src-c") {
+          throw new Error("boom on last tool");
+        }
+        return { bash: emptyBash(), fileCount: 0 };
+      },
+    );
+
+    await expect(
+      refreshBashInstances(["src-a", "src-b", "src-c"], "test"),
+    ).rejects.toThrow("boom on last tool");
+
+    const live = __getBashInstancesForTesting();
+    expect(live.get("tool-a")).toBe(oldA);
+    expect(live.get("tool-b")).toBe(oldB);
+    expect(live.get("tool-c")).toBe(oldC);
+  });
+});

--- a/src/__tests__/close-all-sessions-summary.test.ts
+++ b/src/__tests__/close-all-sessions-summary.test.ts
@@ -1,0 +1,124 @@
+/**
+ * R3 #12 — closeAllSessions must emit a summary log that includes BOTH the
+ * count of rejected close() calls and the sid label of each failing
+ * transport so operators see which transport misbehaved during shutdown.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+describe("closeAllSessions rejection summary (R3 #12)", () => {
+  it("emits a summary with the rejection count for each map", async () => {
+    const { closeAllSessions } = await import("../server.js");
+    const errLogs: unknown[][] = [];
+    const logLogs: unknown[][] = [];
+    const errSpy = vi.spyOn(console, "error").mockImplementation((...a) => {
+      errLogs.push(a);
+    });
+    const logSpy = vi.spyOn(console, "log").mockImplementation((...a) => {
+      logLogs.push(a);
+    });
+    try {
+      const transports = {
+        "s-good": { close: async () => {} },
+        "s-bad-1": {
+          close: async () => {
+            throw new Error("boom-s-1");
+          },
+        },
+        "s-bad-2": {
+          close: async () => {
+            throw new Error("boom-s-2");
+          },
+        },
+      };
+      const sseTransports = {
+        "e-bad": {
+          close: async () => {
+            throw new Error("boom-e");
+          },
+        },
+      };
+      await closeAllSessions({
+        transports: transports as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["transports"],
+        sseTransports: sseTransports as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["sseTransports"],
+      });
+      const allArgs = [...errLogs, ...logLogs].flat();
+      // Summary must explicitly include a rejection count.
+      const hasStreamableSummary = allArgs.some(
+        (a) =>
+          typeof a === "string" &&
+          /2 of 3.*reject|2.*rejected|streamable.*2/i.test(a),
+      );
+      expect(hasStreamableSummary).toBe(true);
+      const hasSseSummary = allArgs.some(
+        (a) =>
+          typeof a === "string" && /1 of 1.*reject|1.*rejected|sse.*1/i.test(a),
+      );
+      expect(hasSseSummary).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+      logSpy.mockRestore();
+    }
+  });
+
+  it("still emits existing per-sid error logs for each rejection", async () => {
+    const { closeAllSessions } = await import("../server.js");
+    const errLogs: unknown[][] = [];
+    const spy = vi.spyOn(console, "error").mockImplementation((...a) => {
+      errLogs.push(a);
+    });
+    try {
+      const transports = {
+        "s-bad": {
+          close: async () => {
+            throw new Error("boom");
+          },
+        },
+      };
+      await closeAllSessions({
+        transports: transports as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["transports"],
+        sseTransports: {} as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["sseTransports"],
+      });
+      const sawSidLog = errLogs.some((args) =>
+        args.some((a) => typeof a === "string" && a.includes("s-bad")),
+      );
+      expect(sawSidLog).toBe(true);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  it("does not emit a summary with rejection>0 when every close succeeds", async () => {
+    const { closeAllSessions } = await import("../server.js");
+    const logs: unknown[][] = [];
+    const spy = vi.spyOn(console, "log").mockImplementation((...a) => {
+      logs.push(a);
+    });
+    try {
+      const transports = { "s-ok": { close: async () => {} } };
+      await closeAllSessions({
+        transports: transports as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["transports"],
+        sseTransports: {} as unknown as Parameters<
+          typeof closeAllSessions
+        >[0]["sseTransports"],
+      });
+      const sawRejectionCount = logs
+        .flat()
+        .some(
+          (a) => typeof a === "string" && / 1.*rejected|rejected: 1/.test(a),
+        );
+      expect(sawRejectionCount).toBe(false);
+    } finally {
+      spy.mockRestore();
+    }
+  });
+});

--- a/src/__tests__/document-source-peer-deps.test.ts
+++ b/src/__tests__/document-source-peer-deps.test.ts
@@ -4,7 +4,7 @@
  * `mammoth`). Also verify package.json advertises them as optional peer
  * deps so `npm install` doesn't try to pull them implicitly.
  */
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { readFileSync } from "node:fs";
 import { resolve } from "node:path";
 
@@ -23,6 +23,21 @@ describe("package.json optional peer deps for document extraction (R4-13)", () =
 });
 
 describe("assertDocumentPeerDepsForSources (R4-13)", () => {
+  /**
+   * Helper: build a MODULE_NOT_FOUND error in the shape Node's dynamic
+   * `import()` rejects with — Error instance carrying `.code` = one of
+   * ERR_MODULE_NOT_FOUND (ESM) / MODULE_NOT_FOUND (CJS). The peer-dep
+   * helper distinguishes these from other throws so it can classify
+   * "not installed" vs "installed but broken".
+   */
+  function moduleNotFound(pkg: string): Error & { code: string } {
+    const err = new Error(`Cannot find module '${pkg}'`) as Error & {
+      code: string;
+    };
+    err.code = "ERR_MODULE_NOT_FOUND";
+    return err;
+  }
+
   it("throws naming pdf-parse when a document source pulls PDFs but the peer is missing", async () => {
     const { assertDocumentPeerDepsForSources } = await import("../config.js");
     const sources = [
@@ -36,8 +51,7 @@ describe("assertDocumentPeerDepsForSources (R4-13)", () => {
     await expect(
       assertDocumentPeerDepsForSources(sources, {
         tryImport: async (mod: string) => {
-          if (mod === "pdf-parse")
-            throw new Error("Cannot find module 'pdf-parse'");
+          if (mod === "pdf-parse") throw moduleNotFound("pdf-parse");
           return {};
         },
       }),
@@ -57,12 +71,51 @@ describe("assertDocumentPeerDepsForSources (R4-13)", () => {
     await expect(
       assertDocumentPeerDepsForSources(sources, {
         tryImport: async (mod: string) => {
-          if (mod === "mammoth")
-            throw new Error("Cannot find module 'mammoth'");
+          if (mod === "mammoth") throw moduleNotFound("mammoth");
           return {};
         },
       }),
     ).rejects.toThrow(/mammoth/);
+  });
+
+  it("surfaces a distinct 'installed but failed to import' error when the peer throws a non-MODULE_NOT_FOUND error", async () => {
+    // Regression: the previous empty catch swallowed every throw as "peer
+    // missing", producing a confusing install-hint message even when the
+    // peer WAS installed but failed to load (native-addon ABI mismatch,
+    // ESM/CJS interop throw, fs permission error). This test injects a
+    // runtime TypeError to simulate that case and asserts the surfaced
+    // error is DIFFERENT from the missing-peer path.
+    const { assertDocumentPeerDepsForSources } = await import("../config.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const sources = [
+        {
+          name: "handbook",
+          type: "document" as const,
+          path: "./docs",
+          file_patterns: ["*.pdf"],
+        },
+      ];
+      await expect(
+        assertDocumentPeerDepsForSources(sources, {
+          tryImport: async (mod: string) => {
+            if (mod === "pdf-parse") {
+              throw new TypeError(
+                "Cannot read properties of undefined (reading 'default')",
+              );
+            }
+            return {};
+          },
+        }),
+      ).rejects.toThrow(/installed but failed to import/);
+      // Full stack was logged so operators can diagnose the real cause.
+      const stackCalls = errSpy.mock.calls.filter((args: unknown[]) =>
+        String(args[0] ?? "").includes("installed but failed to import"),
+      );
+      expect(stackCalls.length).toBeGreaterThanOrEqual(1);
+    } finally {
+      errSpy.mockRestore();
+    }
   });
 
   it("does not throw when the peer is installed", async () => {

--- a/src/__tests__/document-source-peer-deps.test.ts
+++ b/src/__tests__/document-source-peer-deps.test.ts
@@ -1,0 +1,99 @@
+/**
+ * R4-13 — document sources referencing PDFs or DOCX must surface a clear
+ * error message naming the missing peer dependency (`pdf-parse` or
+ * `mammoth`). Also verify package.json advertises them as optional peer
+ * deps so `npm install` doesn't try to pull them implicitly.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+describe("package.json optional peer deps for document extraction (R4-13)", () => {
+  it("declares pdf-parse and mammoth as optional peer dependencies", () => {
+    const pkgPath = resolve(__dirname, "../../package.json");
+    const pkg = JSON.parse(readFileSync(pkgPath, "utf-8")) as {
+      peerDependencies?: Record<string, string>;
+      peerDependenciesMeta?: Record<string, { optional?: boolean }>;
+    };
+    expect(pkg.peerDependencies?.["pdf-parse"]).toBeDefined();
+    expect(pkg.peerDependencies?.["mammoth"]).toBeDefined();
+    expect(pkg.peerDependenciesMeta?.["pdf-parse"]?.optional).toBe(true);
+    expect(pkg.peerDependenciesMeta?.["mammoth"]?.optional).toBe(true);
+  });
+});
+
+describe("assertDocumentPeerDepsForSources (R4-13)", () => {
+  it("throws naming pdf-parse when a document source pulls PDFs but the peer is missing", async () => {
+    const { assertDocumentPeerDepsForSources } = await import("../config.js");
+    const sources = [
+      {
+        name: "handbook",
+        type: "document" as const,
+        path: "./docs",
+        file_patterns: ["*.pdf"],
+      },
+    ];
+    await expect(
+      assertDocumentPeerDepsForSources(sources, {
+        tryImport: async (mod: string) => {
+          if (mod === "pdf-parse")
+            throw new Error("Cannot find module 'pdf-parse'");
+          return {};
+        },
+      }),
+    ).rejects.toThrow(/pdf-parse/);
+  });
+
+  it("throws naming mammoth when a document source pulls DOCXs but the peer is missing", async () => {
+    const { assertDocumentPeerDepsForSources } = await import("../config.js");
+    const sources = [
+      {
+        name: "handbook",
+        type: "document" as const,
+        path: "./docs",
+        file_patterns: ["*.docx"],
+      },
+    ];
+    await expect(
+      assertDocumentPeerDepsForSources(sources, {
+        tryImport: async (mod: string) => {
+          if (mod === "mammoth")
+            throw new Error("Cannot find module 'mammoth'");
+          return {};
+        },
+      }),
+    ).rejects.toThrow(/mammoth/);
+  });
+
+  it("does not throw when the peer is installed", async () => {
+    const { assertDocumentPeerDepsForSources } = await import("../config.js");
+    const sources = [
+      {
+        name: "handbook",
+        type: "document" as const,
+        path: "./docs",
+        file_patterns: ["*.pdf"],
+      },
+    ];
+    await expect(
+      assertDocumentPeerDepsForSources(sources, {
+        tryImport: async (_m: string) => ({}),
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it("is a no-op when no document sources are configured", async () => {
+    const { assertDocumentPeerDepsForSources } = await import("../config.js");
+    const calls: string[] = [];
+    await assertDocumentPeerDepsForSources(
+      [{ name: "site", type: "website" as const }],
+      {
+        tryImport: async (m: string) => {
+          calls.push(m);
+          return {};
+        },
+      },
+    );
+    expect(calls).toEqual([]);
+  });
+});

--- a/src/__tests__/error-log-formatting.test.ts
+++ b/src/__tests__/error-log-formatting.test.ts
@@ -1,0 +1,41 @@
+/**
+ * R3 #3 — logs that currently render only `err.message` must render the full
+ * error (with stack) so operators can correlate failures to code lines during
+ * incident triage. The helper exported here is the single canonical place
+ * that formats an unknown error for a server-side log line.
+ */
+import { describe, it, expect } from "vitest";
+import { formatErrorForLog } from "../server.js";
+
+describe("formatErrorForLog (R3 #3)", () => {
+  it("includes the stack trace when the error is an Error instance", () => {
+    const err = new Error("boom");
+    const out = formatErrorForLog(err);
+    expect(out).toContain("boom");
+    // Stack always includes the error message + the function frame; match
+    // on the "at " prefix that Node's V8 stack traces use so we're not
+    // coupling to a specific frame path.
+    expect(out).toMatch(/\n\s+at\s/);
+  });
+
+  it("falls back to String(err) when the value has no stack", () => {
+    expect(formatErrorForLog("plain string")).toBe("plain string");
+    expect(formatErrorForLog(42)).toBe("42");
+    expect(formatErrorForLog(null)).toBe("null");
+  });
+
+  it("handles Error-like objects without a stack property", () => {
+    // e.g. thrown object literals { message: "..." }
+    const errLike = { message: "custom" };
+    const out = formatErrorForLog(errLike);
+    // We don't promise a specific format here — just that the message
+    // content survives into the log line.
+    expect(out).toContain("custom");
+  });
+
+  it("preserves the message even when stack is present", () => {
+    const err = new Error("very specific message");
+    const out = formatErrorForLog(err);
+    expect(out).toContain("very specific message");
+  });
+});

--- a/src/__tests__/ip-limiter.test.ts
+++ b/src/__tests__/ip-limiter.test.ts
@@ -273,29 +273,23 @@ describe("IpSessionLimiter", () => {
     });
 
     it("getSessionCount reflects pre-allowlist tracking for an IP later covered by the allowlist", () => {
-      // IP is tracked BEFORE the allowlist covers it (e.g. allowlist loaded
-      // after sessions already opened). Retroactively applying the allowlist
-      // must not silently zero out the tracked count.
-      const allow = new IpSessionLimiter(5, { allowlist: [] });
-      expect(allow.tryAdd("10.1.2.3", "s1")).toBe(true);
-      expect(allow.tryAdd("10.1.2.3", "s2")).toBe(true);
-      expect(allow.getSessionCount("10.1.2.3")).toBe(2);
-
-      // Now a fresh limiter with the SAME IP already "tracked" simulated by
-      // re-adding under an allowlist — but for the existing limiter, the
-      // tracked state must remain visible; the allowlist does not retroactively
-      // remove sessions that were counted.
-      // We can't hot-swap the allowlist, so verify the contract directly:
-      // getSessionCount returns the tracked count regardless of allowlist
-      // status at call time.
-      const allow2 = new IpSessionLimiter(5, { allowlist: ["10.0.0.0/8"] });
-      // Manually simulate pre-existing tracked state by flipping internals:
-      // this models "IP was tracked, then allowlist was applied".
+      // IP was tracked BEFORE the allowlist covered it (e.g. allowlist
+      // loaded after sessions already opened, or allowlist hot-reloaded).
+      // Retroactively applying the allowlist must not silently zero out the
+      // already-counted sessions. We can't hot-swap an allowlist on an
+      // existing limiter, so we model the scenario by flipping internals
+      // on a limiter that was CONSTRUCTED with the allowlist already set:
+      // the internal `ipToSessions` map has pre-existing entries, and
+      // getSessionCount must return them regardless of allowlist coverage
+      // at call time.
+      const allow = new IpSessionLimiter(5, { allowlist: ["10.0.0.0/8"] });
+      // Manually simulate pre-existing tracked state — models "IP was
+      // tracked, then allowlist was applied".
       const internalIpToSessions = (
-        allow2 as unknown as { ipToSessions: Map<string, Set<string>> }
+        allow as unknown as { ipToSessions: Map<string, Set<string>> }
       ).ipToSessions;
       internalIpToSessions.set("10.1.2.3", new Set(["s1", "s2"]));
-      expect(allow2.getSessionCount("10.1.2.3")).toBe(2);
+      expect(allow.getSessionCount("10.1.2.3")).toBe(2);
     });
 
     it("tryAdd with a re-used sid from a DIFFERENT IP does not cause counter drift", () => {
@@ -473,7 +467,24 @@ describe("IpSessionLimiter", () => {
         const internal = (
           allow as unknown as { lastAllowlistLog: Map<string, number> }
         ).lastAllowlistLog;
+        // (1) Hot IP survived — the core true-LRU contract.
         expect(internal.has("10.9.9.9")).toBe(true);
+        // (2) Capacity was enforced. Without this assertion the test
+        //     would pass even if the LRU map grew unbounded (all 5000
+        //     cold IPs retained), which is the exact regression the
+        //     capacity-bound is meant to prevent. The hard cap is 1000
+        //     (see ALLOWLIST_LOG_MAX_ENTRIES in src/ip-limiter.ts); we
+        //     asserted the same bound in the earlier "internal map
+        //     must not grow past a sane cap" test, so pin it here too.
+        expect(internal.size).toBeLessThanOrEqual(1000);
+        // (3) Eviction actually happened. With 5000 distinct cold IPs
+        //     inserted and a 1000-entry cap, the map must have dropped
+        //     at least 4000 entries. Asserting strict `< insertedTotal`
+        //     catches "eviction code path never ran" while the cap
+        //     assertion above catches "eviction ran but didn't keep the
+        //     size bounded". Together they pin the full contract.
+        const insertedColdCount = 5000;
+        expect(internal.size).toBeLessThan(insertedColdCount);
       } finally {
         vi.useRealTimers();
         infoSpy.mockRestore();

--- a/src/__tests__/is-localhost-parse-failure-log.test.ts
+++ b/src/__tests__/is-localhost-parse-failure-log.test.ts
@@ -7,21 +7,24 @@
  * signal — an operator would have to bisect through the handler to see
  * that the parse was the root cause.
  *
- * Fix: add a debug-level log on the parse failure so the reason is
+ * Fix: add a warn-level log on the parse failure so the reason is
  * visible without widening the return contract (still returns false).
+ * Warn (not debug) because this path only fires on malformed peer
+ * addresses, which is rare enough that warn isn't spammy and is visible
+ * in production log aggregators that filter out debug.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { __isLocalhostReqForTesting } from "../server.js";
 import type { Request } from "express";
 
-describe("isLocalhostReq parse-failure debug log (R3 #14)", () => {
-  let debugSpy: ReturnType<typeof vi.spyOn>;
+describe("isLocalhostReq parse-failure warn log (R3 #14)", () => {
+  let warnSpy: ReturnType<typeof vi.spyOn>;
 
   beforeEach(() => {
-    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+    warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
   });
   afterEach(() => {
-    debugSpy.mockRestore();
+    warnSpy.mockRestore();
   });
 
   function makeReq(remoteAddress: string): Request {
@@ -31,24 +34,24 @@ describe("isLocalhostReq parse-failure debug log (R3 #14)", () => {
     } as unknown as Request;
   }
 
-  it("returns false and emits a debug log when ipaddr.parse throws", () => {
+  it("returns false and emits a warn log when ipaddr.parse throws", () => {
     // "not-an-ip" is syntactically invalid, so ipaddr.parse will throw.
     const result = __isLocalhostReqForTesting(makeReq("not-an-ip"));
     expect(result).toBe(false);
-    const joined = debugSpy.mock.calls.flat().map(String).join(" ");
+    const joined = warnSpy.mock.calls.flat().map(String).join(" ");
     expect(joined).toMatch(/isLocalhostReq|parse/);
     expect(joined).toContain("not-an-ip");
   });
 
-  it("does NOT emit a debug log on empty remote address (handled by early return)", () => {
+  it("does NOT emit a warn log on empty remote address (handled by early return)", () => {
     const result = __isLocalhostReqForTesting(makeReq(""));
     expect(result).toBe(false);
-    expect(debugSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 
   it("returns true for 127.0.0.1 without emitting a parse-failure log", () => {
     const result = __isLocalhostReqForTesting(makeReq("127.0.0.1"));
     expect(result).toBe(true);
-    expect(debugSpy).not.toHaveBeenCalled();
+    expect(warnSpy).not.toHaveBeenCalled();
   });
 });

--- a/src/__tests__/is-localhost-parse-failure-log.test.ts
+++ b/src/__tests__/is-localhost-parse-failure-log.test.ts
@@ -1,0 +1,54 @@
+/**
+ * R3 #14 — isLocalhostReq swallowed ipaddr.parse failures in a bare
+ * `catch {}`, so an address that doesn't parse (e.g. a corrupt socket
+ * peer, a test harness providing "" or a garbage value) returns false
+ * silently. In production, a persistent parse failure on the auth-mode
+ * path would make the analytics dev-bypass stop working with zero log
+ * signal — an operator would have to bisect through the handler to see
+ * that the parse was the root cause.
+ *
+ * Fix: add a debug-level log on the parse failure so the reason is
+ * visible without widening the return contract (still returns false).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { __isLocalhostReqForTesting } from "../server.js";
+import type { Request } from "express";
+
+describe("isLocalhostReq parse-failure debug log (R3 #14)", () => {
+  let debugSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    debugSpy = vi.spyOn(console, "debug").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    debugSpy.mockRestore();
+  });
+
+  function makeReq(remoteAddress: string): Request {
+    return {
+      socket: { remoteAddress },
+      ip: remoteAddress,
+    } as unknown as Request;
+  }
+
+  it("returns false and emits a debug log when ipaddr.parse throws", () => {
+    // "not-an-ip" is syntactically invalid, so ipaddr.parse will throw.
+    const result = __isLocalhostReqForTesting(makeReq("not-an-ip"));
+    expect(result).toBe(false);
+    const joined = debugSpy.mock.calls.flat().map(String).join(" ");
+    expect(joined).toMatch(/isLocalhostReq|parse/);
+    expect(joined).toContain("not-an-ip");
+  });
+
+  it("does NOT emit a debug log on empty remote address (handled by early return)", () => {
+    const result = __isLocalhostReqForTesting(makeReq(""));
+    expect(result).toBe(false);
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+
+  it("returns true for 127.0.0.1 without emitting a parse-failure log", () => {
+    const result = __isLocalhostReqForTesting(makeReq("127.0.0.1"));
+    expect(result).toBe(true);
+    expect(debugSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/server-round2.test.ts
+++ b/src/__tests__/server-round2.test.ts
@@ -883,6 +883,73 @@ describe("handleSessionInitAccept (R3 #2 rollback signaling + H2 sessionStateMan
       consoleErrSpy.mockRestore();
     }
   });
+
+  it("R4-17: still runs rollback side effects (map delete, ipLimiter.remove, close) when headersSent is true", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+
+    const consoleErrSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    try {
+      const sid = "r4-17-sid";
+      const transports: Record<string, unknown> = {
+        [sid]: { fake: true },
+        other: { fake: true },
+      };
+      const sessionLastActivity: Record<string, number> = {
+        [sid]: Date.now(),
+        other: Date.now(),
+      };
+
+      let ipLimiterRemovedSid: string | undefined;
+      let closeCalled = false;
+
+      const res = {
+        headersSent: true,
+        status: () => res,
+        json: () => res,
+      };
+
+      handleSessionInitAccept({
+        transport: {
+          close: async () => {
+            closeCalled = true;
+          },
+        },
+        sid,
+        ip: "9.9.9.9",
+        transports,
+        sessionLastActivity,
+        ipLimiter: {
+          remove: (s: string) => {
+            ipLimiterRemovedSid = s;
+          },
+        },
+        workspaceManager: {
+          ensureSession: () => {
+            throw new Error("ensure-hs-boom");
+          },
+        },
+        res: res as unknown as Parameters<
+          typeof handleSessionInitAccept
+        >[0]["res"],
+      });
+
+      // Allow the microtask-scheduled transport.close() to run.
+      await new Promise((r) => setImmediate(r));
+
+      // Side effects that MUST run even when the body couldn't be written:
+      expect(transports[sid]).toBeUndefined();
+      expect(sessionLastActivity[sid]).toBeUndefined();
+      expect(ipLimiterRemovedSid).toBe(sid);
+      expect(closeCalled).toBe(true);
+      // And unrelated entries untouched.
+      expect(transports.other).toBeDefined();
+      expect(sessionLastActivity.other).toBeDefined();
+    } finally {
+      consoleErrSpy.mockRestore();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/server-round2.test.ts
+++ b/src/__tests__/server-round2.test.ts
@@ -1607,7 +1607,8 @@ describe("rollbackSessionAfterConnectFailure (Z-1)", () => {
   }
 
   it("runs the cleanup chain exactly once even though transport.close() triggers the wired onclose", async () => {
-    const { rollbackSessionAfterConnectFailure } = await import("../server.js");
+    const { rollbackSessionAfterConnectFailure, __rejectedSidsForTesting } =
+      await import("../server.js");
 
     const sid = "sid-double-cleanup";
     const transport = makeTransport(sid);
@@ -1631,10 +1632,19 @@ describe("rollbackSessionAfterConnectFailure (Z-1)", () => {
       },
     };
 
-    // Simulate the handler having wired onclose to the REAL cleanup-running
-    // handler before the connect-throw. If the rollback doesn't neutralize
-    // onclose before close(), this fires and runs cleanup a SECOND time.
+    // Simulate the production onclose handler: it runs application cleanup
+    // UNLESS rejectedSids contains the sid (the suppression branch). The
+    // rollback helper seeds that marker before invoking close(), so a prod-
+    // faithful onclose short-circuits while still performing any SDK-
+    // internal teardown it wants. This test replaces that SDK teardown with
+    // a trackable side-effect (priorOncloseFired) to assert the wrapper
+    // still forwards the invocation.
+    let priorOncloseFired = 0;
     transport.onclose = () => {
+      priorOncloseFired++;
+      if (__rejectedSidsForTesting?.().has(sid)) return;
+      // Not rejected — fall through to "real" cleanup. Should NOT run here
+      // because the rollback helper seeds rejectedSids before close().
       sessionStateManager.cleanup(sid);
       ipLimiter.remove(sid);
       workspaceManager.cleanup(sid);
@@ -1653,9 +1663,16 @@ describe("rollbackSessionAfterConnectFailure (Z-1)", () => {
     // Allow microtask-scheduled close() to run.
     await new Promise((r) => setImmediate(r));
 
+    // Cleanup ran exactly once (from the inline rollback chain; the prior
+    // onclose short-circuited via the rejectedSids guard).
     expect(cleanupCalls.state).toBe(1);
     expect(cleanupCalls.ipLimiter).toBe(1);
     expect(cleanupCalls.workspace).toBe(1);
+    // The prior onclose was STILL invoked by the wrapper, so any SDK-internal
+    // bookkeeping it was doing still runs. This is the regression fix: the
+    // previous `transport.onclose = () => {}` neutralizer swallowed the
+    // invocation entirely, skipping SDK bookkeeping as well.
+    expect(priorOncloseFired).toBe(1);
     expect(transport.closeCalls).toBe(1);
     expect(transports[sid]).toBeUndefined();
     expect(sessionLastActivity[sid]).toBeUndefined();
@@ -1683,6 +1700,59 @@ describe("rollbackSessionAfterConnectFailure (Z-1)", () => {
     expect(sessionLastActivity[sid]).toBeUndefined();
     expect(transports.other).toBeDefined();
     expect(sessionLastActivity.other).toBe(2);
+  });
+
+  it("invokes a pre-existing transport.onclose (preserves SDK-internal bookkeeping)", async () => {
+    // Regression: earlier fix replaced transport.onclose with a bare `() => {}`
+    // no-op, which silently clobbered any SDK-internal onclose wiring (the
+    // MCP SDK StreamableHTTPServerTransport attaches onclose listeners for
+    // its own bookkeeping). The wrapper must forward the invocation so SDK
+    // state teardown still happens even while our cleanup branch skips.
+    const { rollbackSessionAfterConnectFailure } = await import("../server.js");
+
+    const sid = "sid-prior-onclose";
+    const transport = makeTransport(sid);
+    const transports: Record<string, unknown> = { [sid]: transport };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+
+    // Simulate an SDK-attached onclose (e.g. request-queue drain) that does
+    // NOT know about rejectedSids — it just wants to be told the transport
+    // closed.
+    let sdkOncloseFired = 0;
+    transport.onclose = () => {
+      sdkOncloseFired++;
+    };
+
+    rollbackSessionAfterConnectFailure({
+      transport,
+      sid,
+      transports,
+      sessionLastActivity,
+    });
+    await new Promise((r) => setImmediate(r));
+
+    expect(sdkOncloseFired).toBe(1);
+  });
+
+  it("tolerates a null transport.onclose (no prior handler attached)", async () => {
+    const { rollbackSessionAfterConnectFailure } = await import("../server.js");
+
+    const sid = "sid-no-prior";
+    const transport = makeTransport(sid);
+    // Explicitly no onclose.
+    transport.onclose = undefined as unknown as (() => void) | undefined;
+    const transports: Record<string, unknown> = { [sid]: transport };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+
+    // Must not throw.
+    rollbackSessionAfterConnectFailure({
+      transport,
+      sid,
+      transports,
+      sessionLastActivity,
+    });
+    await new Promise((r) => setImmediate(r));
+    expect(transport.closeCalls).toBe(1);
   });
 
   it("continues cleanup even if an earlier cleanup step throws", async () => {

--- a/src/__tests__/server-round2.test.ts
+++ b/src/__tests__/server-round2.test.ts
@@ -559,6 +559,63 @@ describe("reapIdleSessionsTick (R3 #1: SSE reaper dep plumbing)", () => {
     // Map entry gone (reaper deletes inline).
     expect(sseTransports["sse-stale"]).toBeUndefined();
   });
+
+  it("emits a per-sid cleanup summary log for each reaped streamable session (R4-6)", async () => {
+    const { reapIdleSessionsTickForTesting } = await import("../server.js");
+
+    const transports: Record<string, { close: () => Promise<void> | void }> = {
+      "stale-a": { close: async () => {} },
+      "stale-b": { close: async () => {} },
+    };
+    const sseTransports: Record<string, { close: () => Promise<void> | void }> =
+      {};
+    const sessionLastActivity: Record<string, number> = {
+      "stale-a": Date.now() - 10 * 60 * 1000,
+      "stale-b": Date.now() - 10 * 60 * 1000,
+    };
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      reapIdleSessionsTickForTesting({
+        transports,
+        sseTransports,
+        sessionLastActivity,
+        ttlMs: 5 * 60 * 1000,
+        now: Date.now(),
+        ipLimiter: { remove: () => {} },
+        workspaceManager: {
+          cleanup: (sid: string) => {
+            if (sid === "stale-b") throw new Error("workspace-boom");
+          },
+        },
+        sessionStateManager: { cleanup: () => {} },
+      });
+
+      const summaryLines = logSpy.mock.calls
+        .map((c) => c.join(" "))
+        .filter((line) => line.includes("Reap cleanup"));
+      // One summary line per reaped streamable sid.
+      expect(summaryLines.length).toBe(2);
+      const summaryForA = summaryLines.find((l) => l.includes("stale-a"));
+      const summaryForB = summaryLines.find((l) => l.includes("stale-b"));
+      expect(summaryForA).toBeDefined();
+      expect(summaryForB).toBeDefined();
+      // The stale-a row reports ok for every step; stale-b reports workspace=throw.
+      expect(summaryForA).toMatch(/state=ok/);
+      expect(summaryForA).toMatch(/ipLimiter=ok/);
+      expect(summaryForA).toMatch(/workspace=ok/);
+      expect(summaryForB).toMatch(/workspace=(throw|failed|err)/);
+      // The aggregate log still fires.
+      const aggregate = logSpy.mock.calls
+        .map((c) => c.join(" "))
+        .find((line) => line.includes("Reaped 2 idle sessions"));
+      expect(aggregate).toBeDefined();
+    } finally {
+      logSpy.mockRestore();
+      errSpy.mockRestore();
+    }
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -1227,6 +1284,40 @@ describe("write429RateLimited (R3 #5: headersSent guard)", () => {
 // ---------------------------------------------------------------------------
 
 describe("closeAllSessions (shutdown helper)", () => {
+  it("runs streamable + sse close batches in parallel, not sequentially (R3 #11)", async () => {
+    const { closeAllSessions } = await import("../server.js");
+
+    const SLOW_MS = 80;
+    const transports: Record<string, { close: () => Promise<void> | void }> = {
+      "s-slow": {
+        close: () => new Promise((r) => setTimeout(r, SLOW_MS)),
+      },
+    };
+    const sseTransports: Record<string, { close: () => Promise<void> | void }> =
+      {
+        "e-slow": {
+          close: () => new Promise((r) => setTimeout(r, SLOW_MS)),
+        },
+      };
+
+    const start = Date.now();
+    await closeAllSessions({
+      transports: transports as unknown as Parameters<
+        typeof closeAllSessions
+      >[0]["transports"],
+      sseTransports: sseTransports as unknown as Parameters<
+        typeof closeAllSessions
+      >[0]["sseTransports"],
+    });
+    const elapsed = Date.now() - start;
+
+    // Sequential would be ~2*SLOW_MS, parallel ~SLOW_MS. Leave headroom for
+    // Node timer jitter: anything under 1.5*SLOW_MS proves parallelism.
+    expect(elapsed).toBeLessThan(SLOW_MS * 1.5);
+    expect(Object.keys(transports)).toEqual([]);
+    expect(Object.keys(sseTransports)).toEqual([]);
+  });
+
   it("closes every streamable-HTTP transport and every SSE transport and clears the maps", async () => {
     const { closeAllSessions } = await import("../server.js");
 
@@ -1332,6 +1423,243 @@ describe("closeAllSessions (shutdown helper)", () => {
       expect(sawSseBoom).toBe(true);
     } finally {
       consoleErrSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// runStartupIndexAndBashRefresh (R3 #5): distinguishable log prefixes for
+// index-check failure vs bash-refresh failure on startup.
+// ---------------------------------------------------------------------------
+
+describe("runStartupIndexAndBashRefresh (R3 #5)", () => {
+  it("logs '[startup] Initial index check failed:' when checkAndIndex rejects", async () => {
+    const { runStartupIndexAndBashRefresh } = await import("../server.js");
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await runStartupIndexAndBashRefresh(
+        {
+          checkAndIndex: async () => {
+            throw new Error("index-boom");
+          },
+        },
+        [],
+      );
+      const lines = errSpy.mock.calls.map((c) => c.join(" "));
+      const indexLine = lines.find((l) =>
+        l.includes("[startup] Initial index check failed:"),
+      );
+      const refreshLine = lines.find((l) =>
+        l.includes("[startup] Bash refresh after index check failed:"),
+      );
+      expect(indexLine).toBeDefined();
+      expect(refreshLine).toBeUndefined();
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+
+  it("logs '[startup] Bash refresh after index check failed:' when refresh rejects (NOT the index prefix)", async () => {
+    // Stub getServerConfig to return a bash tool so refreshBashInstances
+    // reaches its rebuild path, then force rebuildBashInstance to throw.
+    mockGetServerConfig.mockReturnValue({
+      server: { name: "t", version: "0" },
+      sources: [{ name: "src-a", type: "github", repo: "x/y" }],
+      tools: [
+        {
+          name: "bash",
+          type: "bash",
+          sources: ["src-a"],
+          bash: { virtual_files: false },
+        },
+      ],
+    });
+    const bashFs = await import("../mcp/tools/bash-fs.js");
+    const rebuildSpy = vi
+      .spyOn(bashFs, "rebuildBashInstance")
+      .mockRejectedValueOnce(new Error("refresh-boom"));
+
+    const { runStartupIndexAndBashRefresh } = await import("../server.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await runStartupIndexAndBashRefresh(
+        {
+          checkAndIndex: async () => {
+            /* resolves */
+          },
+        },
+        [{ name: "src-a" }],
+      );
+      const lines = errSpy.mock.calls.map((c) => c.join(" "));
+      const indexLine = lines.find((l) =>
+        l.includes("[startup] Initial index check failed:"),
+      );
+      const refreshLine = lines.find((l) =>
+        l.includes("[startup] Bash refresh after index check failed:"),
+      );
+      expect(refreshLine).toBeDefined();
+      expect(indexLine).toBeUndefined();
+    } finally {
+      errSpy.mockRestore();
+      rebuildSpy.mockRestore();
+    }
+  });
+});
+
+// ---------------------------------------------------------------------------
+// rollbackSessionAfterConnectFailure (Z-1): fires when server.connect /
+// completeInitRequestSafely throws AFTER handleSessionInitAccept committed
+// maps + ipLimiter counter + onclose wiring. Must (a) tear down the session
+// exactly once and (b) not double-cleanup via the wired onclose handler.
+// ---------------------------------------------------------------------------
+
+describe("rollbackSessionAfterConnectFailure (Z-1)", () => {
+  /**
+   * Build a fake transport whose `close()` invokes `transport.onclose` to
+   * model the MCP SDK behavior that stream teardown notifies the wired
+   * listener. The fix detaches onclose before close() runs, so onclose
+   * (assigned to the original handler) must NOT be invoked when the rollback
+   * runs — or if it is, it must be a neutralized no-op.
+   */
+  function makeTransport(sid: string) {
+    const transport: {
+      sessionId: string;
+      onclose?: () => void;
+      close: () => Promise<void>;
+      closeCalls: number;
+    } = {
+      sessionId: sid,
+      closeCalls: 0,
+      close: async () => {
+        transport.closeCalls++;
+        if (typeof transport.onclose === "function") transport.onclose();
+      },
+    };
+    return transport;
+  }
+
+  it("runs the cleanup chain exactly once even though transport.close() triggers the wired onclose", async () => {
+    const { rollbackSessionAfterConnectFailure } = await import("../server.js");
+
+    const sid = "sid-double-cleanup";
+    const transport = makeTransport(sid);
+    const transports: Record<string, unknown> = { [sid]: transport };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+
+    const cleanupCalls = { state: 0, ipLimiter: 0, workspace: 0 };
+    const ipLimiter = {
+      remove: (_sid: string) => {
+        cleanupCalls.ipLimiter++;
+      },
+    };
+    const sessionStateManager = {
+      cleanup: (_sid: string) => {
+        cleanupCalls.state++;
+      },
+    };
+    const workspaceManager = {
+      cleanup: (_sid: string) => {
+        cleanupCalls.workspace++;
+      },
+    };
+
+    // Simulate the handler having wired onclose to the REAL cleanup-running
+    // handler before the connect-throw. If the rollback doesn't neutralize
+    // onclose before close(), this fires and runs cleanup a SECOND time.
+    transport.onclose = () => {
+      sessionStateManager.cleanup(sid);
+      ipLimiter.remove(sid);
+      workspaceManager.cleanup(sid);
+    };
+
+    rollbackSessionAfterConnectFailure({
+      transport,
+      sid,
+      transports,
+      sessionLastActivity,
+      ipLimiter,
+      sessionStateManager,
+      workspaceManager,
+    });
+
+    // Allow microtask-scheduled close() to run.
+    await new Promise((r) => setImmediate(r));
+
+    expect(cleanupCalls.state).toBe(1);
+    expect(cleanupCalls.ipLimiter).toBe(1);
+    expect(cleanupCalls.workspace).toBe(1);
+    expect(transport.closeCalls).toBe(1);
+    expect(transports[sid]).toBeUndefined();
+    expect(sessionLastActivity[sid]).toBeUndefined();
+  });
+
+  it("deletes transports[sid] and sessionLastActivity[sid] synchronously", async () => {
+    const { rollbackSessionAfterConnectFailure } = await import("../server.js");
+
+    const sid = "sid-del";
+    const transport = makeTransport(sid);
+    const transports: Record<string, unknown> = { [sid]: transport, other: {} };
+    const sessionLastActivity: Record<string, number> = {
+      [sid]: 1,
+      other: 2,
+    };
+
+    rollbackSessionAfterConnectFailure({
+      transport,
+      sid,
+      transports,
+      sessionLastActivity,
+    });
+
+    expect(transports[sid]).toBeUndefined();
+    expect(sessionLastActivity[sid]).toBeUndefined();
+    expect(transports.other).toBeDefined();
+    expect(sessionLastActivity.other).toBe(2);
+  });
+
+  it("continues cleanup even if an earlier cleanup step throws", async () => {
+    const { rollbackSessionAfterConnectFailure } = await import("../server.js");
+
+    const sid = "sid-throwy";
+    const transport = makeTransport(sid);
+    const transports: Record<string, unknown> = { [sid]: transport };
+    const sessionLastActivity: Record<string, number> = { [sid]: Date.now() };
+
+    let ipLimiterCalled = false;
+    let workspaceCalled = false;
+    const ipLimiter = {
+      remove: (_sid: string) => {
+        ipLimiterCalled = true;
+      },
+    };
+    const sessionStateManager = {
+      cleanup: (_sid: string) => {
+        throw new Error("state-boom");
+      },
+    };
+    const workspaceManager = {
+      cleanup: (_sid: string) => {
+        workspaceCalled = true;
+      },
+    };
+
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      rollbackSessionAfterConnectFailure({
+        transport,
+        sid,
+        transports,
+        sessionLastActivity,
+        ipLimiter,
+        sessionStateManager,
+        workspaceManager,
+      });
+      await new Promise((r) => setImmediate(r));
+      expect(ipLimiterCalled).toBe(true);
+      expect(workspaceCalled).toBe(true);
+    } finally {
+      errSpy.mockRestore();
     }
   });
 });

--- a/src/__tests__/server-round2.test.ts
+++ b/src/__tests__/server-round2.test.ts
@@ -223,7 +223,7 @@ describe("handleSessionInitRaceFallback", () => {
     await new Promise((r) => setTimeout(r, 10));
   });
 
-  it("emits a JSON-RPC error frame (or documented fallback) before closing the transport", async () => {
+  it("closes the transport and logs a diagnostic warn without calling transport.send (pinned fallback contract)", async () => {
     const { handleSessionInitRaceFallback } = await import("../server.js");
 
     const transports: Record<string, { close: () => Promise<void> }> = {};
@@ -267,31 +267,32 @@ describe("handleSessionInitRaceFallback", () => {
     // Allow send/close microtasks to flush.
     await new Promise((r) => setTimeout(r, 20));
 
-    if (sendCalls.length > 0) {
-      // Happy path: the fallback emitted a JSON-RPC error frame via
-      // transport.send BEFORE closing so the client sees a descriptive
-      // rejection rather than a silent disconnect.
-      const frame = sendCalls[0] as Record<string, unknown>;
-      expect(frame.jsonrpc).toBe("2.0");
-      expect((frame.error as Record<string, unknown>)?.code).toBe(-32005);
-      expect(sentAt).toBeDefined();
-      expect(closedAt).toBeDefined();
-      expect(sentAt!).toBeLessThanOrEqual(closedAt!);
-    } else {
-      // Documented fallback path: if transport.send isn't safe at this point
-      // in the SDK lifecycle, the race-fallback still closes the transport
-      // but MUST log a diagnostic warn — the silent-disconnect footgun
-      // turns into a loud log line instead.
-      expect(closedAt).toBeDefined();
-      const warnCalls = warnSpy.mock.calls.map((c) => c[0]);
-      const rejectedLog = warnCalls.find(
-        (m) =>
-          typeof m === "string" &&
-          m.includes("race fallback") &&
-          m.includes(sid.slice(0, 8)),
-      );
-      expect(rejectedLog).toBeDefined();
-    }
+    // Pinned contract (R3 #24 / R4-15): the fallback MUST take the
+    // "silent-disconnect + loud warn" path because the MCP SDK lifecycle
+    // rejects transport.send() inside onsessioninitialized (send() throws
+    // "Not connected" — the stream controller isn't wired yet). The JSDoc
+    // on handleSessionInitRaceFallback in src/server.ts documents this as
+    // intentional. Prior to this commit the test accepted EITHER branch,
+    // which is a contract-less assertion: the code has always taken the
+    // fallback, so the "happy path" branch was unreachable dead validation.
+    // If a future SDK change unlocks transport.send() here, that's a
+    // separate diff — update the contract AND the test together.
+
+    // (1) transport.send must NOT be called.
+    expect(sendCalls.length).toBe(0);
+    expect(sentAt).toBeUndefined();
+    // (2) transport.close WAS called.
+    expect(closedAt).toBeDefined();
+    // (3) A diagnostic warn fired with the sid prefix so operators can
+    //     correlate the silent disconnect with a rate-limit trip.
+    const warnCalls = warnSpy.mock.calls.map((c) => c[0]);
+    const rejectedLog = warnCalls.find(
+      (m) =>
+        typeof m === "string" &&
+        m.includes("race fallback") &&
+        m.includes(sid.slice(0, 8)),
+    );
+    expect(rejectedLog).toBeDefined();
 
     warnSpy.mockRestore();
     errSpy.mockRestore();

--- a/src/__tests__/session-init-rollback-reason.test.ts
+++ b/src/__tests__/session-init-rollback-reason.test.ts
@@ -1,0 +1,115 @@
+/**
+ * R4-5 — the 503 body emitted on handleSessionInitAccept rollback must
+ * carry a `reason:` discriminant (workspace_init_failed / state_init_failed
+ * / ip_limit_rollback) so clients and monitoring can tell the three
+ * failure modes apart. Additionally, the full error (stack) must be
+ * logged server-side, not just err.message.
+ */
+import { describe, it, expect, vi } from "vitest";
+
+describe("handleSessionInitAccept 503 reason + full-error logging (R4-5)", () => {
+  it("rollback body carries reason=workspace_init_failed", async () => {
+    const { handleSessionInitAccept } = await import("../server.js");
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const bodies: unknown[] = [];
+      const boomed = new Error("disk full stack included");
+      const res = {
+        headersSent: false,
+        status: () => ({
+          json: (b: unknown) => {
+            bodies.push(b);
+            return {};
+          },
+        }),
+      };
+      const accepted = handleSessionInitAccept({
+        transport: { close: () => {} },
+        sid: "sid-test-xxxxxxxx",
+        ip: "127.0.0.1",
+        transports: {},
+        sessionLastActivity: {},
+        workspaceManager: {
+          ensureSession: () => {
+            throw boomed;
+          },
+        },
+        res,
+      });
+      expect(accepted).toBe(false);
+      expect(bodies).toHaveLength(1);
+      const body = bodies[0] as {
+        jsonrpc: string;
+        error: { code: number; message: string; data?: { reason?: string } };
+      };
+      expect(body.error?.data?.reason).toBe("workspace_init_failed");
+      // Full Error instance (stack-bearing) must be in the server log, not
+      // just the stringified message.
+      const sawErrorObj = errSpy.mock.calls.some((args) =>
+        args.some((a) => a instanceof Error && a.message === boomed.message),
+      );
+      expect(sawErrorObj).toBe(true);
+    } finally {
+      errSpy.mockRestore();
+    }
+  });
+});
+
+describe("SSE sseGet ensureSession rollback reason (R4-5)", () => {
+  it("503 body uses reason=workspace_init_failed discriminant", async () => {
+    const { createSseHandlers } = await import("../sse-handlers.js");
+    const workspaceManager = {
+      ensureSession: () => {
+        throw new Error("ws-throw");
+      },
+      cleanup: () => {},
+    };
+    const sseTransports: Record<string, unknown> = {};
+    const sessionLastActivity: Record<string, number> = {};
+    const { getHandler } = createSseHandlers({
+      sseTransports: sseTransports as never,
+      sessionLastActivity,
+      ipLimiter: undefined,
+      workspaceManager,
+      createMcpServer: () => ({}) as never,
+    });
+    // Drive the sseGet handler; the handler factory returns
+    // [bearerMiddleware, sseGet]. Invoke the sseGet tail directly.
+    const sseGet = getHandler[getHandler.length - 1];
+    const captured: unknown[] = [];
+    const res: Record<string, unknown> = {
+      headersSent: false,
+      destroyed: false,
+      writableEnded: false,
+      setHeader: () => {},
+      on: () => {},
+      status: (_c: number) => ({
+        json: (b: unknown) => {
+          captured.push(b);
+          return {};
+        },
+      }),
+    };
+    const req = {
+      headers: {},
+      socket: { remoteAddress: "127.0.0.1" },
+    } as never;
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      await (sseGet as unknown as (req: never, res: never) => Promise<void>)(
+        req,
+        res as never,
+      );
+    } finally {
+      errSpy.mockRestore();
+    }
+    // Should have captured a 503 body with reason discriminant.
+    const gotReason = captured.some(
+      (b) =>
+        !!b &&
+        typeof b === "object" &&
+        (b as { reason?: string }).reason === "workspace_init_failed",
+    );
+    expect(gotReason).toBe(true);
+  });
+});

--- a/src/__tests__/session-init-rollback-reason.test.ts
+++ b/src/__tests__/session-init-rollback-reason.test.ts
@@ -103,12 +103,16 @@ describe("SSE sseGet ensureSession rollback reason (R4-5)", () => {
     } finally {
       errSpy.mockRestore();
     }
-    // Should have captured a 503 body with reason discriminant.
+    // Should have captured a 503 body with reason discriminant nested
+    // under error.data, matching the /mcp JSON-RPC envelope shape so
+    // clients read body.error.data.reason uniformly across transports.
     const gotReason = captured.some(
       (b) =>
         !!b &&
         typeof b === "object" &&
-        (b as { reason?: string }).reason === "workspace_init_failed",
+        typeof (b as { error?: unknown }).error === "object" &&
+        (b as { error: { data?: { reason?: string } } }).error.data?.reason ===
+          "workspace_init_failed",
     );
     expect(gotReason).toBe(true);
   });

--- a/src/__tests__/sse-get-correlation.test.ts
+++ b/src/__tests__/sse-get-correlation.test.ts
@@ -92,9 +92,9 @@ describe("sseGet 500 catch correlation ID (R3 #9)", () => {
     );
 
     expect(res._status).toBe(500);
-    const body = res._json as { error: string; correlationId?: string };
-    expect(body.correlationId).toBeTruthy();
+    const body = res._json as { error: string; correlation_id?: string };
+    expect(body.correlation_id).toBeTruthy();
     const joined = consoleErrorSpy.mock.calls.flat().map(String).join(" ");
-    expect(joined).toContain(body.correlationId!);
+    expect(joined).toContain(body.correlation_id!);
   });
 });

--- a/src/__tests__/sse-get-correlation.test.ts
+++ b/src/__tests__/sse-get-correlation.test.ts
@@ -1,0 +1,100 @@
+/**
+ * R3 #9 — sseGet's outer catch block emits
+ * `console.error("[mcp] SSE connection error:", err)` and a generic 500
+ * body. Like /analytics sendFile, there's no shared ID between log and
+ * response — an operator who gets "SSE session failed" from a user can't
+ * find THIS session's failure in logs. Add a correlation ID to both.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSseHandlers } from "../sse-handlers.js";
+import type { Request, Response } from "express";
+
+describe("sseGet 500 catch correlation ID (R3 #9)", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  interface TestRes {
+    _status: number | undefined;
+    _json: unknown;
+    _ended: boolean;
+  }
+
+  function makeRes(): Response & TestRes {
+    const state: TestRes = {
+      _status: undefined,
+      _json: undefined,
+      _ended: false,
+    };
+    const res = {
+      headersSent: false,
+      destroyed: false,
+      writableEnded: false,
+      status(code: number) {
+        state._status = code;
+        return res;
+      },
+      json(body: unknown) {
+        state._json = body;
+        state._ended = true;
+        return res;
+      },
+      setHeader: vi.fn(),
+      on: vi.fn(),
+      get _status() {
+        return state._status;
+      },
+      get _json() {
+        return state._json;
+      },
+      get _ended() {
+        return state._ended;
+      },
+    };
+    return res as unknown as Response & TestRes;
+  }
+
+  it("emits a correlation ID in both the log line and the 500 response", async () => {
+    const handlers = createSseHandlers({
+      sseTransports: {},
+      sessionLastActivity: {},
+      ipLimiter: undefined,
+      workspaceManager: undefined,
+      // Force a throw from the SSE construction path — the simplest
+      // trigger is making createMcpServer throw, which runs inside the
+      // try block and lands in the outer catch.
+      createMcpServer: () => {
+        throw new Error("createMcpServer exploded");
+      },
+      trustProxy: false,
+    });
+
+    // Build a minimal Request that the handler will accept.
+    const req = {
+      socket: { remoteAddress: "127.0.0.1" },
+      ip: "127.0.0.1",
+      headers: {},
+    } as unknown as Request;
+    const res = makeRes();
+
+    // createSseHandlers returns { getHandler: [auth, sseGet],
+    // postHandler: [auth, messagesPost] }. We want sseGet only (skip
+    // bearer middleware). The array is [auth, sseGet] — sseGet is at [1].
+    const sseGet = handlers.getHandler[1];
+    await (sseGet as (req: Request, res: Response) => Promise<void> | void)(
+      req,
+      res,
+    );
+
+    expect(res._status).toBe(500);
+    const body = res._json as { error: string; correlationId?: string };
+    expect(body.correlationId).toBeTruthy();
+    const joined = consoleErrorSpy.mock.calls.flat().map(String).join(" ");
+    expect(joined).toContain(body.correlationId!);
+  });
+});

--- a/src/__tests__/sse-messages-ip-log.test.ts
+++ b/src/__tests__/sse-messages-ip-log.test.ts
@@ -1,0 +1,85 @@
+/**
+ * R3 #10 — /messages 500 catch logs the session-id prefix but no client IP.
+ * Sibling 404 branches (missing-session-id / unknown-session-id) already
+ * log `ip=${clientIp(...)}`; the 500 catch is an outlier and loses the
+ * signal at the exact point an operator is most likely to want it. This
+ * test drives the catch and asserts the log line carries `ip=`.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { createSseHandlers } from "../sse-handlers.js";
+import type { Request, Response } from "express";
+import type { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+
+describe("/messages handlePostMessage 500 log includes client IP (R3 #10)", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  interface TestRes {
+    _status: number | undefined;
+  }
+  function makeRes(): Response & TestRes {
+    const state: TestRes = { _status: undefined };
+    const res = {
+      headersSent: false,
+      status(code: number) {
+        state._status = code;
+        return res;
+      },
+      json() {
+        return res;
+      },
+      get _status() {
+        return state._status;
+      },
+    };
+    return res as unknown as Response & TestRes;
+  }
+
+  it("logs ip= when handlePostMessage rejects", async () => {
+    // Seed a fake transport keyed under sessionId="abcdef1234567890" so
+    // the handler passes the "unknown session" guard and reaches the try
+    // block. The transport's handlePostMessage throws to hit the catch.
+    const sessionId = "abcdef1234567890";
+    const fakeTransport = {
+      handlePostMessage: () => {
+        throw new Error("post boom");
+      },
+    } as unknown as SSEServerTransport;
+    const sseTransports: Record<string, SSEServerTransport> = {
+      [sessionId]: fakeTransport,
+    };
+    const handlers = createSseHandlers({
+      sseTransports,
+      sessionLastActivity: {},
+      ipLimiter: undefined,
+      workspaceManager: undefined,
+      createMcpServer: () => ({}) as never,
+      trustProxy: false,
+    });
+    const req = {
+      socket: { remoteAddress: "127.0.0.1" },
+      ip: "127.0.0.1",
+      headers: {},
+      query: { sessionId },
+      body: {},
+    } as unknown as Request;
+    const res = makeRes();
+
+    // postHandler is [bearerMiddleware, messagesPost] — skip bearer.
+    const messagesPost = handlers.postHandler[1];
+    await (messagesPost as (req: Request, res: Response) => Promise<void>)(
+      req,
+      res,
+    );
+
+    const joined = consoleErrorSpy.mock.calls.flat().map(String).join(" ");
+    expect(joined).toMatch(/\[mcp\] SSE handlePostMessage failed/);
+    expect(joined).toMatch(/ip=/);
+  });
+});

--- a/src/__tests__/start-server-error-wrap.test.ts
+++ b/src/__tests__/start-server-error-wrap.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Mock config module so we can throw from getConfig() deterministically. The
+// module factory reads mock state via closures so per-test overrides work.
+const configState: {
+  throwFrom: "getConfig" | "getServerConfig" | null;
+  error: Error;
+} = {
+  throwFrom: null,
+  error: new Error("synthetic config failure"),
+};
+
+vi.mock("../config.js", () => ({
+  getConfig: vi.fn(() => {
+    if (configState.throwFrom === "getConfig") throw configState.error;
+    return {
+      port: 0,
+      databaseUrl: "pglite:///tmp/test-startserver-wrap",
+      openaiApiKey: "",
+      githubToken: "",
+      githubWebhookSecret: "",
+      nodeEnv: "test",
+      logLevel: "info",
+      cloneDir: "/tmp/test-startserver-wrap",
+      slackBotToken: "",
+      slackSigningSecret: "",
+      discordBotToken: "",
+      discordPublicKey: "",
+      notionToken: "",
+      mcpJwtSecret: "x".repeat(32),
+    };
+  }),
+  getServerConfig: vi.fn(() => {
+    if (configState.throwFrom === "getServerConfig") throw configState.error;
+    return {
+      server: {
+        name: "test-server",
+        version: "0.0.0",
+        max_sessions_per_ip: 20,
+        session_ttl_minutes: 30,
+        allowlist: [],
+        trust_proxy: false,
+      },
+      sources: [],
+      tools: [],
+    };
+  }),
+  getAnalyticsConfig: vi.fn(),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import { startServer } from "../server.js";
+
+describe("startServer top-level error wrapping (R3 #4)", () => {
+  let errorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    configState.throwFrom = null;
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
+  it("logs '[startup] fatal:' and re-throws when getConfig throws", async () => {
+    configState.throwFrom = "getConfig";
+    configState.error = new Error("config.yaml not found");
+
+    await expect(startServer()).rejects.toThrow("config.yaml not found");
+
+    // At least one console.error call must carry the '[startup] fatal:'
+    // prefix plus the underlying error — operators grep this prefix to
+    // correlate startup failures in logs.
+    const fatalCalls = errorSpy.mock.calls.filter((args: unknown[]) => {
+      const msg = String(args[0] ?? "");
+      return msg.includes("[startup] fatal:");
+    });
+    expect(fatalCalls.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("logs '[startup] fatal:' and re-throws when getServerConfig throws", async () => {
+    configState.throwFrom = "getServerConfig";
+    configState.error = new Error("invalid YAML");
+
+    await expect(startServer()).rejects.toThrow("invalid YAML");
+
+    const fatalCalls = errorSpy.mock.calls.filter((args: unknown[]) => {
+      const msg = String(args[0] ?? "");
+      return msg.includes("[startup] fatal:");
+    });
+    expect(fatalCalls.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/src/__tests__/tool-config.test.ts
+++ b/src/__tests__/tool-config.test.ts
@@ -530,6 +530,123 @@ describe("ServerConfigSchema", () => {
       expect(result.success).toBe(false);
     });
   });
+
+  // R4-14: trust_proxy accepts boolean | number (hop count) | string[] (CIDRs).
+  describe("trust_proxy widened shape", () => {
+    const baseTools = [
+      {
+        name: "search-docs",
+        type: "search",
+        description: "Search",
+        source: "docs",
+        default_limit: 5,
+        max_limit: 20,
+        result_format: "docs",
+      },
+    ];
+
+    it("accepts trust_proxy: true (backwards compatible)", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server, trust_proxy: true },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.server.trust_proxy).toBe(true);
+    });
+
+    it("accepts trust_proxy: false (backwards compatible)", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server, trust_proxy: false },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.server.trust_proxy).toBe(false);
+    });
+
+    it("applies the default (false) when trust_proxy is omitted", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.server.trust_proxy).toBe(false);
+    });
+
+    it("accepts trust_proxy as a hop-count number", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server, trust_proxy: 2 },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success) expect(result.data.server.trust_proxy).toBe(2);
+    });
+
+    it("rejects negative hop count", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server, trust_proxy: -1 },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects non-integer hop count", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server, trust_proxy: 1.5 },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it("accepts trust_proxy as a CIDR list", () => {
+      const config = {
+        ...minimalConfig,
+        server: {
+          ...minimalConfig.server,
+          trust_proxy: ["10.0.0.0/8", "192.168.0.0/16"],
+        },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(true);
+      if (result.success)
+        expect(result.data.server.trust_proxy).toEqual([
+          "10.0.0.0/8",
+          "192.168.0.0/16",
+        ]);
+    });
+
+    it("rejects an empty CIDR list", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server, trust_proxy: [] },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+
+    it("rejects a list with an empty string entry", () => {
+      const config = {
+        ...minimalConfig,
+        server: { ...minimalConfig.server, trust_proxy: [""] },
+        tools: baseTools,
+      };
+      const result = ServerConfigSchema.safeParse(config);
+      expect(result.success).toBe(false);
+    });
+  });
 });
 
 describe("BashToolConfigSchema with bash options", () => {

--- a/src/__tests__/webhook-404-vs-503.test.ts
+++ b/src/__tests__/webhook-404-vs-503.test.ts
@@ -1,0 +1,88 @@
+/**
+ * R3 #2 — distinguish 404 (no sources of that type configured) from 503
+ * (sources exist but handler isn't attached yet because startup is still
+ * in progress).
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import express from "express";
+import http from "node:http";
+
+const mockGetConfig = vi.fn();
+const mockGetServerConfig = vi.fn();
+const mockGetAnalyticsConfig = vi.fn();
+
+vi.mock("../config.js", () => ({
+  getConfig: (...args: unknown[]) => mockGetConfig(...args),
+  getServerConfig: (...args: unknown[]) => mockGetServerConfig(...args),
+  getAnalyticsConfig: (...args: unknown[]) => mockGetAnalyticsConfig(...args),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+beforeEach(() => {
+  mockGetConfig.mockReturnValue({
+    port: 0,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "e".repeat(64),
+  });
+  mockGetServerConfig.mockReturnValue({
+    server: { name: "pathfinder-test", version: "0.0.0" },
+    sources: [],
+    tools: [],
+  });
+  mockGetAnalyticsConfig.mockReturnValue(undefined);
+});
+
+describe("classifyWebhookUnavailable (R3 #2)", () => {
+  it("returns 404 not-configured when no sources of that type exist", async () => {
+    const { classifyWebhookUnavailable } = await import("../server.js");
+    mockGetServerConfig.mockReturnValue({
+      server: { name: "t", version: "0.0.0" },
+      sources: [{ name: "docs", type: "website" }],
+      tools: [],
+    });
+    const r = classifyWebhookUnavailable({ sourceType: "github" });
+    expect(r.status).toBe(404);
+    expect(r.body.error).toMatch(/not configured/i);
+  });
+
+  it("returns 503 still-initializing when sources exist but handler not ready", async () => {
+    const { classifyWebhookUnavailable } = await import("../server.js");
+    mockGetServerConfig.mockReturnValue({
+      server: { name: "t", version: "0.0.0" },
+      sources: [{ name: "repo", type: "github" }],
+      tools: [],
+    });
+    const r = classifyWebhookUnavailable({ sourceType: "github" });
+    expect(r.status).toBe(503);
+    expect(r.body.error).toMatch(/initializing/i);
+  });
+
+  it("works for slack and discord source types", async () => {
+    const { classifyWebhookUnavailable } = await import("../server.js");
+    mockGetServerConfig.mockReturnValue({
+      server: { name: "t", version: "0.0.0" },
+      sources: [{ name: "s", type: "slack" }],
+      tools: [],
+    });
+    expect(classifyWebhookUnavailable({ sourceType: "slack" }).status).toBe(
+      503,
+    );
+    expect(classifyWebhookUnavailable({ sourceType: "discord" }).status).toBe(
+      404,
+    );
+  });
+});

--- a/src/__tests__/webhook-middleware-order.test.ts
+++ b/src/__tests__/webhook-middleware-order.test.ts
@@ -60,6 +60,7 @@ function post(
   server: http.Server,
   path: string,
   body: string,
+  contentType = "application/json",
 ): Promise<{ status: number; body: string }> {
   const addr = server.address();
   if (!addr || typeof addr === "string") throw new Error("no address");
@@ -71,7 +72,7 @@ function post(
         path,
         method: "POST",
         headers: {
-          "Content-Type": "application/json",
+          "Content-Type": contentType,
           "Content-Length": Buffer.byteLength(body).toString(),
         },
       },
@@ -112,6 +113,47 @@ describe("assertWebhookRawBodyOrder runtime guard (R4-7)", () => {
         const resp = await post(server, "/webhooks/github", '{"x":1}');
         expect(resp.status).toBe(200);
         expect(receivedType).toBe("buffer");
+      } finally {
+        await stopServer(server);
+      }
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("does NOT log 'middleware misconfigured' when content-type mismatch makes express.raw skip", async () => {
+    // Regression: before this guard distinguished cases, a webhook request
+    // arriving with Content-Type: text/plain caused express.raw (configured
+    // with type: "application/json") to skip parsing. req.body stayed as
+    // the Express default {} and the guard fired "middleware misconfigured"
+    // — but NOTHING was misconfigured; the client just used the wrong
+    // content-type. The guard should return 415 quietly instead.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const app = express();
+      app.post(
+        "/webhooks/github",
+        express.raw({ type: "application/json" }),
+        assertWebhookRawBodyOrder("webhook"),
+        (_req: Request, res: Response) => {
+          // Should never reach the handler — request is rejected at the guard.
+          res.status(200).json({ ok: true });
+        },
+      );
+      const server = await startServer(app);
+      try {
+        const resp = await post(
+          server,
+          "/webhooks/github",
+          "hello",
+          "text/plain",
+        );
+        expect(resp.status).toBe(415);
+        // No "middleware misconfigured" / "middleware ordering bug" log.
+        const misconfigCalls = errorSpy.mock.calls.filter((args: unknown[]) =>
+          String(args[0] ?? "").includes("middleware"),
+        );
+        expect(misconfigCalls.length).toBe(0);
       } finally {
         await stopServer(server);
       }

--- a/src/__tests__/webhook-middleware-order.test.ts
+++ b/src/__tests__/webhook-middleware-order.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect, vi } from "vitest";
+import express from "express";
+import type { Request, Response } from "express";
+import http from "node:http";
+
+// Mock config so importing server.ts doesn't blow up.
+vi.mock("../config.js", () => ({
+  getConfig: vi.fn().mockReturnValue({
+    port: 0,
+    databaseUrl: "pglite:///tmp/test",
+    openaiApiKey: "",
+    githubToken: "",
+    githubWebhookSecret: "",
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    discordPublicKey: "",
+    notionToken: "",
+    mcpJwtSecret: "x".repeat(32),
+  }),
+  getServerConfig: vi.fn().mockReturnValue({
+    server: { name: "test", version: "0.0.0" },
+    sources: [],
+    tools: [],
+  }),
+  getAnalyticsConfig: vi.fn(),
+  hasSearchTools: vi.fn().mockReturnValue(false),
+  hasKnowledgeTools: vi.fn().mockReturnValue(false),
+  hasCollectTools: vi.fn().mockReturnValue(false),
+  hasBashSemanticSearch: vi.fn().mockReturnValue(false),
+}));
+
+import { assertWebhookRawBodyOrder } from "../server.js";
+
+// ---------------------------------------------------------------------------
+// R4-7: middleware-ordering guard for /webhooks/* routes.
+//
+// The production /webhooks/{github,slack,discord} routes all mount
+// express.raw BEFORE the handler so req.body arrives as a Buffer for
+// HMAC signature verification. A refactor that (accidentally) places
+// express.json earlier in the stack would silently swap Buffer -> object
+// and every signature check would 401. These tests verify the runtime
+// guard fires a loud 500 on that exact misconfiguration.
+// ---------------------------------------------------------------------------
+
+function startServer(app: express.Express): Promise<http.Server> {
+  return new Promise((resolve) => {
+    const server = app.listen(0, () => resolve(server));
+  });
+}
+
+function stopServer(server: http.Server): Promise<void> {
+  return new Promise((resolve) => server.close(() => resolve()));
+}
+
+function post(
+  server: http.Server,
+  path: string,
+  body: string,
+): Promise<{ status: number; body: string }> {
+  const addr = server.address();
+  if (!addr || typeof addr === "string") throw new Error("no address");
+  return new Promise((resolve, reject) => {
+    const req = http.request(
+      {
+        hostname: "127.0.0.1",
+        port: addr.port,
+        path,
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          "Content-Length": Buffer.byteLength(body).toString(),
+        },
+      },
+      (res) => {
+        const chunks: Buffer[] = [];
+        res.on("data", (c: Buffer) => chunks.push(c));
+        res.on("end", () =>
+          resolve({
+            status: res.statusCode ?? 0,
+            body: Buffer.concat(chunks).toString("utf8"),
+          }),
+        );
+      },
+    );
+    req.on("error", reject);
+    req.write(body);
+    req.end();
+  });
+}
+
+describe("assertWebhookRawBodyOrder runtime guard (R4-7)", () => {
+  it("passes through when express.raw ran first (req.body is a Buffer)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const app = express();
+      let receivedType = "";
+      app.post(
+        "/webhooks/github",
+        express.raw({ type: "application/json" }),
+        assertWebhookRawBodyOrder("webhook"),
+        (req: Request, res: Response) => {
+          receivedType = Buffer.isBuffer(req.body) ? "buffer" : typeof req.body;
+          res.status(200).json({ ok: true });
+        },
+      );
+      const server = await startServer(app);
+      try {
+        const resp = await post(server, "/webhooks/github", '{"x":1}');
+        expect(resp.status).toBe(200);
+        expect(receivedType).toBe("buffer");
+      } finally {
+        await stopServer(server);
+      }
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+
+  it("returns 500 with a loud log when express.json ran first (req.body is object)", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      const app = express();
+      // DELIBERATELY WRONG ORDER: json before raw. Express uses the first
+      // matching body parser, so req.body will be the parsed object. The
+      // guard must refuse.
+      app.use(express.json());
+      app.post(
+        "/webhooks/github",
+        express.raw({ type: "application/json" }),
+        assertWebhookRawBodyOrder("webhook"),
+        (_req: Request, res: Response) => {
+          // Should never run.
+          res.status(200).json({ ok: true });
+        },
+      );
+      const server = await startServer(app);
+      try {
+        const resp = await post(server, "/webhooks/github", '{"x":1}');
+        expect(resp.status).toBe(500);
+        expect(resp.body).toContain("misconfigured");
+        // Verify the loud log fired.
+        const loudCalls = errorSpy.mock.calls.filter((args: unknown[]) =>
+          String(args[0] ?? "").includes("middleware ordering bug"),
+        );
+        expect(loudCalls.length).toBeGreaterThanOrEqual(1);
+      } finally {
+        await stopServer(server);
+      }
+    } finally {
+      errorSpy.mockRestore();
+    }
+  });
+});

--- a/src/config.ts
+++ b/src/config.ts
@@ -363,6 +363,64 @@ export function getAnalyticsConfig(): AnalyticsConfig | undefined {
 }
 
 /**
+ * Render an unknown thrown value as a single log-friendly string. Local
+ * duplicate of server.ts's `formatErrorForLog` to avoid a config → server
+ * circular import. Keep these two in sync.
+ */
+function formatErrorForConfigLog(err: unknown): string {
+  if (err instanceof Error) return err.stack ?? err.message;
+  if (err && typeof err === "object") {
+    const maybe = err as { stack?: unknown; message?: unknown };
+    if (typeof maybe.stack === "string") return maybe.stack;
+    if (typeof maybe.message === "string") return maybe.message;
+  }
+  return String(err);
+}
+
+/**
+ * Try to import a peer dep module and classify the outcome:
+ *   - success         → no-op
+ *   - MODULE_NOT_FOUND / ERR_MODULE_NOT_FOUND → add to `missing`
+ *   - any other error → log full stack + re-throw a distinct "installed but
+ *     failed to import" error so the caller surfaces the real cause
+ *
+ * Distinguishing these matters: the previous empty catch swallowed every
+ * throw as "peer missing", which produced a confusing install-hint message
+ * even when the peer WAS installed but failed to load (e.g. native-addon
+ * ABI mismatch, ESM/CJS interop throw, file-system permission error on
+ * node_modules/). Operators would follow the hint, reinstall, and see no
+ * change.
+ */
+async function probePeerDepOrThrow(
+  tryImport: (module: string) => Promise<unknown>,
+  pkg: string,
+  forType: string,
+  missing: Array<{ pkg: string; forType: string }>,
+): Promise<void> {
+  try {
+    await tryImport(pkg);
+  } catch (err) {
+    const code = (err as { code?: unknown })?.code;
+    const isNotFound =
+      code === "ERR_MODULE_NOT_FOUND" || code === "MODULE_NOT_FOUND";
+    if (isNotFound) {
+      missing.push({ pkg, forType });
+      return;
+    }
+    // Unexpected failure shape — log the full stack so operators can diagnose
+    // the real cause (native-addon failure, ESM interop throw, etc.) and
+    // re-throw a distinct error with the original attached as the cause.
+    console.error(
+      `[startup] ${pkg} is installed but failed to import: ${formatErrorForConfigLog(err)}`,
+    );
+    throw new Error(
+      `${pkg} is installed but failed to import (required for ${forType} document sources). See preceding log for details.`,
+      { cause: err },
+    );
+  }
+}
+
+/**
  * R4-13 — validate that required document-extraction peer deps
  * (`pdf-parse`, `mammoth`) are installed when a `document` source is
  * configured with file patterns that need them.
@@ -402,18 +460,10 @@ export async function assertDocumentPeerDepsForSources(
   );
   const missing: Array<{ pkg: string; forType: string }> = [];
   if (needsPdf) {
-    try {
-      await tryImport("pdf-parse");
-    } catch {
-      missing.push({ pkg: "pdf-parse", forType: "PDF" });
-    }
+    await probePeerDepOrThrow(tryImport, "pdf-parse", "PDF", missing);
   }
   if (needsDocx) {
-    try {
-      await tryImport("mammoth");
-    } catch {
-      missing.push({ pkg: "mammoth", forType: "DOCX" });
-    }
+    await probePeerDepOrThrow(tryImport, "mammoth", "DOCX", missing);
   }
   if (missing.length === 0) return;
   const lines = missing.map(

--- a/src/config.ts
+++ b/src/config.ts
@@ -361,3 +361,68 @@ export function getAnalyticsConfig(): AnalyticsConfig | undefined {
     | AnalyticsConfig
     | undefined;
 }
+
+/**
+ * R4-13 — validate that required document-extraction peer deps
+ * (`pdf-parse`, `mammoth`) are installed when a `document` source is
+ * configured with file patterns that need them.
+ *
+ * The per-file extraction path in indexing/content-extractors.ts throws a
+ * clear error when the dynamic import fails — but that throw only fires
+ * when a specific file is being indexed, which could be hours into a first
+ * run. Running the check at config-load time surfaces the missing peer
+ * BEFORE the server starts accepting traffic, so operators see the install
+ * hint alongside the rest of their startup errors.
+ *
+ * `tryImport` is injected so tests can drive every present/absent
+ * combination without manipulating node_modules.
+ */
+export async function assertDocumentPeerDepsForSources(
+  sources: ReadonlyArray<{
+    type: string;
+    file_patterns?: string[];
+    [key: string]: unknown;
+  }>,
+  opts?: { tryImport?: (module: string) => Promise<unknown> },
+): Promise<void> {
+  const tryImport =
+    opts?.tryImport ??
+    (async (m: string) => {
+      // Dynamic require via Function to dodge TS's static resolution of the
+      // optional peer — same pattern content-extractors.ts uses.
+      return await import(m);
+    });
+  const documentSources = sources.filter((s) => s.type === "document");
+  if (documentSources.length === 0) return;
+  const needsPdf = documentSources.some((s) =>
+    (s.file_patterns ?? []).some((p) => p.includes(".pdf")),
+  );
+  const needsDocx = documentSources.some((s) =>
+    (s.file_patterns ?? []).some((p) => p.includes(".docx")),
+  );
+  const missing: Array<{ pkg: string; forType: string }> = [];
+  if (needsPdf) {
+    try {
+      await tryImport("pdf-parse");
+    } catch {
+      missing.push({ pkg: "pdf-parse", forType: "PDF" });
+    }
+  }
+  if (needsDocx) {
+    try {
+      await tryImport("mammoth");
+    } catch {
+      missing.push({ pkg: "mammoth", forType: "DOCX" });
+    }
+  }
+  if (missing.length === 0) return;
+  const lines = missing.map(
+    (m) =>
+      `  - ${m.pkg} (required for ${m.forType} document sources). Install: npm install ${m.pkg}`,
+  );
+  throw new Error(
+    `Configured document sources require optional peer dependencies that are not installed:\n${lines.join(
+      "\n",
+    )}\n\nAdd these to your install or remove the corresponding source.`,
+  );
+}

--- a/src/ip-util.ts
+++ b/src/ip-util.ts
@@ -19,8 +19,23 @@ import type { Request } from "express";
  * reverse proxy that strips and rewrites the incoming `X-Forwarded-For`
  * header. Railway's edge does this correctly; a bare `node` process exposed
  * directly to the public internet does not.
+ *
+ * IMPORTANT — Express `trust proxy = true` leftmost-XFF caveat: see the
+ * detailed warning in startServer() in `src/server.ts` (search for
+ * "leftmost (client-supplied, potentially spoofable)"). In short, Express's
+ * boolean `trust proxy = true` trusts EVERY hop in the X-Forwarded-For chain
+ * and resolves `req.ip` to the LEFTMOST entry — which is the client-supplied
+ * (and therefore spoofable) value unless the fronting reverse proxy strips
+ * and rewrites XFF before it reaches us. For tighter single-hop deployments
+ * prefer a numeric hop count (`app.set("trust proxy", 1)`); the IP allowlist
+ * bypass in the per-IP session limiter is only as strong as the trust
+ * boundary configured here. See `pathfinder.example.yaml` next to
+ * `server.trust_proxy` for the operator-facing version of this warning.
  */
-export function clientIp(req: Request, trustProxy: boolean): string {
+export function clientIp(
+  req: Request,
+  trustProxy: boolean | number | string[],
+): string {
   // NOTE: we use `||` rather than `??` throughout so the empty string also
   // falls through to the next candidate. An empty `remoteAddress` can show
   // up after abrupt disconnects, in some HTTP/2 upgrade paths, and in test
@@ -28,7 +43,16 @@ export function clientIp(req: Request, trustProxy: boolean): string {
   // into a single "" counter in the per-IP rate limiter, letting one
   // client DoS every other client in that state. `||` treats "" the same
   // as undefined/null and keeps walking the fallback chain.
-  if (trustProxy) {
+  //
+  // `trustProxy` mirrors Express's `trust proxy` union: truthy boolean,
+  // positive hop count, or non-empty CIDR/IP array all honor req.ip (which
+  // Express resolves from the XFF chain). Falsy boolean / 0 / empty array
+  // ignores XFF and trusts only the TCP peer.
+  const honorXff =
+    trustProxy === true ||
+    (typeof trustProxy === "number" && trustProxy > 0) ||
+    (Array.isArray(trustProxy) && trustProxy.length > 0);
+  if (honorXff) {
     // Express populates req.ip from the XFF chain when `trust proxy` is set.
     // Fall back to the socket if the framework somehow didn't resolve one
     // (or left an empty string), and to "unknown" only as a last resort so

--- a/src/server.ts
+++ b/src/server.ts
@@ -189,6 +189,29 @@ async function refreshBashInstances(
 }
 
 /**
+ * Render an unknown thrown value as a single log-friendly string.
+ *
+ * R3 #3 — multiple catch sites previously emitted only `err.message`. That
+ * strips the stack, so during incident triage operators can't correlate the
+ * failure to a code line without reproducing locally. This helper returns
+ * `err.stack` when present (which always includes `err.message`) and falls
+ * back to `String(err)` for non-Error throws. Centralized so every call site
+ * speaks one format and future additions of redaction / correlation IDs
+ * happen in one place.
+ */
+export function formatErrorForLog(err: unknown): string {
+  if (err instanceof Error) return err.stack ?? err.message;
+  // Error-like objects (thrown object literals, DOMExceptions, etc.) may
+  // carry a `.stack` or `.message` without being Error instances.
+  if (err && typeof err === "object") {
+    const maybe = err as { stack?: unknown; message?: unknown };
+    if (typeof maybe.stack === "string") return maybe.stack;
+    if (typeof maybe.message === "string") return maybe.message;
+  }
+  return String(err);
+}
+
+/**
  * Test-only accessor to the live bash registry. Production code should
  * continue to use the module-local `bashInstances` closure reference.
  */
@@ -2132,9 +2155,27 @@ function isLocalhostReq(req: Request): boolean {
     }
     // IPv6 loopback is exactly ::1.
     return (parsed as ipaddr.IPv6).toNormalizedString() === "0:0:0:0:0:0:0:1";
-  } catch {
+  } catch (err) {
+    // R3 #14 — emit a debug-level log so an operator bisecting why
+    // the analytics dev-bypass stopped working can see that the parse
+    // itself failed. Debug-level so we don't spam normal logs, but
+    // operators with debug enabled get the address + error message.
+    // Return contract is unchanged — unparseable addresses still
+    // resolve to "not localhost" (fail-closed).
+    console.debug(
+      `[isLocalhostReq] ipaddr.parse failed for addr=${addr}: ${formatErrorForLog(err)}`,
+    );
     return false;
   }
+}
+
+/**
+ * Test-only export — isLocalhostReq is module-scoped because the live
+ * path needs access to the module-level `trustProxy` mutable flag. Tests
+ * drive it via this helper so they don't have to spoof TCP sockets.
+ */
+export function __isLocalhostReqForTesting(req: Request): boolean {
+  return isLocalhostReq(req);
 }
 
 /**
@@ -2211,7 +2252,7 @@ export function analyticsAuth(
     analyticsCfg = getAnalyticsConfig();
   } catch (err) {
     console.error(
-      `[analytics] auth misconfigured: config read failed: ${err instanceof Error ? err.message : String(err)}`,
+      `[analytics] auth misconfigured: config read failed: ${formatErrorForLog(err)}`,
     );
     res.status(503).json({
       error: "misconfigured",
@@ -2249,9 +2290,7 @@ export function analyticsAuth(
   try {
     token = getAnalyticsToken();
   } catch (err) {
-    console.error(
-      `[analytics] auth misconfigured: ${err instanceof Error ? err.message : String(err)}`,
-    );
+    console.error(`[analytics] auth misconfigured: ${formatErrorForLog(err)}`);
     res.status(503).json({
       error: "misconfigured",
       error_description: tokenDescription,
@@ -2283,15 +2322,30 @@ export function analyticsAuth(
   }
 
   const provided = authHeader.slice(7);
-  // Constant-time comparison so an attacker can't infer the token from
-  // response-time differences. Buffers must be the same length; mismatched
-  // lengths fail fast.
   const providedBuf = Buffer.from(provided, "utf8");
   const tokenBuf = Buffer.from(token, "utf8");
-  if (
-    providedBuf.length !== tokenBuf.length ||
-    !timingSafeEqual(providedBuf, tokenBuf)
-  ) {
+  // R4-18 — dedicated early return on length mismatch BEFORE calling
+  // timingSafeEqual. crypto.timingSafeEqual REQUIRES same-length buffers;
+  // passing different lengths throws ERR_CRYPTO_TIMING_SAFE_EQUAL_LENGTH
+  // which would escape as an unhandled 500. The previous shape fused the
+  // check into `len !== len || !timingSafeEqual(...)` — correct today
+  // because || short-circuits, but a future refactor swapping operator
+  // precedence or reordering the operands would crash at the call. The
+  // early return is both self-documenting and robust to refactor errors.
+  //
+  // Separating the checks does NOT leak a timing oracle on token length:
+  // the correct token length is already observable via the error body
+  // shape and the call latency to any non-constant-time string op in
+  // JavaScript. The value of timingSafeEqual is protecting the BYTES of
+  // the secret once the lengths match, which this structure preserves.
+  if (providedBuf.length !== tokenBuf.length) {
+    res.status(403).json({
+      error: "forbidden",
+      error_description: "Invalid analytics token",
+    });
+    return;
+  }
+  if (!timingSafeEqual(providedBuf, tokenBuf)) {
     res.status(403).json({
       error: "forbidden",
       error_description: "Invalid analytics token",
@@ -2620,7 +2674,7 @@ export function registerAnalyticsRoutes(
         res.json(summary);
       } catch (err) {
         console.error(
-          `[analytics] Summary query failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value}):`,
+          `[analytics] Summary query failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value} ip=${clientIp(req, trustProxy)}):`,
           err,
         );
         res.status(500).json({ error: "Failed to fetch analytics summary" });
@@ -2656,7 +2710,7 @@ export function registerAnalyticsRoutes(
         res.json(queries);
       } catch (err) {
         console.error(
-          `[analytics] Top queries failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value} limit=${limitParsed.value}):`,
+          `[analytics] Top queries failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value} limit=${limitParsed.value} ip=${clientIp(req, trustProxy)}):`,
           err,
         );
         res.status(500).json({ error: "Failed to fetch top queries" });
@@ -2692,7 +2746,7 @@ export function registerAnalyticsRoutes(
         res.json(queries);
       } catch (err) {
         console.error(
-          `[analytics] Empty queries failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value} limit=${limitParsed.value}):`,
+          `[analytics] Empty queries failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value} limit=${limitParsed.value} ip=${clientIp(req, trustProxy)}):`,
           err,
         );
         res.status(500).json({ error: "Failed to fetch empty queries" });
@@ -2719,7 +2773,7 @@ export function registerAnalyticsRoutes(
         res.json(counts);
       } catch (err) {
         console.error(
-          `[analytics] Tool counts failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value}):`,
+          `[analytics] Tool counts failed (filter=${JSON.stringify(parsed.filter)} days=${daysParsed.value} ip=${clientIp(req, trustProxy)}):`,
           err,
         );
         res.status(500).json({ error: "Failed to fetch tool counts" });
@@ -2769,11 +2823,21 @@ export function registerAnalyticsRoutes(
         res.status(404).json({ error: "analytics dashboard not available" });
         return;
       }
+      // R3 #8 — emit a correlation ID in BOTH the server log and the
+      // response body. Operators who get a user report can grep logs for
+      // the ID the user saw and jump straight to the failing stack
+      // without cross-referencing timestamps. Using short randomUUID
+      // slices keeps the ID operator-readable while still collision-safe
+      // at our failure-log volumes.
+      const correlationId = randomUUID().replace(/-/g, "").slice(0, 12);
       console.error(
-        `[analytics] sendFile failed path=${_analyticsHtmlPath}:`,
+        `[analytics] sendFile failed path=${_analyticsHtmlPath} cid=${correlationId}:`,
         err,
       );
-      res.status(500).json({ error: "analytics dashboard unavailable" });
+      res.status(500).json({
+        error: "analytics dashboard unavailable",
+        correlationId,
+      });
     });
   });
 }
@@ -2953,7 +3017,7 @@ async function startServerInner(options?: ServerOptions): Promise<void> {
           .catch((err) =>
             console.error(
               "[telemetry] Periodic flush failed:",
-              err instanceof Error ? err.message : String(err),
+              formatErrorForLog(err),
             ),
           );
       }, 60_000);

--- a/src/server.ts
+++ b/src/server.ts
@@ -360,7 +360,7 @@ if (process.env.PATHFINDER_TRACE_CLAUDE_AI === "1") {
     // Route through the shared helper so tracing, rate limiting, and
     // analytics dev-bypass all agree on the resolved IP (and all share
     // the same X-Forwarded-For spoof protection when trust_proxy=false).
-    const ip = clientIp(req, trustProxy);
+    const ip = clientIp(req, isTrustingProxy());
     if (
       ip.startsWith("160.79.106") ||
       ip.startsWith("104.192.205") ||
@@ -683,10 +683,11 @@ function reapIdleSessionsTick(): void {
  *   body here, so the losing client sees a silent TCP close. The loud
  *   `console.warn` below is the operator-side compensation.
  *
- *   TODO: revisit this asymmetry if/when the MCP SDK exposes a way to
- *   emit a protocol-level error frame during onsessioninitialized — at
- *   that point both transports can converge on the same "descriptive
- *   rejection" shape and this helper can stop being the quiet one.
+ *   If a future MCP SDK version exposes a way to emit a protocol-level
+ *   error frame during onsessioninitialized, both transports can
+ *   converge on the same "descriptive rejection" shape and this helper
+ *   can stop being the quiet one. Until then the silent-disconnect is
+ *   the documented SDK-imposed behavior — not a TODO, a constraint.
  *
  * Note on step 1: the MCP SDK's `StreamableHTTPServerTransport.send()`
  * requires a live SSE stream (see node_modules/.../webStandardStreamableHttp
@@ -1184,7 +1185,27 @@ let sessionReaperInterval: ReturnType<typeof setInterval> | undefined;
 // run yet, or the config omits the flag, we IGNORE X-Forwarded-For and fall
 // back to the socket address — matching the hardened, spoof-resistant
 // default documented in types.ts.
-let trustProxy = false;
+// R4-14: widened to match the types.ts schema. Express's `app.set("trust
+// proxy", …)` accepts boolean | number | string[] (list of CIDRs) so the
+// config surface exposes all three. `clientIp` still takes a boolean — we
+// derive it via `isTrustingProxy(trustProxy)` below.
+let trustProxy: boolean | number | string[] = false;
+
+/**
+ * Reduce the widened `trust_proxy` config value to a boolean for `clientIp`
+ * and the analytics-dev-bypass guard. Anything other than the literal `false`
+ * (including `true`, a positive hop count, or any non-empty CIDR list) means
+ * "we're honoring X-Forwarded-For in some form" — the spoof risk surface
+ * is identical from `clientIp`'s perspective, so we collapse to a boolean.
+ */
+function isTrustingProxy(
+  value: boolean | number | string[] = trustProxy,
+): boolean {
+  if (typeof value === "boolean") return value;
+  if (typeof value === "number") return value > 0;
+  if (Array.isArray(value)) return value.length > 0;
+  return false;
+}
 
 /**
  * Test-only accessor for the module-level trustProxy flag. The flag is set
@@ -1194,14 +1215,16 @@ let trustProxy = false;
  * reset to `false` in an afterEach / finally so other tests don't inherit
  * the stale value.
  */
-export function __setTrustProxyForTesting(value: boolean): void {
+export function __setTrustProxyForTesting(
+  value: boolean | number | string[],
+): void {
   trustProxy = value;
 }
 
 app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
   try {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
-    const ip = clientIp(req, trustProxy);
+    const ip = clientIp(req, isTrustingProxy());
 
     // Existing session — route to its transport
     if (sessionId && transports[sessionId]) {
@@ -1616,8 +1639,10 @@ const sseHandlers = createSseHandlers({
   workspaceManager: () => workspaceManager,
   // Late-bound via getter: trustProxy is resolved inside startServer() from
   // the loaded config, after this handler factory has already been invoked
-  // at module-load time.
-  trustProxy: () => trustProxy,
+  // at module-load time. Collapse to boolean for the SSE handlers' clientIp
+  // contract — the spoof-risk surface is identical whether we're trusting by
+  // hop count, CIDR list, or a blanket `true`.
+  trustProxy: () => isTrustingProxy(),
   rateLimitRetryAfterSeconds: () => retryAfterSecondsFromTtl(),
   createMcpServer: () => {
     let transportRef: SSEServerTransport | undefined;
@@ -1907,6 +1932,48 @@ export function __resetAnalyticsTokenForTesting(): void {
 }
 
 /**
+ * R4-8 — startup-time guard for the production-analytics token.
+ *
+ * Previously `getAnalyticsToken()` would auto-generate a process-ephemeral
+ * UUID when analytics was enabled without an explicit token. That token was
+ * unique per replica, so in multi-replica deployments the dashboard could
+ * authenticate against replica A and then hit replica B on the next request
+ * and be rejected with 401 (replica B minted its own different UUID).
+ *
+ * The fix: at startup, when `analytics.enabled && nodeEnv === "production"`
+ * and neither `analytics.token` nor the ANALYTICS_TOKEN env var is set, we
+ * throw a clear error so operators discover the missing config BEFORE the
+ * server starts serving. The existing runtime throw inside
+ * `getAnalyticsToken()` remains as a defense-in-depth second check; this
+ * assert just moves the discovery to process boot.
+ *
+ * Pure function so tests can drive every combination of
+ * (nodeEnv × enabled × configuredToken × envToken) without booting the full
+ * server.
+ */
+export function assertAnalyticsTokenConfigured(opts: {
+  nodeEnv: string;
+  analyticsEnabled: boolean;
+  configuredToken: string | undefined;
+  envToken: string | undefined;
+}): void {
+  if (!opts.analyticsEnabled) return;
+  if (opts.nodeEnv !== "production") return;
+  // Treat empty string same as undefined — `analytics.token: ""` in YAML
+  // otherwise silently skips the guard.
+  const hasConfigured =
+    !!opts.configuredToken && opts.configuredToken.length > 0;
+  const hasEnv = !!opts.envToken && opts.envToken.length > 0;
+  if (hasConfigured || hasEnv) return;
+  throw new Error(
+    "ANALYTICS_TOKEN required in production (set analytics.token in config " +
+      "or the ANALYTICS_TOKEN env var). Auto-generated tokens are " +
+      "process-ephemeral and break multi-replica deployments — a dashboard " +
+      "authenticated against one replica will 401 on another.",
+  );
+}
+
+/**
  * Return true if the request originated from a loopback interface. Trusts
  * ONLY `req.socket.remoteAddress` (not `X-Forwarded-For` — that's client-
  * controlled and would let anyone forge "I'm localhost").
@@ -1939,7 +2006,7 @@ function isLocalhostReq(req: Request): boolean {
   // trust_proxy or bind the dev server directly without a fronting proxy.
   // A startup WARN is emitted from startServer() when both flags are set so
   // this behavior isn't silent.
-  if (trustProxy) return false;
+  if (isTrustingProxy()) return false;
   const addr = req.socket?.remoteAddress ?? "";
   if (!addr) return false;
   try {
@@ -2321,8 +2388,13 @@ export function parsePositiveIntParam(
 ): number | { error: string } {
   if (raw === undefined || raw === null || raw === "") return defaultValue;
   if (typeof raw !== "string") return { error: "must be a string" };
+  // R4-10: STRICT /^\d+$/ guard BEFORE Number.parseInt. Without this, inputs
+  // like "1.5", "1e3", " 123", and "123abc" would be silently coerced by
+  // parseInt's permissive grammar (truncating at the first non-digit / after
+  // implicit trim) and the function would return a plausible-looking
+  // positive integer for gibberish input. See the dedicated test cases.
   if (!/^\d+$/.test(raw)) return { error: "must be a positive integer" };
-  const n = parseInt(raw, 10);
+  const n = Number.parseInt(raw, 10);
   if (n <= 0) return { error: "must be > 0" };
   if (n > max) return { error: `must be <= ${max}` };
   return n;
@@ -2658,9 +2730,14 @@ async function startServerInner(options?: ServerOptions): Promise<void> {
   // must agree, always.
   trustProxy = serverCfg.server.trust_proxy ?? false;
   app.set("trust proxy", trustProxy);
-  if (trustProxy) {
+  if (isTrustingProxy()) {
+    // R4-14: print the configured value so operators can confirm the shape
+    // (blanket boolean, hop count, or CIDR list) actually took effect.
+    const rendered = Array.isArray(trustProxy)
+      ? `[${trustProxy.join(", ")}]`
+      : String(trustProxy);
     console.log(
-      "[startup] trust_proxy=true — honoring X-Forwarded-For (reverse proxy must strip/rewrite this header)",
+      `[startup] trust_proxy=${rendered} — honoring X-Forwarded-For (reverse proxy must strip/rewrite this header)`,
     );
     if (cfg.nodeEnv === "development") {
       // Dev bypass and trust_proxy=true is an unsupported combination:
@@ -2680,6 +2757,22 @@ async function startServerInner(options?: ServerOptions): Promise<void> {
       "[startup] trust_proxy=false — X-Forwarded-For ignored; client IP derived from socket (hardened default)",
     );
   }
+
+  // R4-8 — refuse to start in production when analytics is enabled but no
+  // stable token is configured. The runtime `getAnalyticsToken()` throw is
+  // too late: the error only surfaces on the first /api/analytics request
+  // AND — worse — a pre-R4-8 replica would auto-generate its own token and
+  // silently start answering with an unshared secret. Fail loudly here so
+  // the missing ANALYTICS_TOKEN is discovered at deploy time, not hours
+  // later when the dashboard starts randomly 401-ing against the other
+  // replicas.
+  const analyticsCfg = getAnalyticsConfig();
+  assertAnalyticsTokenConfigured({
+    nodeEnv: cfg.nodeEnv,
+    analyticsEnabled: !!analyticsCfg?.enabled,
+    configuredToken: analyticsCfg?.token,
+    envToken: process.env.ANALYTICS_TOKEN,
+  });
 
   // Configure session TTL and IP rate limiter from config
   const maxSessionsPerIp = serverCfg.server.max_sessions_per_ip ?? 20;

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,4 +1,9 @@
-import express, { Request, Response } from "express";
+import express, {
+  NextFunction,
+  Request,
+  RequestHandler,
+  Response,
+} from "express";
 import cors from "cors";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import { Bash } from "just-bash";
@@ -95,6 +100,40 @@ app.use((_req, res, next) => {
 // requests receive 503 (server still initializing).
 // ---------------------------------------------------------------------------
 
+/**
+ * Webhook middleware-ordering assertion (R4-7).
+ *
+ * Every `/webhooks/*` route below MUST receive a `Buffer` body (parsed by
+ * express.raw) because HMAC signature verification runs against the exact
+ * bytes on the wire — an already-JSON-parsed object cannot be
+ * re-serialized byte-for-byte (key ordering, whitespace, numeric
+ * representation all diverge). If a future refactor ever places
+ * `app.use(express.json())` BEFORE these routes, the JSON parser would
+ * win, req.body would arrive as an object, and every signature check
+ * would fail closed with a silent 401 — or worse, a handler that doesn't
+ * verify signatures would accept forged payloads.
+ *
+ * This factory produces a per-route guard that asserts Buffer-typed body
+ * at REQUEST time. We don't rely on app-setup-time ordering alone because
+ * Express doesn't expose a stable "middleware inserted before route"
+ * predicate, and re-ordering at module scope is the exact class of
+ * refactor most likely to silently undo the invariant.
+ */
+export function assertWebhookRawBodyOrder(routeName: string): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (!Buffer.isBuffer(req.body)) {
+      console.error(
+        `[${routeName}] middleware ordering bug: express.json ran before express.raw (req.body is ${typeof req.body}); HMAC verification cannot proceed — refusing request`,
+      );
+      res.status(500).json({
+        error: "Webhook middleware misconfigured",
+      });
+      return;
+    }
+    next();
+  };
+}
+
 let webhookHandler: ((req: Request, res: Response) => Promise<void>) | null =
   null;
 let slackWebhookHandler:
@@ -151,6 +190,10 @@ async function refreshBashInstances(
 app.post(
   "/webhooks/github",
   express.raw({ type: "application/json" }),
+  // Runtime guard: assert req.body is a Buffer. If a future refactor moves
+  // express.json() above this route, the guard fires a loud 500 instead of
+  // silently 401-ing every webhook delivery.
+  assertWebhookRawBodyOrder("webhook"),
   async (req: Request, res: Response) => {
     const handler = webhookHandler;
     if (!handler) {
@@ -193,6 +236,7 @@ app.post(
 app.post(
   "/webhooks/slack",
   express.raw({ type: "application/json" }),
+  assertWebhookRawBodyOrder("slack-webhook"),
   async (req: Request, res: Response) => {
     const handler = slackWebhookHandler;
     if (!handler) {
@@ -214,6 +258,7 @@ app.post(
 app.post(
   "/webhooks/discord",
   express.raw({ type: "application/json" }),
+  assertWebhookRawBodyOrder("discord-webhook"),
   async (req: Request, res: Response) => {
     const handler = discordWebhookHandler;
     if (!handler) {
@@ -2329,6 +2374,23 @@ registerAnalyticsRoutes(app);
 // ---------------------------------------------------------------------------
 
 export async function startServer(options?: ServerOptions): Promise<void> {
+  // Top-level try/catch around the entire startup sequence so synchronous
+  // throws from getConfig/getServerConfig AND async failures from
+  // initializeSchema/checkAndIndex carry a uniform '[startup] fatal:' log
+  // prefix before propagating. Without this wrapper, failures escape as
+  // bare rejections: index.ts' .catch prints them, but ops can't grep for
+  // a single stable token to correlate startup-crash incidents across
+  // deployments. Re-throw so callers (src/index.ts and its process.exit
+  // path) keep their existing exit-code contract.
+  try {
+    return await startServerInner(options);
+  } catch (err) {
+    console.error("[startup] fatal:", err);
+    throw err;
+  }
+}
+
+async function startServerInner(options?: ServerOptions): Promise<void> {
   if (options?.configPath) {
     process.env.PATHFINDER_CONFIG = options.configPath;
   }

--- a/src/server.ts
+++ b/src/server.ts
@@ -27,6 +27,7 @@ import {
   hasKnowledgeTools,
   hasCollectTools,
   hasBashSemanticSearch,
+  assertDocumentPeerDepsForSources,
 } from "./config.js";
 import {
   isSlackSourceConfig,
@@ -256,6 +257,43 @@ export function runStartupIndexAndBashRefresh(
     });
 }
 
+/**
+ * R3 #2 — classify why a webhook endpoint has no handler attached.
+ *
+ * Before this helper, all three webhook endpoints returned 503 "Server still
+ * initializing" regardless of whether (a) no sources of that type were
+ * configured (operator error / wrong endpoint) or (b) startup was still
+ * running and the handler hadn't been wired yet. 503 "not configured" is
+ * misleading — the operator would keep retrying against an endpoint that
+ * cannot ever come up. Route the two cases to 404 vs 503 so monitoring /
+ * smoke tests can distinguish them.
+ *
+ * Exported for tests.
+ */
+export function classifyWebhookUnavailable(opts: {
+  sourceType: "github" | "slack" | "discord";
+}): { status: 404 | 503; body: { error: string; sourceType: string } } {
+  const configured = getServerConfig().sources.some(
+    (s) => s.type === opts.sourceType,
+  );
+  if (!configured) {
+    return {
+      status: 404,
+      body: {
+        error: `${opts.sourceType} webhook not configured — no sources of type '${opts.sourceType}' in config`,
+        sourceType: opts.sourceType,
+      },
+    };
+  }
+  return {
+    status: 503,
+    body: {
+      error: "Server still initializing — webhook handler not yet attached",
+      sourceType: opts.sourceType,
+    },
+  };
+}
+
 
 app.post(
   "/webhooks/github",
@@ -267,7 +305,8 @@ app.post(
   async (req: Request, res: Response) => {
     const handler = webhookHandler;
     if (!handler) {
-      res.status(503).json({ error: "Server still initializing" });
+      const classified = classifyWebhookUnavailable({ sourceType: "github" });
+      res.status(classified.status).json(classified.body);
       return;
     }
     try {
@@ -310,7 +349,8 @@ app.post(
   async (req: Request, res: Response) => {
     const handler = slackWebhookHandler;
     if (!handler) {
-      res.status(503).json({ error: "Server still initializing" });
+      const classified = classifyWebhookUnavailable({ sourceType: "slack" });
+      res.status(classified.status).json(classified.body);
       return;
     }
     try {
@@ -332,7 +372,8 @@ app.post(
   async (req: Request, res: Response) => {
     const handler = discordWebhookHandler;
     if (!handler) {
-      res.status(503).json({ error: "Server still initializing" });
+      const classified = classifyWebhookUnavailable({ sourceType: "discord" });
+      res.status(classified.status).json(classified.body);
       return;
     }
     try {
@@ -927,12 +968,19 @@ export function handleSessionInitAccept(opts: {
     // a paranoid guard prevents a throw from crashing the outer handler) we
     // can't write a body, so the caller gets whatever Express does by
     // default (empty response, eventual connection close).
+    // R4-5 — surface a machine-readable `reason` discriminant on the 503
+    // body so operators and clients can tell this failure mode
+    // (workspace_init_failed) apart from the other rollback paths
+    // (state_init_failed, ip_limit_rollback) without parsing the human
+    // message. The discriminant lives on `error.data` per JSON-RPC 2.0 —
+    // clients that already read `error.code`/`error.message` keep working.
     if (res && !res.headersSent) {
       res.status(503).json({
         jsonrpc: "2.0",
         error: {
           code: -32003,
           message: "Server unavailable: failed to initialize session workspace",
+          data: { reason: "workspace_init_failed" },
         },
         id: null,
       });
@@ -1144,9 +1192,14 @@ export async function closeAllSessions(opts: {
     ),
   ]);
 
+  // R3 #12 — track which sids rejected so the summary log can name them.
+  // Per-sid error logs stay for full-stack diagnosis; the summary is what
+  // operators grep for when they just want the count + labels.
+  const streamableRejectedSids: string[] = [];
   streamableResults.forEach((result, i) => {
     const sid = streamableSids[i];
     if (result.status === "rejected") {
+      streamableRejectedSids.push(sid);
       console.error(
         `[shutdown] Streamable-HTTP transport close failed for ${sid.slice(0, 8)}:`,
         result.reason,
@@ -1155,14 +1208,24 @@ export async function closeAllSessions(opts: {
     delete tMap[sid];
   });
   if (streamableSids.length > 0) {
+    if (streamableRejectedSids.length > 0) {
+      // Summary first so a log scanner gate-filtering for "rejected" still
+      // sees the aggregate count. Label list is full-sids truncated to 8
+      // chars to stay parseable.
+      console.error(
+        `[shutdown] Streamable-HTTP close: ${streamableRejectedSids.length} of ${streamableSids.length} rejected — sids: ${streamableRejectedSids.map((s) => s.slice(0, 8)).join(", ")}`,
+      );
+    }
     console.log(
       `[shutdown] Closed ${streamableSids.length} Streamable-HTTP transport${streamableSids.length === 1 ? "" : "s"}`,
     );
   }
 
+  const sseRejectedSids: string[] = [];
   sseResults.forEach((result, i) => {
     const sid = sseSids[i];
     if (result.status === "rejected") {
+      sseRejectedSids.push(sid);
       console.error(
         `[shutdown] SSE transport close failed for ${sid.slice(0, 8)}:`,
         result.reason,
@@ -1171,6 +1234,11 @@ export async function closeAllSessions(opts: {
     delete sseMap[sid];
   });
   if (sseSids.length > 0) {
+    if (sseRejectedSids.length > 0) {
+      console.error(
+        `[shutdown] SSE close: ${sseRejectedSids.length} of ${sseSids.length} rejected — sids: ${sseRejectedSids.map((s) => s.slice(0, 8)).join(", ")}`,
+      );
+    }
     console.log(
       `[shutdown] Closed ${sseSids.length} SSE transport${sseSids.length === 1 ? "" : "s"}`,
     );
@@ -1221,6 +1289,39 @@ export function __setTrustProxyForTesting(
   trustProxy = value;
 }
 
+/**
+ * R4-3 — dispatch an existing-session /mcp request and update its activity
+ * stamp AFTER the transport handler returns successfully. A throw from
+ * handleRequest propagates to the outer catch-all in the /mcp route
+ * WITHOUT bumping sessionLastActivity — so a consistently-failing transport
+ * eventually crosses the TTL threshold and the idle reaper sweeps it
+ * instead of infinitely re-refreshing the stamp on every failed call.
+ *
+ * Exported so tests can assert the success/throw branch of the ordering
+ * contract without standing up Express + a live SDK transport.
+ */
+export async function handleExistingSessionRequest<TReq, TRes>(opts: {
+  sid: string;
+  transport: {
+    handleRequest: (req: TReq, res: TRes, body?: unknown) => Promise<void>;
+  };
+  req: TReq;
+  res: TRes;
+  sessionLastActivity: Record<string, number>;
+  /** Optional clock injection for deterministic tests. */
+  now?: () => number;
+}): Promise<void> {
+  const now = opts.now ?? Date.now;
+  await opts.transport.handleRequest(
+    opts.req,
+    opts.res,
+    (opts.req as unknown as { body?: unknown })?.body,
+  );
+  // Stamp update runs AFTER await returns without throwing — a throw
+  // propagates out before this line executes.
+  opts.sessionLastActivity[opts.sid] = now();
+}
+
 app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
   try {
     const sessionId = req.headers["mcp-session-id"] as string | undefined;
@@ -1228,7 +1329,6 @@ app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
 
     // Existing session — route to its transport
     if (sessionId && transports[sessionId]) {
-      sessionLastActivity[sessionId] = Date.now();
       const method = req.body?.method as string | undefined;
       if (method === "tools/call") {
         const params = req.body?.params as Record<string, unknown> | undefined;
@@ -1258,7 +1358,18 @@ app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
       } else if (method === "tools/list") {
         console.log(`[mcp] tools/list [${ip}]`);
       }
-      await transports[sessionId].handleRequest(req, res, req.body);
+      // R4-3 — update sessionLastActivity AFTER handleRequest returns
+      // successfully, not before. Pre-refresh let a consistently-throwing
+      // transport keep bumping its stamp on every failed request and evade
+      // the idle reaper. Routing through the helper below also makes the
+      // success-vs-throw contract unit-testable without spinning up Express.
+      await handleExistingSessionRequest({
+        sid: sessionId,
+        transport: transports[sessionId],
+        req,
+        res,
+        sessionLastActivity,
+      });
       return;
     }
 
@@ -2757,6 +2868,19 @@ async function startServerInner(options?: ServerOptions): Promise<void> {
       "[startup] trust_proxy=false — X-Forwarded-For ignored; client IP derived from socket (hardened default)",
     );
   }
+
+  // R4-13 — assert document-extraction peer deps (pdf-parse / mammoth) are
+  // present when the config wires document sources with PDF/DOCX file
+  // patterns. Surfacing the missing peer now (instead of at first-file
+  // indexing time hours later) gives operators the install command
+  // alongside the rest of their startup errors.
+  await assertDocumentPeerDepsForSources(
+    serverCfg.sources as ReadonlyArray<{
+      type: string;
+      file_patterns?: string[];
+      [key: string]: unknown;
+    }>,
+  );
 
   // R4-8 — refuse to start in production when analytics is enabled but no
   // stable token is configured. The runtime `getAnalyticsToken()` throw is

--- a/src/server.ts
+++ b/src/server.ts
@@ -187,6 +187,76 @@ async function refreshBashInstances(
   }
 }
 
+/**
+ * Test-only accessor to the live bash registry. Production code should
+ * continue to use the module-local `bashInstances` closure reference.
+ */
+export function __getBashInstancesForTesting(): Map<string, Bash> {
+  return bashInstances;
+}
+
+/**
+ * Test-only reset of the bash registry. Lets tests preload known instances
+ * and assert atomic swap / rollback semantics without spinning up a full
+ * server.
+ */
+export function __setBashInstanceForTesting(name: string, bash: Bash): void {
+  bashInstances.set(name, bash);
+}
+
+export function __clearBashInstancesForTesting(): void {
+  bashInstances.clear();
+}
+
+/**
+ * Startup helper (R3 #5): drive `orchestrator.checkAndIndex()` and, on
+ * success, refresh the bash instances against every configured source. Each
+ * phase has its own `.catch(...)` so failures surface under distinguishable
+ * log prefixes — before this helper existed, both phases logged under
+ * `[startup] Initial index check failed:`, so a bash-refresh failure was
+ * indistinguishable from an indexing failure in the logs.
+ *
+ * Contract:
+ *   - checkAndIndex rejection → log "[startup] Initial index check failed:"
+ *     and skip the refresh (we don't want to drive a refresh against a
+ *     half-indexed DB).
+ *   - checkAndIndex resolves but refreshBashInstances rejects → log
+ *     "[startup] Bash refresh after index check failed:" and keep running.
+ *   - Returns a Promise so tests can await the chain; production callers
+ *     use it fire-and-forget.
+ *
+ * Exported for tests.
+ */
+export function runStartupIndexAndBashRefresh(
+  orchestrator: { checkAndIndex: () => Promise<unknown> },
+  sources: Array<{ name: string }>,
+): Promise<void> {
+  return orchestrator
+    .checkAndIndex()
+    .then(() => {
+      // Always refresh bash instances after startup index check.
+      // The initial bash build runs before repos are cloned, so the
+      // filesystem may be empty. If checkAndIndex skipped reindexing (DB
+      // already current), onReindexComplete won't fire and the bash
+      // filesystem would stay empty without this.
+      const allSourceNames = sources.map((s) => s.name);
+      return refreshBashInstances(allSourceNames, "startup-refresh").catch(
+        (err) => {
+          // Swallow the refresh error so it does NOT propagate to the outer
+          // `.catch` (which would mis-label it as an index-check failure).
+          console.error(
+            "[startup] Bash refresh after index check failed:",
+            err,
+          );
+        },
+      );
+    })
+    .catch((err) => {
+      console.error("[startup] Initial index check failed:", err);
+    });
+}
+
+
 app.post(
   "/webhooks/github",
   express.raw({ type: "application/json" }),
@@ -502,9 +572,20 @@ export function reapIdleSessionsTickForTesting(opts: {
     // Propagate the delete back to the canonical map. The reaper already
     // deleted from the snapshot.
     delete opts.transports[sid];
+
+    // R4-6: per-step cleanup with a per-sid summary log so operators can
+    // distinguish "all three steps ran cleanly" from "some threw" from
+    // "dep wasn't injected". The aggregate log below still fires; this
+    // replaces the earlier silent-success behavior.
+    type StepResult = "ok" | "throw" | "skipped";
+    let stateResult: StepResult = opts.sessionStateManager ? "ok" : "skipped";
+    let ipLimiterResult: StepResult = opts.ipLimiter ? "ok" : "skipped";
+    let workspaceResult: StepResult = opts.workspaceManager ? "ok" : "skipped";
+
     try {
       opts.sessionStateManager?.cleanup(sid);
     } catch (e) {
+      stateResult = "throw";
       console.error(
         `[mcp] Session state cleanup failed for ${sid.slice(0, 8)}:`,
         e,
@@ -513,16 +594,21 @@ export function reapIdleSessionsTickForTesting(opts: {
     try {
       opts.ipLimiter?.remove(sid);
     } catch (e) {
+      ipLimiterResult = "throw";
       console.error(`[mcp] IP limiter cleanup failed:`, e);
     }
     try {
       opts.workspaceManager?.cleanup(sid);
     } catch (e) {
+      workspaceResult = "throw";
       console.error(
         `[mcp] Workspace cleanup failed for ${sid.slice(0, 8)}:`,
         e,
       );
     }
+    console.log(
+      `[mcp] Reap cleanup sid=${sid.slice(0, 8)} state=${stateResult} ipLimiter=${ipLimiterResult} workspace=${workspaceResult}`,
+    );
   }
   if (reapedStreamable.length > 0) {
     console.log(
@@ -859,6 +945,120 @@ export function handleSessionInitAccept(opts: {
 }
 
 /**
+ * Rollback helper for the `server.connect(transport)` /
+ * `completeInitRequestSafely` path in the /mcp POST initialize handler.
+ *
+ * Motivation (Z-1): after handleSessionInitAccept succeeds the handler has
+ * already:
+ *   - registered transports[preSid] + sessionLastActivity[preSid]
+ *   - incremented the ipLimiter counter (tryAdd succeeded pre-accept)
+ *   - ensureSession'd the workspace
+ *   - wired transport.onclose to cleanup
+ * It then calls `server.connect(transport)` followed by handleRequest via
+ * completeInitRequestSafely. If EITHER throws (createMcpServer wiring bug,
+ * bash-instance lookup failure, OOM during construction, closed-stream mid-
+ * handleRequest without an onsessioninitialized race), NOTHING calls
+ * transport.close() — so onclose never fires — and the session is stranded
+ * against max_sessions_per_ip until the 30-minute TTL reaper cleans it.
+ *
+ * Design invariant: cleanup runs EXACTLY ONCE for this sid.
+ *
+ * The obvious "seed rejectedSids then close()" approach is unsound when the
+ * onclose handler IS wired (our case): close() fires onclose, onclose reads
+ * rejectedSids.has(sid), drains the marker, then runs the suppression branch
+ * — but only if the marker is still present when onclose runs. If we drain
+ * inline to keep the Set bounded regardless of whether onclose fires, the
+ * later-firing onclose sees an empty Set and runs the cleanup chain a second
+ * time. We avoid both horns by DETACHING transport.onclose before calling
+ * close(). The inline rollback below is the sole owner of the cleanup chain;
+ * any onclose invocation from the SDK lands on our neutralized handler and
+ * is a no-op.
+ *
+ * Per-step try/catch on each cleanup mirrors the onclose + reaper +
+ * handleSessionInitAccept rollback pattern: a throw from one step must not
+ * skip the others. ipLimiter.remove in particular is load-bearing — a
+ * rollback that bails before ipLimiter.remove leaks the counter against
+ * this IP until TTL reap, which is the exact failure mode this helper
+ * exists to prevent.
+ *
+ * Caller (the /mcp POST handler) wraps server.connect + handleRequest in a
+ * try/catch, invokes this helper, then rethrows so the outer catch-all
+ * writes the 500 body (preserving the pre-existing response behavior).
+ *
+ * Exported for tests.
+ */
+export function rollbackSessionAfterConnectFailure(opts: {
+  transport: {
+    close: () => Promise<void> | void;
+    onclose?: (() => void) | null;
+  };
+  sid: string;
+  transports: Record<string, unknown>;
+  sessionLastActivity: Record<string, number>;
+  ipLimiter?: { remove: (sid: string) => void };
+  sessionStateManager?: { cleanup: (sid: string) => void };
+  workspaceManager?: { cleanup: (sid: string) => void };
+}): void {
+  const {
+    transport,
+    sid,
+    transports: tMap,
+    sessionLastActivity: lastActivityMap,
+    ipLimiter: limiter,
+    sessionStateManager: sessionState,
+    workspaceManager: workspace,
+  } = opts;
+
+  // Detach the wired onclose handler BEFORE we fire close(). The MCP SDK may
+  // invoke onclose as part of stream teardown; replacing it with a no-op
+  // (rather than deleting) keeps the property shape predictable for any
+  // other SDK introspection and ensures a single cleanup run — ours, inline,
+  // below — regardless of whether the SDK fires the listener.
+  transport.onclose = () => {
+    /* neutralized by rollbackSessionAfterConnectFailure */
+  };
+
+  delete tMap[sid];
+  delete lastActivityMap[sid];
+
+  try {
+    limiter?.remove(sid);
+  } catch (e) {
+    console.error(
+      `[mcp] ipLimiter rollback after connect-throw failed for ${sid.slice(0, 8)}:`,
+      e,
+    );
+  }
+  try {
+    sessionState?.cleanup(sid);
+  } catch (e) {
+    console.error(
+      `[mcp] sessionStateManager rollback after connect-throw failed for ${sid.slice(0, 8)}:`,
+      e,
+    );
+  }
+  try {
+    workspace?.cleanup(sid);
+  } catch (e) {
+    console.error(
+      `[mcp] workspaceManager rollback after connect-throw failed for ${sid.slice(0, 8)}:`,
+      e,
+    );
+  }
+
+  // Fire-and-forget close so async rejections land in console.error rather
+  // than unhandledRejection. Matches handleSessionInitAccept's pattern.
+  Promise.resolve()
+    .then(() => transport.close())
+    .catch((closeErr) => {
+      console.error(
+        `[mcp] transport.close after server.connect/handleRequest throw failed for ${sid.slice(0, 8)}:`,
+        closeErr,
+      );
+    });
+}
+
+/**
  * Drive `transport.handleRequest(req, res, body)` with defensive handling
  * for the onsessioninitialized-race case. `onsessioninitialized` fires
  * INSIDE `handleRequest`, so when the defensive race-fallback inside that
@@ -925,11 +1125,24 @@ export async function closeAllSessions(opts: {
   const { transports: tMap, sseTransports: sseMap } = opts;
 
   const streamableSids = Object.keys(tMap);
-  const streamableResults = await Promise.allSettled(
-    streamableSids.map((sid) =>
-      Promise.resolve().then(() => tMap[sid].close()),
+  const sseSids = Object.keys(sseMap);
+
+  // R3 #11: run the two close batches in parallel rather than sequentially.
+  // Shutdown latency upper bound becomes max(streamableClose, sseClose)
+  // instead of their sum, which matters when the orchestrator's kill-
+  // deadline is tight and both maps are non-trivial. allSettled semantics
+  // still isolate a single slow/rejecting close from the rest.
+  const [streamableResults, sseResults] = await Promise.all([
+    Promise.allSettled(
+      streamableSids.map((sid) =>
+        Promise.resolve().then(() => tMap[sid].close()),
+      ),
     ),
-  );
+    Promise.allSettled(
+      sseSids.map((sid) => Promise.resolve().then(() => sseMap[sid].close())),
+    ),
+  ]);
+
   streamableResults.forEach((result, i) => {
     const sid = streamableSids[i];
     if (result.status === "rejected") {
@@ -946,10 +1159,6 @@ export async function closeAllSessions(opts: {
     );
   }
 
-  const sseSids = Object.keys(sseMap);
-  const sseResults = await Promise.allSettled(
-    sseSids.map((sid) => Promise.resolve().then(() => sseMap[sid].close())),
-  );
   sseResults.forEach((result, i) => {
     const sid = sseSids[i];
     if (result.status === "rejected") {
@@ -1264,20 +1473,42 @@ app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
         bashTelemetry,
         workspaceManager,
       );
-      await server.connect(transport);
-      // completeInitRequestSafely swallows throws from handleRequest when
-      // onsessioninitialized's defensive race-fallback closed the transport
-      // mid-flight (initOutcome.rejected=true). The fallback already handled
-      // the response lifecycle; a naked await here would bubble the closed-
-      // transport throw into the outer catch-all and produce a 500 write on
-      // top of the 429 the fallback already streamed.
-      await completeInitRequestSafely(
-        transport,
-        req,
-        res,
-        req.body,
-        initOutcome,
-      );
+      // Z-1: server.connect(transport) can throw AFTER handleSessionInitAccept
+      // committed maps + ipLimiter counter + ensureSession + onclose wiring.
+      // Without an explicit rollback, the session is stranded against
+      // max_sessions_per_ip until TTL reap because nothing calls
+      // transport.close(), so onclose never fires. Wrap BOTH server.connect
+      // and completeInitRequestSafely so the rollback chain runs regardless
+      // of where the throw originates (connect wiring bug OR handleRequest
+      // mid-flight throw that completeInitRequestSafely rethrows). Rethrow
+      // into the outer catch-all so the 500 response behavior is preserved.
+      try {
+        await server.connect(transport);
+        // completeInitRequestSafely swallows throws from handleRequest when
+        // onsessioninitialized's defensive race-fallback closed the transport
+        // mid-flight (initOutcome.rejected=true). The fallback already handled
+        // the response lifecycle; a naked await here would bubble the closed-
+        // transport throw into the outer catch-all and produce a 500 write on
+        // top of the 429 the fallback already streamed.
+        await completeInitRequestSafely(
+          transport,
+          req,
+          res,
+          req.body,
+          initOutcome,
+        );
+      } catch (connectErr) {
+        rollbackSessionAfterConnectFailure({
+          transport,
+          sid: preSid,
+          transports,
+          sessionLastActivity,
+          ipLimiter,
+          sessionStateManager,
+          workspaceManager,
+        });
+        throw connectErr;
+      }
       return;
     }
 
@@ -2364,10 +2595,13 @@ export function registerAnalyticsRoutes(
   });
 }
 
-// Wire the analytics routes onto the top-level app at import time so the
-// production server exposes them on listen(). Tests that want to mount the
-// real handlers can call registerAnalyticsRoutes() on their own app.
-registerAnalyticsRoutes(app);
+// R4-19: single surface — `registerAnalyticsRoutes` is the canonical way to
+// mount the analytics routes. Production wires it up inside startServer()
+// before app.listen(); tests that want the real handlers call it on their
+// own app. Do NOT add a module-load-time side-effect call here: that created
+// a second surface that (a) confused readers about which was canonical and
+// (b) coupled mere module import (e.g. an unrelated re-export in a test
+// fixture) to mutating the module-level app.
 
 // ---------------------------------------------------------------------------
 // Startup
@@ -2437,6 +2671,14 @@ async function startServerInner(options?: ServerOptions): Promise<void> {
         "[startup] trust_proxy=true + NODE_ENV=development is unsupported — analytics dev bypass is DISABLED to prevent exposing the dashboard via a fronting proxy",
       );
     }
+  } else {
+    // R3 #18: give operators a positive confirmation that the hardened
+    // default is in effect. Without this, an operator who enabled
+    // trust_proxy expecting it to take effect had to grep for the absence
+    // of the truthy log above to infer the state — fragile.
+    console.log(
+      "[startup] trust_proxy=false — X-Forwarded-For ignored; client IP derived from socket (hardened default)",
+    );
   }
 
   // Configure session TTL and IP rate limiter from config
@@ -2560,25 +2802,21 @@ async function startServerInner(options?: ServerOptions): Promise<void> {
       });
     };
 
-    orchestrator
-      .checkAndIndex()
-      .then(() => {
-        // Always refresh bash instances after startup index check.
-        // The initial bash build (above) runs before repos are cloned,
-        // so the filesystem may be empty. If checkAndIndex skipped
-        // reindexing (DB already current), onReindexComplete won't fire
-        // and the bash filesystem would stay empty without this.
-        const allSourceNames = serverCfg.sources.map((s) => s.name);
-        return refreshBashInstances(allSourceNames, "startup-refresh");
-      })
-      .catch((err) => {
-        console.error("[startup] Initial index check failed:", err);
-      });
+    // R3 #5: use two distinct catches so an index-check failure and a
+    // bash-refresh failure surface under distinguishable log prefixes.
+    // Previously the combined `.then(refresh).catch(...)` mis-labeled
+    // refresh failures as "[startup] Initial index check failed:" — an
+    // operator reading logs couldn't tell which operation actually broke.
+    runStartupIndexAndBashRefresh(orchestrator, serverCfg.sources);
 
     orchestrator.startNightlyReindex();
   } else {
     console.log("[startup] No search tools configured — skipping indexing");
   }
+
+  // R4-19: explicit mount — the module-load side-effect was removed so this
+  // is now the single call site for the production app.
+  registerAnalyticsRoutes(app);
 
   const serverName = serverCfg.server.name;
   const server = app.listen(port, () => {

--- a/src/server.ts
+++ b/src/server.ts
@@ -122,16 +122,60 @@ app.use((_req, res, next) => {
  */
 export function assertWebhookRawBodyOrder(routeName: string): RequestHandler {
   return (req: Request, res: Response, next: NextFunction) => {
-    if (!Buffer.isBuffer(req.body)) {
-      console.error(
-        `[${routeName}] middleware ordering bug: express.json ran before express.raw (req.body is ${typeof req.body}); HMAC verification cannot proceed — refusing request`,
-      );
-      res.status(500).json({
-        error: "Webhook middleware misconfigured",
+    if (Buffer.isBuffer(req.body)) {
+      // Happy path: express.raw parsed the request into a Buffer. HMAC
+      // verification downstream can proceed against the exact wire bytes.
+      next();
+      return;
+    }
+
+    // At this point req.body is NOT a Buffer. Two distinct causes need to be
+    // distinguished, because only ONE of them is a server misconfiguration:
+    //
+    //   (a) express.raw was mounted with `type: "application/json"` but the
+    //       client sent a different Content-Type (e.g. "text/plain"). In that
+    //       case express.raw deliberately SKIPS parsing, and Express leaves
+    //       req.body as the default `{}`. The middleware chain itself is
+    //       wired correctly; the request is simply malformed from the client
+    //       side. Reject with 415 and stay quiet in the log.
+    //
+    //   (b) An earlier body parser (express.json, urlencoded, text) already
+    //       consumed the body, so req.body arrives as a parsed object /
+    //       string BEFORE express.raw got a chance. This is the ordering-bug
+    //       case the guard was built for — fire the loud 500 so the bug
+    //       surfaces in logs and CI.
+    //
+    // Discriminant: when express.raw is configured with a specific type and
+    // the incoming Content-Type doesn't match, express.raw deliberately
+    // does NOT populate req.body at all — it remains `undefined`. A body
+    // parser that DID run (correctly or incorrectly) leaves req.body as
+    // a Buffer / object / string / array — anything but `undefined`.
+    const body = req.body as unknown;
+    const contentType = String(req.headers["content-type"] ?? "");
+    const looksLikeJsonContentType = contentType
+      .toLowerCase()
+      .includes("application/json");
+
+    if (body === undefined && !looksLikeJsonContentType) {
+      // Case (a): client sent a non-JSON Content-Type. express.raw correctly
+      // declined to parse, and no earlier parser intervened. The middleware
+      // chain is healthy; the request is just wrong. Return 415 without
+      // logging — a noisy log here would spam on every misconfigured client.
+      res.status(415).json({
+        error: "Unsupported Content-Type for webhook endpoint",
       });
       return;
     }
-    next();
+
+    // Case (b): req.body is a parsed object/string/array/etc. An earlier
+    // body parser ran before express.raw — the exact ordering bug this
+    // guard exists to catch. Log loudly and refuse.
+    console.error(
+      `[${routeName}] middleware ordering bug: express.json ran before express.raw (req.body is ${typeof req.body}); HMAC verification cannot proceed — refusing request`,
+    );
+    res.status(500).json({
+      error: "Webhook middleware misconfigured",
+    });
   };
 }
 
@@ -158,7 +202,24 @@ let telemetryFlushInterval: ReturnType<typeof setInterval> | undefined;
 // scheduling, remove them on fire, and clear the entire set on shutdown.
 const pendingBashRefreshTimers = new Set<ReturnType<typeof setTimeout>>();
 
-async function refreshBashInstances(
+/**
+ * Rebuild bash instances for tools affected by the given sources.
+ *
+ * All-or-nothing semantics: every affected tool is rebuilt into a temporary
+ * Map. Only after every rebuild succeeds does the temp map get merged into
+ * the live `bashInstances` registry. If any single rebuild throws, the live
+ * registry is left untouched (callers keep serving the previous, consistent
+ * index for every tool) and the first error propagates to the caller.
+ *
+ * Rationale: the previous loop mutated `bashInstances` per-tool, so a mid-
+ * iteration failure (network, git clone, ENOSPC, embedding error) left the
+ * map in a mixed stale/fresh state — `bash_explore` / sibling tools would
+ * return inconsistent file sets depending on which tool name was invoked.
+ * Callers already `.catch(...)` and log; throwing the first error (rather
+ * than returning a per-tool summary) keeps the API tiny while still letting
+ * those callers surface failures in logs.
+ */
+export async function refreshBashInstances(
   sourceNames: string[],
   logPrefix = "webhook",
 ): Promise<void> {
@@ -168,6 +229,8 @@ async function refreshBashInstances(
     .filter((t) => t.type === "search")
     .map((t) => t.name);
 
+  const pending = new Map<string, { bash: Bash; fileCount: number }>();
+
   for (const tool of bashTools) {
     const affected = tool.sources.some((s) => sourceNames.includes(s));
     if (!affected) continue;
@@ -176,14 +239,32 @@ async function refreshBashInstances(
       tool.sources.includes(s.name),
     );
     const virtualFiles = tool.bash?.virtual_files === true;
-    const { bash, fileCount } = await rebuildBashInstance(toolSources, {
-      virtualFiles,
-      searchToolNames: virtualFiles ? searchToolNames : undefined,
-      cloneDir: getConfig().cloneDir,
-    });
-    bashInstances.set(tool.name, bash);
+    try {
+      const { bash, fileCount } = await rebuildBashInstance(toolSources, {
+        virtualFiles,
+        searchToolNames: virtualFiles ? searchToolNames : undefined,
+        cloneDir: getConfig().cloneDir,
+      });
+      pending.set(tool.name, { bash, fileCount });
+    } catch (err) {
+      // Leave `bashInstances` untouched so every tool keeps serving its
+      // previous (consistent) filesystem. Log which tool + trigger failed
+      // so the caller's `.catch(...)` / monitors can identify the source.
+      console.error(
+        `[${logPrefix}] Bash refresh failed for tool "${tool.name}" ` +
+          `(triggered by sources: ${sourceNames.join(", ")}): `,
+        err,
+      );
+      throw err;
+    }
+  }
+
+  // Every rebuild succeeded — atomically publish the new instances.
+  // Unaffected tools keep their existing entries in `bashInstances`.
+  for (const [name, { bash, fileCount }] of pending) {
+    bashInstances.set(name, bash);
     console.log(
-      `[${logPrefix}] Refreshed bash tool "${tool.name}": ${fileCount} files`,
+      `[${logPrefix}] Refreshed bash tool "${name}": ${fileCount} files`,
     );
   }
 }
@@ -230,6 +311,16 @@ export function __setBashInstanceForTesting(name: string, bash: Bash): void {
 
 export function __clearBashInstancesForTesting(): void {
   bashInstances.clear();
+}
+
+/**
+ * Test-only accessor to the rejected-sid marker Set so
+ * `rollbackSessionAfterConnectFailure` regression tests can assert the
+ * prior onclose handler observes `rejectedSids.has(sid) === true` during
+ * its invocation.
+ */
+export function __rejectedSidsForTesting(): Set<string> {
+  return rejectedSids;
 }
 
 /**
@@ -316,7 +407,6 @@ export function classifyWebhookUnavailable(opts: {
     },
   };
 }
-
 
 app.post(
   "/webhooks/github",
@@ -1082,12 +1172,43 @@ export function rollbackSessionAfterConnectFailure(opts: {
   } = opts;
 
   // Detach the wired onclose handler BEFORE we fire close(). The MCP SDK may
-  // invoke onclose as part of stream teardown; replacing it with a no-op
-  // (rather than deleting) keeps the property shape predictable for any
-  // other SDK introspection and ensures a single cleanup run — ours, inline,
-  // below — regardless of whether the SDK fires the listener.
+  // invoke onclose as part of stream teardown; replacing it with a wrapper
+  // (rather than a no-op) preserves any prior onclose the SDK or surrounding
+  // code had attached for its OWN bookkeeping, while suppressing OUR cleanup
+  // branch so the inline rollback below remains the single cleanup run.
+  //
+  // Saving `priorOnclose` matters because the MCP SDK wires internal state
+  // teardown on its StreamableHTTPServerTransport.onclose at construction;
+  // blindly clobbering with `() => {}` would leak SDK-internal listeners
+  // (request-queue drain, in-flight response rejection) and mask those
+  // failures from the runtime. The wrapper invokes it in a try/catch so a
+  // prior-handler throw never reaches this rollback's own per-step errors.
+  const priorOnclose = transport.onclose ?? null;
+  // Seed the rejected-sid marker BEFORE wiring the wrapper so that when the
+  // prior handler (the cleanup-running onclose from handleSessionInitAccept,
+  // or any other application-level listener gated on rejectedSids) executes,
+  // it self-detects the rollback-in-progress case and skips its own cleanup
+  // chain. Its SDK-internal bookkeeping (request-queue drain, in-flight
+  // response rejection) still runs — only the application cleanup short-
+  // circuits. The inline rollback below then drains the marker by running
+  // exactly once.
+  rejectedSids.add(sid);
   transport.onclose = () => {
-    /* neutralized by rollbackSessionAfterConnectFailure */
+    // Our application cleanup branch is guarded by rejectedSids.has(sid) on
+    // the prior handler side; because we seeded the marker, the prior
+    // handler's application cleanup is a no-op. Forward the invocation so
+    // any SDK-internal onclose wiring (stream teardown listeners, request-
+    // queue drain) still fires.
+    if (priorOnclose) {
+      try {
+        priorOnclose();
+      } catch (e) {
+        console.error(
+          `[mcp] prior transport.onclose threw during rollback for ${sid.slice(0, 8)}:`,
+          e,
+        );
+      }
+    }
   };
 
   delete tMap[sid];
@@ -1127,6 +1248,12 @@ export function rollbackSessionAfterConnectFailure(opts: {
         `[mcp] transport.close after server.connect/handleRequest throw failed for ${sid.slice(0, 8)}:`,
         closeErr,
       );
+    })
+    .finally(() => {
+      // Drain the rejected-sid marker once the close() settles, regardless
+      // of whether the prior onclose fired and drained it already
+      // (rejectedSids.delete is idempotent). Keeps the Set bounded.
+      rejectedSids.delete(sid);
     });
 }
 
@@ -2156,13 +2283,14 @@ function isLocalhostReq(req: Request): boolean {
     // IPv6 loopback is exactly ::1.
     return (parsed as ipaddr.IPv6).toNormalizedString() === "0:0:0:0:0:0:0:1";
   } catch (err) {
-    // R3 #14 — emit a debug-level log so an operator bisecting why
-    // the analytics dev-bypass stopped working can see that the parse
-    // itself failed. Debug-level so we don't spam normal logs, but
-    // operators with debug enabled get the address + error message.
-    // Return contract is unchanged — unparseable addresses still
-    // resolve to "not localhost" (fail-closed).
-    console.debug(
+    // R3 #14 — emit a warn-level log so an operator bisecting why the
+    // analytics dev-bypass stopped working can see that the parse itself
+    // failed. This path only fires on malformed TCP peer addresses, which
+    // in practice is very rare — so warn-level isn't spammy, and it's
+    // visible in production log aggregators that filter out debug. Return
+    // contract is unchanged — unparseable addresses still resolve to
+    // "not localhost" (fail-closed).
+    console.warn(
       `[isLocalhostReq] ipaddr.parse failed for addr=${addr}: ${formatErrorForLog(err)}`,
     );
     return false;
@@ -2834,9 +2962,13 @@ export function registerAnalyticsRoutes(
         `[analytics] sendFile failed path=${_analyticsHtmlPath} cid=${correlationId}:`,
         err,
       );
+      // Emit snake_case `correlation_id` in the response body to match the
+      // convention analyticsAuth already uses for OAuth-style
+      // `error_description` (RFC 6749 snake_case). Internal variable stays
+      // camelCase per JS convention; only the wire format standardizes.
       res.status(500).json({
         error: "analytics dashboard unavailable",
-        correlationId,
+        correlation_id: correlationId,
       });
     });
   });
@@ -2928,9 +3060,23 @@ async function startServerInner(options?: ServerOptions): Promise<void> {
     // default is in effect. Without this, an operator who enabled
     // trust_proxy expecting it to take effect had to grep for the absence
     // of the truthy log above to infer the state — fragile.
-    console.log(
-      "[startup] trust_proxy=false — X-Forwarded-For ignored; client IP derived from socket (hardened default)",
-    );
+    //
+    // Non-production warning (test/staging/unset all count): emit the
+    // reminder as a WARN so dev/staging operators running locally or in
+    // preview environments surface the hardening in console output, where
+    // they're most likely to be surprised by XFF being ignored (e.g. when
+    // spoofing a client IP for local testing). In production we stay at
+    // INFO level so the ops log isn't noised up with a steady-state
+    // confirmation on every boot.
+    if (cfg.nodeEnv === "production") {
+      console.log(
+        "[startup] trust_proxy=false — X-Forwarded-For ignored; client IP derived from socket (hardened default)",
+      );
+    } else {
+      console.warn(
+        `[startup] trust_proxy=false (NODE_ENV=${cfg.nodeEnv ?? "<unset>"}) — X-Forwarded-For ignored; client IP derived from socket (hardened default). Set trust_proxy in pathfinder.yaml when running behind a reverse proxy.`,
+      );
+    }
   }
 
   // R4-13 — assert document-extraction peer deps (pdf-parse / mammoth) are

--- a/src/sse-handlers.ts
+++ b/src/sse-handlers.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, RequestHandler } from "express";
+import { randomUUID } from "node:crypto";
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { bearerMiddleware } from "./oauth/handlers.js";
@@ -373,9 +374,17 @@ export function createSseHandlers(deps: SseHandlerDeps): {
         `[mcp] New SSE session ${sessionId.slice(0, 8)} (${Object.keys(sseTransports).length} active) [${ip}]`,
       );
     } catch (err) {
-      console.error("[mcp] SSE connection error:", err);
+      // R3 #9 — emit a correlation ID in BOTH the log line and the
+      // response body so operators who get a user report ("SSE session
+      // failed") can grep the ID from the user and land on the exact
+      // failing stack. Short-form ID keeps it operator-readable.
+      const correlationId = randomUUID().replace(/-/g, "").slice(0, 12);
+      console.error(`[mcp] SSE connection error cid=${correlationId}:`, err);
       if (!res.headersSent) {
-        res.status(500).json({ error: "Failed to establish SSE session" });
+        res.status(500).json({
+          error: "Failed to establish SSE session",
+          correlationId,
+        });
       }
     }
   };
@@ -418,8 +427,15 @@ export function createSseHandlers(deps: SseHandlerDeps): {
       await transport.handlePostMessage(req, res, req.body);
       sessionLastActivity[sessionId] = Date.now();
     } catch (err) {
+      // R3 #10 — include client IP so this log line matches the
+      // info-density of the sibling 404 branches (missing-session-id /
+      // unknown-session-id). Operators debugging a broken client now
+      // have `ip` + `sid` on every failure path, not just the
+      // not-found paths.
+      const trustProxy = resolve(deps.trustProxy ?? false) ?? false;
+      const ip = clientIp(req, trustProxy);
       console.error(
-        `[mcp] SSE handlePostMessage failed for session ${sessionId.slice(0, 8)}:`,
+        `[mcp] SSE handlePostMessage failed for session ${sessionId.slice(0, 8)} ip=${ip}:`,
         err,
       );
       if (!res.headersSent) {

--- a/src/sse-handlers.ts
+++ b/src/sse-handlers.ts
@@ -348,17 +348,26 @@ export function createSseHandlers(deps: SseHandlerDeps): {
             ),
           );
         if (!res.headersSent) {
-          // R4-5 — `reason` is now a machine-readable discriminant
-          // (workspace_init_failed) rather than a human sentence, so
-          // monitoring + client code can tell this rollback apart from
-          // state_init_failed / ip_limit_rollback. The human-facing hint
-          // moves to `message`. The full error object is already logged
-          // above via console.error(..., ensureErr).
+          // R4-5 — emit a machine-readable `reason` discriminant
+          // (workspace_init_failed) so monitoring + client code can tell
+          // this rollback apart from state_init_failed / ip_limit_rollback
+          // without parsing the human message. The discriminant is nested
+          // under `error.data` to match the /mcp (JSON-RPC) rollback body
+          // shape — clients read `body.error.data.reason` on BOTH transports.
+          //
+          // The outer envelope stays SSE-flavored (`error`/`message` at top
+          // level rather than the full JSON-RPC wrapper) because a pure
+          // JSON-RPC body on the GET /sse handshake would surprise existing
+          // clients that never expected it there. We only standardize the
+          // INNER discriminant placement; the outer shape remains transport-
+          // appropriate.
           res.status(503).json({
-            error: "workspace_unavailable",
-            reason: "workspace_init_failed",
-            message:
-              "Failed to initialize session workspace. Please try again.",
+            error: {
+              code: "workspace_unavailable",
+              message:
+                "Failed to initialize session workspace. Please try again.",
+              data: { reason: "workspace_init_failed" },
+            },
           });
         }
         return;
@@ -381,9 +390,13 @@ export function createSseHandlers(deps: SseHandlerDeps): {
       const correlationId = randomUUID().replace(/-/g, "").slice(0, 12);
       console.error(`[mcp] SSE connection error cid=${correlationId}:`, err);
       if (!res.headersSent) {
+        // Emit snake_case `correlation_id` in the response body to match the
+        // convention analyticsAuth already uses for OAuth-style
+        // `error_description` (RFC 6749 snake_case). Internal variable stays
+        // camelCase per JS convention; only the wire format standardizes.
         res.status(500).json({
           error: "Failed to establish SSE session",
-          correlationId,
+          correlation_id: correlationId,
         });
       }
     }

--- a/src/sse-handlers.ts
+++ b/src/sse-handlers.ts
@@ -347,9 +347,17 @@ export function createSseHandlers(deps: SseHandlerDeps): {
             ),
           );
         if (!res.headersSent) {
+          // R4-5 — `reason` is now a machine-readable discriminant
+          // (workspace_init_failed) rather than a human sentence, so
+          // monitoring + client code can tell this rollback apart from
+          // state_init_failed / ip_limit_rollback. The human-facing hint
+          // moves to `message`. The full error object is already logged
+          // above via console.error(..., ensureErr).
           res.status(503).json({
             error: "workspace_unavailable",
-            reason: "Failed to initialize session workspace. Please try again.",
+            reason: "workspace_init_failed",
+            message:
+              "Failed to initialize session workspace. Please try again.",
           });
         }
         return;
@@ -401,9 +409,14 @@ export function createSseHandlers(deps: SseHandlerDeps): {
       });
       return;
     }
-    sessionLastActivity[sessionId] = Date.now();
+    // R4-3 — do NOT bump sessionLastActivity BEFORE handlePostMessage. A
+    // consistently-throwing transport would otherwise keep refreshing its
+    // idle-reaper stamp on every failed call and never time out. The stamp
+    // is updated inside the try block AFTER a successful await, so a throw
+    // propagates to the catch below without updating it.
     try {
       await transport.handlePostMessage(req, res, req.body);
+      sessionLastActivity[sessionId] = Date.now();
     } catch (err) {
       console.error(
         `[mcp] SSE handlePostMessage failed for session ${sessionId.slice(0, 8)}:`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -318,13 +318,34 @@ export const ServerConfigSchema = z
       // the TCP peer address (`req.socket.remoteAddress`) is used for rate
       // limiting, allowlist checks, tracing, and analytics.
       //
-      // SECURITY: Only enable `trust_proxy: true` when this server runs
-      // behind a reverse proxy that strips or rewrites incoming
-      // `X-Forwarded-For` headers. Enabling it on a server directly exposed
-      // to the public internet lets any client spoof their source IP by
-      // sending an `X-Forwarded-For` header — which would let them claim
-      // to be an allowlisted IP and bypass the per-IP session limiter.
-      trust_proxy: z.boolean().optional().default(false),
+      // SECURITY: Only enable `trust_proxy` when this server runs behind a
+      // reverse proxy that strips or rewrites incoming `X-Forwarded-For`
+      // headers. Enabling it on a server directly exposed to the public
+      // internet lets any client spoof their source IP by sending an
+      // `X-Forwarded-For` header — which would let them claim to be an
+      // allowlisted IP and bypass the per-IP session limiter.
+      //
+      // Accepted shapes (all passed through verbatim to
+      // `app.set("trust proxy", …)` — see Express docs for semantics:
+      // https://expressjs.com/en/guide/behind-proxies.html):
+      //   boolean  — `true` trusts EVERY proxy on the XFF chain (only safe
+      //              when the ingress strips/rewrites incoming XFF).
+      //              `false` (default) ignores XFF entirely.
+      //   number   — hop count; Express trusts the last N hops on the chain.
+      //              Use when the ingress topology is a fixed number of
+      //              proxies deep and you want to pin it.
+      //   string[] — list of trusted proxy IPs/CIDRs (e.g.
+      //              ["10.0.0.0/8", "192.168.0.0/16"]); Express walks the
+      //              XFF chain, trusting only hops matching the list.
+      //              Prefer this when your ingress isn't a single point.
+      trust_proxy: z
+        .union([
+          z.boolean(),
+          z.number().int().nonnegative(),
+          z.array(z.string().min(1)).min(1),
+        ])
+        .optional()
+        .default(false),
     }),
     sources: z.array(SourceConfigSchema).min(1),
     tools: z.array(AnyToolConfigSchema).min(1),


### PR DESCRIPTION
## Summary

Consolidates ~40 drift items flagged during PR #42's CR rounds into a single hygiene pass. Covers observability/logging improvements, session lifecycle correctness on /mcp and /sse, startup-failure framing, configuration schema widening, webhook middleware safety, and test hardening.

## Notable changes

- `refreshBashInstances` now atomic (all-or-nothing via temp map) so a mid-iteration failure leaves bash tools in their prior state.
- New `rollbackSessionAfterConnectFailure` handles `server.connect` throws symmetrically with `handleSessionInitAccept`'s ensureSession-rollback.
- Webhook middleware ordering guard (`assertWebhookRawBodyOrder`) distinguishes Buffer-body from parsed-object from content-type-skipped so drift doesn't silently break signature verification.
- `startServer` wrapped with `[startup] fatal:` prefix; `server.on(\"error\")` routes through graceful shutdown instead of inline process.exit.
- `trust_proxy` schema widened to \`boolean | number | string[]\` per Express's native semantics.
- \`/faq.txt\` no longer caches partial results on per-source failure; emits \`X-Partial-Sources\` header.
- Session activity stamps now refresh after successful handler completion (not before) so poisoned sessions don't evade the idle reaper.
- \`closeAllSessions\` closes Streamable-HTTP and SSE in parallel; emits per-transport rejection counts in shutdown summary.
- Analytics startup guard fails loudly in production when the token isn't resolvable; \`analyticsAuth\` length-checks before \`timingSafeEqual\`.
- Document-source peer-deps (\`pdf-parse\`, \`mammoth\`) declared in \`peerDependenciesMeta\`; loader distinguishes MODULE_NOT_FOUND from other import errors.
- Correlation IDs on 500 bodies served by \`/analytics\` sendFile and SSE outer catch (snake_case \`correlation_id\` for wire consistency with existing OAuth-style fields).
- Numerous error-log improvements: client IP context, stack preservation, webhook 404 vs 503 distinction.

## Test plan

- [x] \`npm test\` — all pass
- [x] \`npx tsc --noEmit\` — clean
- [x] \`npm run build\` — clean
- [x] \`npx prettier --check \"src/**/*.ts\"\` — clean
- [x] CI green