### PR TITLE
Analytics time-window correctness: gap-fill, URL persistence, and data-availability label

### DIFF
--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -724,23 +724,35 @@
       var draftFromInput = null;
       var draftToInput = null;
 
-      // Intl formatters (cached)
+      // Intl formatters (cached). timeZone: "UTC" keeps the pill label
+      // frame-aligned with parseISODate (UTC-noon) and todayISO (UTC) so
+      // the pill doesn't render a different calendar day for users east
+      // or west of UTC than the URL / server computations see.
       var shortDateFmt = new Intl.DateTimeFormat(undefined, {
         month: "short",
         day: "numeric",
+        timeZone: "UTC",
       });
 
       function parseISODate(s) {
-        // Parse YYYY-MM-DD as a local-noon Date so DST/TZ doesn't shift the day label.
+        // Parse YYYY-MM-DD as a UTC-noon Date. UTC (not local) so the
+        // resulting Date is frame-aligned with todayISO() — both use UTC
+        // accessors downstream. A local-noon construction would misfire
+        // for users east of UTC (e.g. Tokyo early-morning deep links where
+        // UTC still reads yesterday) when the future-date guard compares
+        // parseISODate-derived dates against todayISO(). Noon keeps us
+        // safely away from DST/leap-second boundaries on any frame.
         var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
         if (!m) return null;
         return new Date(
-          parseInt(m[1], 10),
-          parseInt(m[2], 10) - 1,
-          parseInt(m[3], 10),
-          12,
-          0,
-          0,
+          Date.UTC(
+            parseInt(m[1], 10),
+            parseInt(m[2], 10) - 1,
+            parseInt(m[3], 10),
+            12,
+            0,
+            0,
+          ),
         );
       }
 
@@ -770,10 +782,12 @@
       // alongside the persisted ?preview=1 flag; the canned payload just
       // doesn't change in response.
 
-      // Mirrors server.ts MAX_DAYS (see src/server.ts:2703). Kept in sync by
-      // hand — if server raises the cap, raise it here too. days values
-      // beyond this are clamped (not rejected) so deep links remain valid.
-      var URL_MAX_DAYS = 100000;
+      // Upper bound for ?days= in the URL. Shares a single source of truth
+      // with ALL_TIME_DAYS so the "All time" pill label and the URL clamp
+      // always align. The server-side MAX_DAYS (src/server.ts:2703) must
+      // stay >= this value; days beyond this cap are clamped (not rejected)
+      // so shared deep links degrade gracefully to "All time".
+      var URL_MAX_DAYS = ALL_TIME_DAYS;
 
       // Parse the current page URL's time-window query params.
       // Returns one of:
@@ -803,11 +817,12 @@
           if (!fromDate || !toDate) return null;
           // Round-trip check: parseISODate regex-validates shape but accepts
           // e.g. 2026-02-30 (JS Date normalizes to Mar 2). Reconstruct the
-          // YYYY-MM-DD from the parsed Date and compare.
+          // YYYY-MM-DD from the parsed Date and compare. Uses UTC accessors
+          // to stay frame-aligned with parseISODate (UTC-noon construction).
           function roundTrip(d) {
-            var y = d.getFullYear();
-            var mo = String(d.getMonth() + 1).padStart(2, "0");
-            var da = String(d.getDate()).padStart(2, "0");
+            var y = d.getUTCFullYear();
+            var mo = String(d.getUTCMonth() + 1).padStart(2, "0");
+            var da = String(d.getUTCDate()).padStart(2, "0");
             return y + "-" + mo + "-" + da;
           }
           if (roundTrip(fromDate) !== fromRaw) return null;
@@ -863,16 +878,23 @@
       // adjacent to its read/write counterparts for maintainability.
       function applyUrlWindowOnMount() {
         var parsed = readWindowFromUrl();
-        if (!parsed) return;
-        if (parsed.mode === "days") {
-          activeDaysBack = parsed.days;
-          activeFrom = null;
-          activeTo = null;
-        } else if (parsed.mode === "range") {
-          activeFrom = parsed.from;
-          activeTo = parsed.to;
-          activeDaysBack = null;
+        if (parsed) {
+          if (parsed.mode === "days") {
+            activeDaysBack = parsed.days;
+            activeFrom = null;
+            activeTo = null;
+          } else if (parsed.mode === "range") {
+            activeFrom = parsed.from;
+            activeTo = parsed.to;
+            activeDaysBack = null;
+          }
         }
+        // Unconditionally rewrite the URL so it reflects the effective
+        // state (clamped value when ?days= exceeded URL_MAX_DAYS, or the
+        // 7-day default when the input was invalid). Without this, the
+        // address bar keeps displaying the user's original (now-wrong)
+        // query and a copy-paste propagates the bad value.
+        writeWindowToUrl();
       }
 
       function formatPillLabel() {
@@ -1370,6 +1392,21 @@
               f = t;
               t = tmp;
             }
+            // Reject future ranges to match readWindowFromUrl's contract —
+            // without this guard, interactive Apply accepts a future range
+            // that a bookmarked/shared URL of the same selection would
+            // reject, silently snapping back to the 7-day default.
+            if (t > todayISO()) {
+              if (dateErr) {
+                dateErr.textContent = "End date cannot be in the future.";
+                dateErr.style.display = "block";
+              }
+              console.warn(
+                "[analytics] dateApply rejected future range",
+                { from: f, to: t },
+              );
+              return;
+            }
             activeFrom = f;
             activeTo = t;
             activeDaysBack = null;
@@ -1654,6 +1691,10 @@
                   draftToInput = null;
                   // Date window changed — invalidate source cache.
                   unfilteredSourcesCache = null;
+                  // Mirror the drill-down into the URL so refresh /
+                  // deep-link preserves it. Matches every other state-
+                  // mutating path (preset, Today, Apply).
+                  writeWindowToUrl();
                   load();
                 },
               },

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -768,6 +768,30 @@
         return y + "-" + m + "-" + dd;
       }
 
+      // tomorrowISO returns today's UTC date + 1 day. Used as the upper bound
+      // for future-date rejection in custom-range validation and URL parsing,
+      // so that a user east of UTC (e.g. Tokyo early-morning, Sydney, etc.)
+      // can still pick their LOCAL "today" without it being rejected as
+      // "future" under UTC reckoning. <input type="date"> and URL-pasted
+      // dates express the user's local calendar; todayISO() is UTC. Every
+      // UTC+ timezone has a nightly band where local-today === UTC-today + 1,
+      // so we allow up to and including tomorrowISO() and reject anything
+      // strictly beyond (which is unambiguously future-future in every zone).
+      function tomorrowISO() {
+        var d = new Date();
+        var t = new Date(
+          Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate() + 1,
+          ),
+        );
+        var y = t.getUTCFullYear();
+        var m = String(t.getUTCMonth() + 1).padStart(2, "0");
+        var dd = String(t.getUTCDate()).padStart(2, "0");
+        return y + "-" + m + "-" + dd;
+      }
+
       // --- URL persistence for the time-window selector ---
       // The selected window (preset days, Today, or custom from/to range) is
       // mirrored into the page URL so that reloading or sharing a deep link
@@ -828,9 +852,13 @@
           if (roundTrip(fromDate) !== fromRaw) return null;
           if (roundTrip(toDate) !== toRaw) return null;
           if (fromRaw > toRaw) return null;
-          // Reject future ranges (to > today UTC). Uses string compare; both
-          // sides are YYYY-MM-DD so lexicographic order matches chronological.
-          if (toRaw > todayISO()) return null;
+          // Reject future ranges. Upper bound is tomorrowISO() (today_UTC + 1)
+          // so users east of UTC whose local "today" reads as UTC tomorrow —
+          // Tokyo early-morning, Sydney, etc. — aren't silently rejected when
+          // deep-linking to their local today. Dates strictly beyond today+1
+          // are unambiguously future in every timezone. String compare is
+          // fine: both sides are YYYY-MM-DD so lexicographic === chronological.
+          if (toRaw > tomorrowISO()) return null;
           return { mode: "range", from: fromRaw, to: toRaw };
         }
         var daysRaw = params.get("days");
@@ -1395,8 +1423,11 @@
             // Reject future ranges to match readWindowFromUrl's contract —
             // without this guard, interactive Apply accepts a future range
             // that a bookmarked/shared URL of the same selection would
-            // reject, silently snapping back to the 7-day default.
-            if (t > todayISO()) {
+            // reject, silently snapping back to the 7-day default. Upper
+            // bound is tomorrowISO() (today_UTC + 1) so users east of UTC
+            // whose local "today" reads as UTC tomorrow can still pick their
+            // local today. See tomorrowISO() for the TZ rationale.
+            if (t > tomorrowISO()) {
               if (dateErr) {
                 dateErr.textContent = "End date cannot be in the future.";
                 dateErr.style.display = "block";

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -184,6 +184,11 @@
       .filter-row .filter-group.source-group {
         margin-left: auto;
       }
+      .filter-row .data-availability {
+        color: #64748b;
+        font-size: 0.74rem;
+        margin-left: 6px;
+      }
 
       /* Date range selector */
       .date-pill .date-value {
@@ -1192,6 +1197,72 @@
         }
         var customVisibleStyle = dateCustomMode ? "" : "display:none;";
 
+        // "Showing N days of data" subtext next to the date pill.
+        // Renders only when earliest_query_day is known AND the requested
+        // window strictly exceeds the actual data depth. Strict `>` means
+        // a same-size window (user picks 9-day range on a 9-day install)
+        // stays quiet — the plateau signal is specifically for the case
+        // where bumping 7d → 14d → 30d produces identical numbers.
+        var dataAvailabilityHtml = "";
+        if (currentEarliestQueryDay) {
+          var earliestDate = parseISODate(currentEarliestQueryDay);
+          if (earliestDate) {
+            // Compare as UTC-midnight dates so timezone offsets don't shift
+            // the day count. parseISODate returns a local-noon Date; using
+            // the numeric year/month/day back out via Date.UTC keeps the
+            // arithmetic timezone-neutral.
+            var earliestUTC = Date.UTC(
+              earliestDate.getFullYear(),
+              earliestDate.getMonth(),
+              earliestDate.getDate(),
+            );
+            var now = new Date();
+            var todayUTC = Date.UTC(
+              now.getUTCFullYear(),
+              now.getUTCMonth(),
+              now.getUTCDate(),
+            );
+            var MS_PER_DAY = 86400000;
+            var availableDays =
+              Math.floor((todayUTC - earliestUTC) / MS_PER_DAY) + 1;
+            var requestedDays = null;
+            if (activeFrom && activeTo) {
+              var fromDate = parseISODate(activeFrom);
+              var toDate = parseISODate(activeTo);
+              if (fromDate && toDate) {
+                var fromUTC = Date.UTC(
+                  fromDate.getFullYear(),
+                  fromDate.getMonth(),
+                  fromDate.getDate(),
+                );
+                var toUTC = Date.UTC(
+                  toDate.getFullYear(),
+                  toDate.getMonth(),
+                  toDate.getDate(),
+                );
+                requestedDays = Math.floor((toUTC - fromUTC) / MS_PER_DAY) + 1;
+              }
+            } else if (activeDaysBack !== null) {
+              requestedDays = activeDaysBack;
+            }
+            if (
+              typeof requestedDays === "number" &&
+              availableDays >= 1 &&
+              requestedDays > availableDays
+            ) {
+              var unit = availableDays === 1 ? "day" : "days";
+              dataAvailabilityHtml =
+                '<span class="data-availability" id="dataAvailability">' +
+                "showing " +
+                esc(String(availableDays)) +
+                " " +
+                unit +
+                " of data" +
+                "</span>";
+            }
+          }
+        }
+
         var dateHtml =
           "" +
           '<div class="filter-group date-group" id="dateGroup">' +
@@ -1235,6 +1306,7 @@
               "</div>" +
               "</div>"
             : "") +
+          dataAvailabilityHtml +
           "</div>";
 
         // Source group (right)
@@ -1480,6 +1552,12 @@
       // Cached so date-popover interactions can re-render without another fetch.
       var currentToolCounts = [];
       var currentSources = [];
+      // Earliest query_log day (YYYY-MM-DD) or null. Set from
+      // summary.earliest_query_day on each successful load(). Renders the
+      // "showing N days of data" subtext in the filter row when the
+      // requested window exceeds the actual data depth. Null = no data or
+      // server hasn't responded yet — skip the label entirely.
+      var currentEarliestQueryDay = null;
 
       // --- Main load ---
       async function load() {
@@ -1519,6 +1597,16 @@
 
           // Cache for non-fetching re-renders (e.g. toggling the date popover)
           currentToolCounts = toolCounts;
+          // Track earliest query day so renderFilters can decide whether the
+          // "showing N days of data" subtext belongs next to the date pill.
+          // Coerce anything other than a YYYY-MM-DD string to null so a
+          // malformed server response doesn't turn into "showing NaN days
+          // of data".
+          currentEarliestQueryDay =
+            typeof summary.earliest_query_day === "string" &&
+            /^\d{4}-\d{2}-\d{2}$/.test(summary.earliest_query_day)
+              ? summary.earliest_query_day
+              : null;
           // When NO filters are active, the summary.queries_by_source
           // reflects the full set. Snapshot it so that later, when a
           // tool-type or source filter shrinks the response, the source

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -756,6 +756,125 @@
         return y + "-" + m + "-" + dd;
       }
 
+      // --- URL persistence for the time-window selector ---
+      // The selected window (preset days, Today, or custom from/to range) is
+      // mirrored into the page URL so that reloading or sharing a deep link
+      // preserves the selection. Other query params (notably ?preview=1) are
+      // always preserved.
+      //
+      // Preview-mode interaction: the preview IIFE at the top of this script
+      // strips query strings from /api/analytics/* fetches and returns canned
+      // 7-day data regardless of ?days / ?from&to. That's by design — preview
+      // exists to render a deterministic mockup. URL persistence still runs
+      // in preview mode so subsequent pill clicks update the visible URL
+      // alongside the persisted ?preview=1 flag; the canned payload just
+      // doesn't change in response.
+
+      // Mirrors server.ts MAX_DAYS (see src/server.ts:2703). Kept in sync by
+      // hand — if server raises the cap, raise it here too. days values
+      // beyond this are clamped (not rejected) so deep links remain valid.
+      var URL_MAX_DAYS = 100000;
+
+      // Parse the current page URL's time-window query params.
+      // Returns one of:
+      //   { mode: "range", from: "YYYY-MM-DD", to: "YYYY-MM-DD" }
+      //   { mode: "days",  days: <positive integer, clamped to URL_MAX_DAYS> }
+      //   null  — caller falls back to the 7-day default
+      //
+      // Precedence: if both days and from/to are present, from/to wins
+      // (matches server buildDateWindow's precedence).
+      //
+      // Validation (returns null on any failure, except days > URL_MAX_DAYS
+      // which clamps rather than rejects so shared deep links degrade
+      // gracefully):
+      //   - from/to: ISO YYYY-MM-DD shape + calendar round-trip; from <= to;
+      //     to <= today UTC; half-specified (only from OR only to) → null
+      //   - days: finite integer >= 1; rejects "garbage", NaN, 0, negative,
+      //     and non-integers like 3.5
+      function readWindowFromUrl() {
+        var params = new URLSearchParams(window.location.search);
+        var fromRaw = params.get("from");
+        var toRaw = params.get("to");
+        // Half-specified range → null (one-sided ranges are ambiguous).
+        if ((fromRaw && !toRaw) || (!fromRaw && toRaw)) return null;
+        if (fromRaw && toRaw) {
+          var fromDate = parseISODate(fromRaw);
+          var toDate = parseISODate(toRaw);
+          if (!fromDate || !toDate) return null;
+          // Round-trip check: parseISODate regex-validates shape but accepts
+          // e.g. 2026-02-30 (JS Date normalizes to Mar 2). Reconstruct the
+          // YYYY-MM-DD from the parsed Date and compare.
+          function roundTrip(d) {
+            var y = d.getFullYear();
+            var mo = String(d.getMonth() + 1).padStart(2, "0");
+            var da = String(d.getDate()).padStart(2, "0");
+            return y + "-" + mo + "-" + da;
+          }
+          if (roundTrip(fromDate) !== fromRaw) return null;
+          if (roundTrip(toDate) !== toRaw) return null;
+          if (fromRaw > toRaw) return null;
+          // Reject future ranges (to > today UTC). Uses string compare; both
+          // sides are YYYY-MM-DD so lexicographic order matches chronological.
+          if (toRaw > todayISO()) return null;
+          return { mode: "range", from: fromRaw, to: toRaw };
+        }
+        var daysRaw = params.get("days");
+        if (daysRaw === null || daysRaw === "") return null;
+        var n = Number(daysRaw);
+        // Reject NaN, non-finite, non-integer, and anything < 1.
+        if (!Number.isFinite(n)) return null;
+        if (!Number.isInteger(n)) return null;
+        if (n < 1) return null;
+        // Clamp days > MAX_DAYS rather than rejecting so shared deep links
+        // with an overlarge but otherwise-valid value degrade gracefully to
+        // the cap instead of snapping back to the 7-day default.
+        if (n > URL_MAX_DAYS) n = URL_MAX_DAYS;
+        return { mode: "days", days: n };
+      }
+
+      // Mirror the current active window state into the page URL via
+      // history.replaceState (no new history entry). Preserves any other
+      // query params already on the URL — e.g. ?preview=1 survives every
+      // preset click. Omits days when from/to is set, and vice versa.
+      function writeWindowToUrl() {
+        var params = new URLSearchParams(window.location.search);
+        if (activeFrom && activeTo) {
+          params.set("from", activeFrom);
+          params.set("to", activeTo);
+          params.delete("days");
+        } else if (activeDaysBack !== null) {
+          params.set("days", String(activeDaysBack));
+          params.delete("from");
+          params.delete("to");
+        } else {
+          // No active window — clear all three params but leave others alone.
+          params.delete("days");
+          params.delete("from");
+          params.delete("to");
+        }
+        var qs = params.toString();
+        var newUrl =
+          window.location.pathname + (qs ? "?" + qs : "") + window.location.hash;
+        window.history.replaceState(null, "", newUrl);
+      }
+
+      // Apply any window selection parsed from the URL BEFORE the first
+      // load() runs. Called from init() further below so this helper stays
+      // adjacent to its read/write counterparts for maintainability.
+      function applyUrlWindowOnMount() {
+        var parsed = readWindowFromUrl();
+        if (!parsed) return;
+        if (parsed.mode === "days") {
+          activeDaysBack = parsed.days;
+          activeFrom = null;
+          activeTo = null;
+        } else if (parsed.mode === "range") {
+          activeFrom = parsed.from;
+          activeTo = parsed.to;
+          activeDaysBack = null;
+        }
+      }
+
       function formatPillLabel() {
         if (activeFrom && activeTo) {
           // Single-day range collapses to a "Today" label when it is in
@@ -1144,6 +1263,9 @@
             // Date window changed — sources cached under the previous
             // window are stale. Let the next unfiltered load refresh it.
             unfilteredSourcesCache = null;
+            // Mirror the new window into the page URL so refresh preserves
+            // it. Preserves any other query params (e.g. ?preview=1).
+            writeWindowToUrl();
             load();
           });
         });
@@ -1164,6 +1286,7 @@
             draftToInput = null;
             // Date window changed — invalidate source cache.
             unfilteredSourcesCache = null;
+            writeWindowToUrl();
             load();
           });
         }
@@ -1256,6 +1379,7 @@
             draftToInput = null;
             // Date window changed — invalidate source cache.
             unfilteredSourcesCache = null;
+            writeWindowToUrl();
             load();
           });
         }
@@ -1683,6 +1807,10 @@
 
       // Check if server is in dev mode (skip auth), otherwise require token
       (async function init() {
+        // Hydrate window state from the URL before any fetch fires so the
+        // initial load() reflects a deep-linked selection. Does nothing when
+        // the URL carries no recognized params.
+        applyUrlWindowOnMount();
         // Preview mode renders from canned data with the fetch stub above;
         // skip both the auth-mode probe and the token prompt entirely.
         if (window.__pathfinderPreview) {

--- a/src/__tests__/analytics-gap-fill.test.ts
+++ b/src/__tests__/analytics-gap-fill.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  __setPoolForTesting,
+  __resetPoolForTesting,
+} from "../db/client.js";
+import { getAnalyticsSummary } from "../db/analytics.js";
+import { generatePostSchemaMigration } from "../db/schema.js";
+
+// -----------------------------------------------------------------------------
+// Integration tests for the per-day gap-fill + 366-day cap.
+//
+// These tests run the real analytics SQL against an in-process PGlite instance
+// rather than a hand-rolled pool mock so they exercise generate_series,
+// LEFT JOIN, date coercion, and window bounds end-to-end. We install a
+// pg.Pool-shaped wrapper around PGlite via __setPoolForTesting so that
+// getAnalyticsSummary's internal getPool() lookup returns it.
+//
+// Schema source of truth: generatePostSchemaMigration() in src/db/schema.ts.
+// That function returns DDL for both `chunks` (requires the pgvector
+// extension) and `query_log`. For gap-fill we only need query_log, so we
+// slice out just the "-- Analytics: query_log" section — avoids pulling in
+// the pgvector extension setup that initializePGlite performs.
+// -----------------------------------------------------------------------------
+
+const QUERY_LOG_DDL_MARKER = "-- Analytics: query_log table for tracking tool usage";
+
+function extractQueryLogDdl(): string {
+  const full = generatePostSchemaMigration();
+  const idx = full.indexOf(QUERY_LOG_DDL_MARKER);
+  if (idx < 0) {
+    throw new Error(
+      `Could not locate "${QUERY_LOG_DDL_MARKER}" in generatePostSchemaMigration(); ` +
+        `schema.ts may have been refactored — update the marker.`,
+    );
+  }
+  return full.slice(idx);
+}
+
+/**
+ * Duck-typed pg.Pool around PGlite. Only implements the methods
+ * analytics.ts actually calls (query). connect/end are stubs for safety.
+ */
+function poolFromPglite(db: PGlite) {
+  return {
+    query: (text: string, params?: unknown[]) => db.query(text, params),
+    connect: async () => ({
+      query: (text: string, params?: unknown[]) => db.query(text, params),
+      release: () => {},
+    }),
+    end: async () => db.close(),
+  };
+}
+
+/** ISO "YYYY-MM-DD" for a UTC day offset from today. */
+function utcDayString(offsetDays: number): string {
+  const d = new Date();
+  d.setUTCDate(d.getUTCDate() + offsetDays);
+  return d.toISOString().slice(0, 10);
+}
+
+/** A timestamp inside the given UTC day (noon UTC, avoids TZ edge ambiguity). */
+function utcNoonOfDay(offsetDays: number): Date {
+  const day = utcDayString(offsetDays);
+  return new Date(`${day}T12:00:00.000Z`);
+}
+
+async function seedQueryLog(
+  db: PGlite,
+  rows: Array<{ created_at: Date; latency_ms?: number; query_text?: string }>,
+) {
+  for (const row of rows) {
+    await db.query(
+      `INSERT INTO query_log
+        (tool_name, query_text, result_count, top_score, latency_ms,
+         source_name, session_id, created_at)
+       VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+      [
+        "search-docs",
+        row.query_text ?? "q",
+        5,
+        0.9,
+        row.latency_ms ?? 42,
+        "docs",
+        "sess-1",
+        row.created_at,
+      ],
+    );
+  }
+}
+
+describe("analytics per-day gap-fill (PGlite integration)", () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await db.exec(extractQueryLogDdl());
+    __setPoolForTesting(poolFromPglite(db));
+  });
+
+  afterAll(async () => {
+    __resetPoolForTesting();
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await db.query("DELETE FROM query_log");
+  });
+
+  it("rolling: 14-day window on sparse data emits 14 ascending rows, non-zero only on seeded days", async () => {
+    // Seed 3 of the 14 days. Days -13 .. 0 (today) should all appear in the
+    // result; the 11 unseeded days must be zero-count but still present.
+    const seeded = new Set([0, -5, -10]);
+    await seedQueryLog(db, [
+      { created_at: utcNoonOfDay(0) },
+      { created_at: utcNoonOfDay(-5) },
+      { created_at: utcNoonOfDay(-10) },
+    ]);
+
+    const result = await getAnalyticsSummary({}, 14);
+
+    expect(result.queries_per_day_window).toHaveLength(14);
+
+    const days = result.queries_per_day_window.map((r) => r.day);
+    // Ascending order
+    expect([...days].sort()).toEqual(days);
+    // All 14 expected days present
+    const expectedDays = Array.from({ length: 14 }, (_, i) =>
+      utcDayString(i - 13),
+    );
+    expect(days).toEqual(expectedDays);
+
+    // Only seeded days non-zero.
+    for (const entry of result.queries_per_day_window) {
+      const offset = Math.round(
+        (Date.parse(entry.day + "T00:00:00Z") -
+          Date.parse(utcDayString(0) + "T00:00:00Z")) /
+          86_400_000,
+      );
+      if (seeded.has(offset)) {
+        expect(entry.count).toBeGreaterThan(0);
+      } else {
+        expect(entry.count).toBe(0);
+      }
+    }
+  });
+
+  it("range: from/to spanning 10 days emits 10 rows on sparse data", async () => {
+    const to = utcNoonOfDay(-2);
+    const from = utcNoonOfDay(-11); // 10-day inclusive span: -11..-2
+    // Seed 2 of the 10 days inside the range.
+    await seedQueryLog(db, [
+      { created_at: utcNoonOfDay(-3) },
+      { created_at: utcNoonOfDay(-8) },
+    ]);
+    // Seed 1 outside the range to make sure the outer gap-fill ignores it.
+    await seedQueryLog(db, [{ created_at: utcNoonOfDay(-15) }]);
+
+    const result = await getAnalyticsSummary({ from, to }, 7);
+
+    expect(result.queries_per_day_window).toHaveLength(10);
+    const days = result.queries_per_day_window.map((r) => r.day);
+    expect([...days].sort()).toEqual(days);
+    // Range boundaries present
+    expect(days[0]).toBe(utcDayString(-11));
+    expect(days[days.length - 1]).toBe(utcDayString(-2));
+    // Non-zero counts exactly on seeded days within the range
+    const nonZero = result.queries_per_day_window
+      .filter((r) => r.count > 0)
+      .map((r) => r.day)
+      .sort();
+    expect(nonZero).toEqual([utcDayString(-8), utcDayString(-3)].sort());
+  });
+
+  it("sum-equals-total invariant: rolling per-day sum matches total_queries_window and excludes out-of-window rows", async () => {
+    // Seed rows across the 14-day boundary. The today-20 row is outside
+    // the window and must NOT contribute to either the sum-of-bars or
+    // total_queries_window — this catches drift between the gap-fill
+    // series bounds and the inner WHERE clause.
+    await seedQueryLog(db, [
+      { created_at: utcNoonOfDay(0) },
+      { created_at: utcNoonOfDay(-3) },
+      { created_at: utcNoonOfDay(-7) },
+      { created_at: utcNoonOfDay(-13) },
+      { created_at: utcNoonOfDay(-20) }, // outside 14-day window
+    ]);
+
+    const result = await getAnalyticsSummary({}, 14);
+
+    // Gap-fill: bar count == window length, not the count of seeded days.
+    expect(result.queries_per_day_window).toHaveLength(14);
+
+    const sumOfBars = result.queries_per_day_window.reduce(
+      (acc, r) => acc + r.count,
+      0,
+    );
+    expect(sumOfBars).toBe(result.total_queries_window);
+    // Exactly four rows fall inside the 14-day window.
+    expect(sumOfBars).toBe(4);
+  });
+
+  it("cap: days=1000 clamps queries_per_day_window to 366 rows while total_queries_window reflects the full window", async () => {
+    // Seed two rows: one ~200 days back, one ~900 days back. The 900-day
+    // row is inside the caller-requested 1000-day window (so it should
+    // count toward total_queries_window) but outside the 366-day per-day
+    // cap (so it should NOT appear as a bar).
+    await seedQueryLog(db, [
+      { created_at: utcNoonOfDay(-200) },
+      { created_at: utcNoonOfDay(-900) },
+    ]);
+
+    const result = await getAnalyticsSummary({}, 1000);
+
+    expect(result.queries_per_day_window).toHaveLength(366);
+    // total_queries_window is not gap-fill-capped — it reflects the full
+    // 1000-day window and so should see both seeded rows.
+    expect(result.total_queries_window).toBe(2);
+
+    // The most-recent day in the bar series is today; the oldest is today-365.
+    const days = result.queries_per_day_window.map((r) => r.day);
+    expect(days[0]).toBe(utcDayString(-365));
+    expect(days[days.length - 1]).toBe(utcDayString(0));
+
+    // The -200 row is inside both windows → bar count is 1; the -900 row is
+    // outside the 366 cap so does not appear as a bar.
+    const sumOfBars = days.reduce(
+      (acc, _, i) => acc + result.queries_per_day_window[i].count,
+      0,
+    );
+    expect(sumOfBars).toBe(1);
+  });
+});

--- a/src/__tests__/analytics-gap-fill.test.ts
+++ b/src/__tests__/analytics-gap-fill.test.ts
@@ -228,4 +228,100 @@ describe("analytics per-day gap-fill (PGlite integration)", () => {
     );
     expect(sumOfBars).toBe(1);
   });
+
+  // Regression guard for the range-mode sum-invariant. The rolling test
+  // above already exercises this invariant on an aligned rolling window; the
+  // interesting case is a user-chosen range with non-midnight from/to where
+  // the outer series runs over `$from::date..$to::date` but the inner WHERE
+  // uses full-timestamp comparison. Rows that straddle the range boundaries
+  // at sub-day resolution must be accepted/rejected by BOTH sides in lock
+  // step so sum-of-bars equals total_queries_window exactly.
+  it("range sum-invariant: non-midnight from/to with straddle rows preserves sum-of-bars == total_queries_window", async () => {
+    const from = new Date(`${utcDayString(-5)}T15:00:00.000Z`);
+    const to = new Date(`${utcDayString(-2)}T18:00:00.000Z`);
+
+    await seedQueryLog(db, [
+      // Before `from` by 1 minute → must be excluded.
+      {
+        created_at: new Date(from.getTime() - 60_000),
+        query_text: "before-from",
+      },
+      // After `from` by 1 minute → must be included.
+      {
+        created_at: new Date(from.getTime() + 60_000),
+        query_text: "after-from",
+      },
+      // Before `to` by 1 minute → must be included.
+      {
+        created_at: new Date(to.getTime() - 60_000),
+        query_text: "before-to",
+      },
+      // After `to` by 1 minute → must be excluded.
+      {
+        created_at: new Date(to.getTime() + 60_000),
+        query_text: "after-to",
+      },
+    ]);
+
+    const result = await getAnalyticsSummary({ from, to }, 7);
+
+    // Inclusive day span: from::date == today-5, to::date == today-2 → 4 days.
+    expect(result.queries_per_day_window).toHaveLength(4);
+    for (const entry of result.queries_per_day_window) {
+      expect(typeof entry.count).toBe("number");
+      expect(Number.isFinite(entry.count)).toBe(true);
+    }
+
+    const sumOfBars = result.queries_per_day_window.reduce(
+      (acc, r) => acc + r.count,
+      0,
+    );
+    expect(result.total_queries_window).toBe(2);
+    expect(sumOfBars).toBe(result.total_queries_window);
+  });
+
+  // Production Postgres sessions often have `TimeZone` set to a non-UTC
+  // value (e.g. America/Los_Angeles on RDS managed configs that inherit a
+  // region default). Without an explicit `AT TIME ZONE 'UTC'` on the inner
+  // `date_trunc`, the inner aggregate groups by the session-local day while
+  // the outer `generate_series` emits UTC-midnight days — a silent mismatch
+  // that drops bars for rows whose UTC day differs from the session-local
+  // day at the time they were logged. PGlite defaults to UTC, which is why
+  // the other tests pass; flipping the session TZ here reproduces the
+  // production-only regression locally.
+  it("non-UTC session TZ: per-day grouping stays in UTC regardless of TimeZone GUC", async () => {
+    // Seed a row deliberately placed on a UTC/LA day boundary. 06:30 UTC
+    // on day 0 is 23:30 on day -1 in America/Los_Angeles (PDT = UTC-7).
+    // A naive `date_trunc('day', created_at)` in the LA session would
+    // bucket this row on day -1; the UTC-normalized grouping MUST bucket
+    // it on day 0 to stay aligned with the series.
+    const row = new Date(`${utcDayString(0)}T06:30:00.000Z`);
+    await seedQueryLog(db, [{ created_at: row }]);
+
+    // Save and override session TZ. PGlite keeps the GUC until reset, so
+    // always restore in a try/finally to avoid leaking into later tests.
+    const prev = await db.query<{ TimeZone: string }>("SHOW TimeZone");
+    const prevTz = prev.rows[0]?.TimeZone ?? "UTC";
+    await db.query("SET TIME ZONE 'America/Los_Angeles'");
+    try {
+      const result = await getAnalyticsSummary({}, 7);
+
+      expect(result.queries_per_day_window).toHaveLength(7);
+      expect(result.total_queries_window).toBe(1);
+
+      const sumOfBars = result.queries_per_day_window.reduce(
+        (acc, r) => acc + r.count,
+        0,
+      );
+      expect(sumOfBars).toBe(result.total_queries_window);
+
+      // The row should land on today (UTC), not on yesterday (LA).
+      const todayBar = result.queries_per_day_window.find(
+        (r) => r.day === utcDayString(0),
+      );
+      expect(todayBar?.count).toBe(1);
+    } finally {
+      await db.query(`SET TIME ZONE '${prevTz}'`);
+    }
+  });
 });

--- a/src/__tests__/analytics-gap-fill.test.ts
+++ b/src/__tests__/analytics-gap-fill.test.ts
@@ -198,11 +198,14 @@ describe("analytics per-day gap-fill (PGlite integration)", () => {
     expect(sumOfBars).toBe(4);
   });
 
-  it("cap: days=1000 clamps queries_per_day_window to 366 rows while total_queries_window reflects the full window", async () => {
-    // Seed two rows: one ~200 days back, one ~900 days back. The 900-day
-    // row is inside the caller-requested 1000-day window (so it should
-    // count toward total_queries_window) but outside the 366-day per-day
-    // cap (so it should NOT appear as a bar).
+  it("cap: days=1000 clamps both queries_per_day_window AND total_queries_window to the shared 366-day rolling cap", async () => {
+    // Seed two rows: one ~200 days back, one ~900 days back. Rolling-window
+    // cap is symmetric across every windowed aggregate (summary totals,
+    // latency, by-source, per-day, top/empty, tool counts) — they all share
+    // buildDateWindow's ROLLING_WINDOW_CAP_DAYS. Previously only the
+    // per-day series was capped, so total_queries_window saw both rows
+    // while bars only showed one — a confusing inconsistency. Now both
+    // sides clamp at 366 and the sum-invariant holds across the cap too.
     await seedQueryLog(db, [
       { created_at: utcNoonOfDay(-200) },
       { created_at: utcNoonOfDay(-900) },
@@ -211,9 +214,9 @@ describe("analytics per-day gap-fill (PGlite integration)", () => {
     const result = await getAnalyticsSummary({}, 1000);
 
     expect(result.queries_per_day_window).toHaveLength(366);
-    // total_queries_window is not gap-fill-capped — it reflects the full
-    // 1000-day window and so should see both seeded rows.
-    expect(result.total_queries_window).toBe(2);
+    // total_queries_window is now also capped — the 900-day row is outside
+    // the 366-day rolling window and should not count toward it.
+    expect(result.total_queries_window).toBe(1);
 
     // The most-recent day in the bar series is today; the oldest is today-365.
     const days = result.queries_per_day_window.map((r) => r.day);
@@ -227,6 +230,8 @@ describe("analytics per-day gap-fill (PGlite integration)", () => {
       0,
     );
     expect(sumOfBars).toBe(1);
+    // Sum-invariant holds in the cap regime too now that the cap is shared.
+    expect(sumOfBars).toBe(result.total_queries_window);
   });
 
   // Regression guard for the range-mode sum-invariant. The rolling test
@@ -278,6 +283,81 @@ describe("analytics per-day gap-fill (PGlite integration)", () => {
     );
     expect(result.total_queries_window).toBe(2);
     expect(sumOfBars).toBe(result.total_queries_window);
+  });
+
+  // Regression guard for the rolling sum-invariant drift that existed when
+  // buildDateWindow used a NOW()-relative INTERVAL window but the per-day
+  // series used UTC-midnight calendar days. At any NOW() != UTC midnight,
+  // the inner WHERE would admit rows on partial UTC day `today-N` that the
+  // outer UTC-midnight series did not emit, so the LEFT JOIN silently
+  // dropped them; total_queries_window still counted them. After the fix,
+  // buildDateWindow rolling mode also uses UTC-calendar-day bounds, so
+  // sum-of-bars == total_queries_window EXACTLY for any seed-row timestamp.
+  it("rolling UTC-day alignment: late-UTC-day row on today-N is excluded from both summary and bars", async () => {
+    // Pre-fix drift scenario: with the old `created_at > NOW() - INTERVAL
+    // '1 day' * 14` rolling window, a row at 14:00 UTC on today-14 passed
+    // the inner WHERE for any NOW() earlier than 14:00 UTC (which is most
+    // of the day), so `total_queries_window` counted it. But the per-day
+    // series emitted UTC-midnight days today-13..today; the inner aggregate
+    // bucketed the row on today-14, and the LEFT JOIN silently dropped it.
+    // Result: `sum(queries_per_day_window) < total_queries_window` — the
+    // sum-invariant violation this fix closes.
+    //
+    // Post-fix, buildDateWindow rolling mode also uses UTC-calendar-day
+    // bounds (`created_at >= (NOW() AT TIME ZONE 'UTC')::date - 13`), so
+    // the row is OUTSIDE both the summary WHERE AND the series; sum and
+    // total both land at 0 and the invariant holds exactly.
+    const driftingRow = new Date(`${utcDayString(-14)}T14:00:00.000Z`);
+    await seedQueryLog(db, [{ created_at: driftingRow }]);
+
+    const result = await getAnalyticsSummary({}, 14);
+
+    expect(result.queries_per_day_window).toHaveLength(14);
+    expect(result.total_queries_window).toBe(0);
+    const sumOfBars = result.queries_per_day_window.reduce(
+      (acc, r) => acc + r.count,
+      0,
+    );
+    expect(sumOfBars).toBe(0);
+    expect(sumOfBars).toBe(result.total_queries_window);
+  });
+
+  // Regression guard for range-mode series TZ coercion. When a session's
+  // TimeZone GUC is non-UTC, `$from::date` coerces a timestamptz to the
+  // session-local day, which can drop the series one day earlier than the
+  // caller intended. The fix wraps the cast in `AT TIME ZONE 'UTC'` so the
+  // series stays aligned with the UTC-normalized inner aggregate.
+  it("range mode non-UTC session TZ: series stays on UTC calendar days", async () => {
+    // Fixed range at UTC midnight so the regression is easy to see:
+    // from = 2026-04-15 00:00 UTC → LA (UTC-7) sees 2026-04-14 17:00 → the
+    // pre-fix `$from::date` would coerce this to 2026-04-14, shifting the
+    // series one day earlier than intended.
+    const from = new Date("2026-04-15T00:00:00.000Z");
+    const to = new Date("2026-04-17T00:00:00.000Z");
+    await seedQueryLog(db, [
+      { created_at: new Date("2026-04-15T00:00:00.000Z") },
+    ]);
+
+    const prev = await db.query<{ TimeZone: string }>("SHOW TimeZone");
+    const prevTz = prev.rows[0]?.TimeZone ?? "UTC";
+    await db.query("SET TIME ZONE 'America/Los_Angeles'");
+    try {
+      const result = await getAnalyticsSummary({ from, to });
+
+      // Inclusive day span: 2026-04-15, 2026-04-16, 2026-04-17 → 3 days.
+      const days = result.queries_per_day_window.map((r) => r.day);
+      expect(days).toEqual(["2026-04-15", "2026-04-16", "2026-04-17"]);
+      expect(days).not.toContain("2026-04-14");
+
+      const sumOfBars = result.queries_per_day_window.reduce(
+        (acc, r) => acc + r.count,
+        0,
+      );
+      expect(sumOfBars).toBe(result.total_queries_window);
+      expect(sumOfBars).toBe(1);
+    } finally {
+      await db.query(`SET TIME ZONE '${prevTz}'`);
+    }
   });
 
   // Production Postgres sessions often have `TimeZone` set to a non-UTC

--- a/src/__tests__/analytics-gap-fill.test.ts
+++ b/src/__tests__/analytics-gap-fill.test.ts
@@ -1,9 +1,6 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
 import { PGlite } from "@electric-sql/pglite";
-import {
-  __setPoolForTesting,
-  __resetPoolForTesting,
-} from "../db/client.js";
+import { __setPoolForTesting, __resetPoolForTesting } from "../db/client.js";
 import { getAnalyticsSummary } from "../db/analytics.js";
 import { generatePostSchemaMigration } from "../db/schema.js";
 
@@ -23,7 +20,8 @@ import { generatePostSchemaMigration } from "../db/schema.js";
 // the pgvector extension setup that initializePGlite performs.
 // -----------------------------------------------------------------------------
 
-const QUERY_LOG_DDL_MARKER = "-- Analytics: query_log table for tracking tool usage";
+const QUERY_LOG_DDL_MARKER =
+  "-- Analytics: query_log table for tracking tool usage";
 
 function extractQueryLogDdl(): string {
   const full = generatePostSchemaMigration();

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2156,9 +2156,9 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
     // written URL so we confirm both: days=14 is added AND from/to are
     // dropped in the same write.
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     expect(finalQS.days).toBe("14");
     expect(finalQS.from).toBeUndefined();
     expect(finalQS.to).toBeUndefined();
@@ -2211,9 +2211,9 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
     await flushAsync();
 
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     expect(finalQS.from).toBe("2024-02-10");
     expect(finalQS.to).toBe("2024-02-20");
     expect(finalQS.days).toBeUndefined();
@@ -2350,9 +2350,9 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
     for (let i = 0; i < 5; i++) await flushAsync();
 
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     expect(finalQS.preview).toBe("1");
     expect(finalQS.days).toBe("14");
     expect(finalQS.from).toBeUndefined();
@@ -2478,9 +2478,9 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     // writeWindowToUrl().
     expect(replaceSpy).toHaveBeenCalled();
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     expect(finalQS.from).toBe(targetDay);
     expect(finalQS.to).toBe(targetDay);
     expect(finalQS.days).toBeUndefined();
@@ -2503,9 +2503,9 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     );
 
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     // After fix (Finding 3) URL_MAX_DAYS === ALL_TIME_DAYS === 99999.
     expect(finalQS.days).toBe("99999");
   });
@@ -2527,9 +2527,9 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     );
 
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     // Post-fix we always emit the effective state. Default is 7 days.
     expect(finalQS.days).toBe("7");
     expect(finalQS.from).toBeUndefined();
@@ -2558,9 +2558,9 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     expect(pillLabel).toBe("All time");
 
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     expect(finalQS.days).toBe("99999");
   });
 
@@ -2582,9 +2582,9 @@ describe("analytics dashboard UI — URL persistence parity", () => {
 
     // URL is re-synced to the clamped value (via Finding 2 fix).
     const finalSearch = win.location.search;
-    const finalQS = parseQS(finalSearch.startsWith("?")
-      ? finalSearch.slice(1)
-      : finalSearch);
+    const finalQS = parseQS(
+      finalSearch.startsWith("?") ? finalSearch.slice(1) : finalSearch,
+    );
     expect(finalQS.days).toBe("99999");
 
     // Outbound summary fetch uses the clamped value too.
@@ -2626,7 +2626,9 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     Object.assign(win, { Date: globalThis.Date });
     installChartStub(win);
     // No fetch needed — we only evaluate the helpers.
-    Object.assign(win, { fetch: vi.fn(() => Promise.reject(new Error("n/a"))) });
+    Object.assign(win, {
+      fetch: vi.fn(() => Promise.reject(new Error("n/a"))),
+    });
 
     const scriptEl = dom.window.document.querySelector("script:not([src])");
     const code = scriptEl!.textContent ?? "";

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2708,4 +2708,203 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     expect(win.location.search).toBe(urlBefore);
     expect(win.location.search).not.toContain("2099");
   });
+
+  // Finding (R2) — future-date rejection uses UTC today, but <input type="date">
+  // and URL-pasted dates express the user's LOCAL calendar. Users east of UTC
+  // (Tokyo UTC+9, Sydney UTC+10, etc.) have a nightly band where their local
+  // "today" is one calendar day ahead of UTC "today". During that band, picking
+  // local today in the custom-range picker — or deep-linking to ?to=<local
+  // today> — is silently rejected as "future".
+  //
+  // Fix: allow dates up to today_UTC + 1 as the upper bound. Strictly beyond
+  // is still unambiguously future and still rejected.
+  //
+  // System time: 2026-04-20T10:00:00Z → todayISO() === "2026-04-20".
+  // tomorrowISO() === "2026-04-21" (the user's local "today" in Tokyo morning).
+  // "2026-04-22" is strictly future-future and must still be rejected.
+
+  it("readWindowFromUrl accepts ?to=<today_UTC + 1> so eastern-TZ users aren't rejected", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(2, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    // Tokyo early-morning scenario: UTC today is 2026-04-20, but the user's
+    // local calendar reads 2026-04-21 and they deep-link to
+    // ?from=2026-04-20&to=2026-04-21 (their local "today"). Pre-fix this is
+    // rejected as future and falls back to the 7-day default — the exact
+    // silent-regression we're fixing.
+    const { calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2026-04-20&to=2026-04-21",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    // Post-fix: the range is accepted (from/to propagate to the fetch).
+    expect(qs.from).toBe("2026-04-20");
+    expect(qs.to).toBe("2026-04-21");
+    expect(qs.days).toBeUndefined();
+  });
+
+  it("Apply handler accepts to=<today_UTC + 1> (eastern-TZ local today)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(2, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+    const fetchCountBefore = calls.length;
+
+    vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
+
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    // from = today_UTC, to = today_UTC + 1 (local today in Tokyo/Sydney morning).
+    fromEl.value = "2026-04-20";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2026-04-21";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    // No inline error.
+    const dateErr = dom.window.document.getElementById(
+      "dateError",
+    ) as HTMLElement | null;
+    expect(dateErr).not.toBeNull();
+    expect(dateErr!.style.display).not.toBe("block");
+
+    // A new fetch fired (range applied).
+    expect(calls.length).toBeGreaterThan(fetchCountBefore);
+    const summaryCall = [...calls]
+      .reverse()
+      .find((u) => u.startsWith("/api/analytics/summary"));
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.from).toBe("2026-04-20");
+    expect(qs.to).toBe("2026-04-21");
+
+    // URL reflects the applied range.
+    const finalQS = parseQS(
+      win.location.search.startsWith("?")
+        ? win.location.search.slice(1)
+        : win.location.search,
+    );
+    expect(finalQS.from).toBe("2026-04-20");
+    expect(finalQS.to).toBe("2026-04-21");
+  });
+
+  it("still rejects to=<today_UTC + 2> in both URL and Apply handler (guard against over-permissive fix)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    // URL deep-link path: today+2 is unambiguously future-future and must
+    // still be rejected — falls back to the 7-day default.
+    const deep = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2026-04-20&to=2026-04-22",
+      endpoints,
+    );
+    const deepSummary = deep.calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(deepSummary).toBeDefined();
+    const deepQS = parseQS(deepSummary!.split("?")[1] ?? "");
+    expect(deepQS.days).toBe("7");
+    expect(deepQS.from).toBeUndefined();
+    expect(deepQS.to).toBeUndefined();
+
+    // Apply handler path: fresh mount, open custom, pick today+2, click Apply.
+    const { dom, win, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+    const fetchCountBefore = calls.length;
+    const urlBefore = win.location.search;
+
+    vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
+
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromEl.value = "2026-04-20";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2026-04-22";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    expect(calls.length).toBe(fetchCountBefore);
+    const dateErr = dom.window.document.getElementById(
+      "dateError",
+    ) as HTMLElement | null;
+    expect(dateErr).not.toBeNull();
+    expect(dateErr!.style.display).toBe("block");
+    expect(dateErr!.textContent).toBe("End date cannot be in the future.");
+    expect(win.location.search).toBe(urlBefore);
+  });
 });

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2805,12 +2805,17 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       );
     await flushAsync();
 
-    // No inline error.
+    // No inline error. On successful Apply the popover closes, which tears
+    // down the #dateError element entirely — so either "no error element in
+    // DOM" (popover closed) or "display !== 'block'" (element exists but
+    // hidden) both indicate acceptance. Rejection paths keep the popover
+    // open AND set display:block, which this assertion excludes.
     const dateErr = dom.window.document.getElementById(
       "dateError",
     ) as HTMLElement | null;
-    expect(dateErr).not.toBeNull();
-    expect(dateErr!.style.display).not.toBe("block");
+    if (dateErr) {
+      expect(dateErr.style.display).not.toBe("block");
+    }
 
     // A new fetch fired (range applied).
     expect(calls.length).toBeGreaterThan(fetchCountBefore);

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2655,11 +2655,12 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/empty-queries": () => [],
     };
 
-    const { dom, calls } = await loadDashboardAtUrl(
+    const { dom, win, calls } = await loadDashboardAtUrl(
       "http://localhost/analytics",
       endpoints,
     );
     const fetchCountBefore = calls.length;
+    const urlBefore = win.location.search;
 
     // Silence warn the handler emits on rejection.
     vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
@@ -2703,7 +2704,8 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     expect(dateErr).not.toBeNull();
     expect(dateErr!.style.display).toBe("block");
     expect(dateErr!.textContent).toBe("End date cannot be in the future.");
-    // URL unchanged (no writeWindowToUrl fired).
-    expect(window.location.search).not.toContain("2099");
+    // URL unchanged (no writeWindowToUrl fired for the rejected range).
+    expect(win.location.search).toBe(urlBefore);
+    expect(win.location.search).not.toContain("2099");
   });
 });

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2913,3 +2913,201 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     expect(win.location.search).toBe(urlBefore);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Data-availability label: when the requested window exceeds the actual
+// query_log depth, show "showing N days of data" next to the date pill so
+// users understand why bumping 7d → 14d → 30d produces identical numbers.
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — data availability label", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Build a Date offset from today-UTC by N days and return YYYY-MM-DD.
+   * Positive N = days before today. Used so the canned `earliest_query_day`
+   * payloads line up with the frozen system time.
+   */
+  function daysBeforeTodayUTC(n: number): string {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - n);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(d.getUTCDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  }
+
+  function makeSummaryEndpoint(earliest: string | null) {
+    return (qs: string) => {
+      const p = parseQS(qs);
+      const days = p.days ? parseInt(p.days, 10) : 7;
+      const base = canned(Math.min(days, 9), 1234).summary;
+      return { ...base, earliest_query_day: earliest };
+    };
+  }
+
+  function makeEndpoints(earliest: string | null) {
+    return {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": makeSummaryEndpoint(earliest),
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+  }
+
+  async function clickPresetDays(dom: JSDOM, days: number): Promise<void> {
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const preset = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === String(days)) as
+      | HTMLElement
+      | undefined;
+    preset!.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+  }
+
+  async function clickTodayPreset(dom: JSDOM): Promise<void> {
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const todayPreset = dom.window.document.querySelector(
+      '.preset[data-preset="today"]',
+    ) as HTMLElement;
+    todayPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+  }
+
+  it("shows 'showing 9 days of data' when earliest is 8 days ago and window=14", async () => {
+    // earliest = today - 8 days → 9 days inclusive. Default window is 7,
+    // so switch to 14 before asserting.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(8);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickPresetDays(dom, 14);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    expect(label).not.toBeNull();
+    expect(label!.textContent!.trim()).toBe("showing 9 days of data");
+  });
+
+  it("hides the label when earliest is older than the requested window", async () => {
+    // earliest = 30 days ago, window = 14. availableDays (31) > requestedDays
+    // (14), so the label must NOT render — the user already sees all the
+    // data their window asked for.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(30);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickPresetDays(dom, 14);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    // Either absent or empty — both acceptable; assert a stable "no content"
+    // condition rather than pinning on element presence so minor DOM
+    // restructurings (container hide/show vs. removal) still pass.
+    if (label) {
+      expect(label.textContent!.trim()).toBe("");
+    }
+  });
+
+  it("hides the label when earliest_query_day is null (empty table)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const { dom } = await loadDashboard(makeEndpoints(null));
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    if (label) {
+      expect(label.textContent!.trim()).toBe("");
+    }
+  });
+
+  it("computes availableDays inclusively for explicit from/to range", async () => {
+    // Custom range spanning 10 UTC days, earliest 5 days ago → 6 days of
+    // data. Requested = 10, available = 6, label = "showing 6 days of data".
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(5);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+
+    // Open popover → enter custom mode → set from/to.
+    const datePill = dom.window.document.getElementById("datePill")!;
+    datePill.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    const customPreset = dom.window.document.querySelector(
+      '.preset[data-custom="1"]',
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    const fromInput = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toInput = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromInput.value = "2026-04-11";
+    toInput.value = "2026-04-20";
+    const applyBtn = dom.window.document.getElementById(
+      "dateApplyBtn",
+    ) as HTMLElement;
+    applyBtn.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    expect(label).not.toBeNull();
+    expect(label!.textContent!.trim()).toBe("showing 6 days of data");
+  });
+
+  it("hides the label for 'Today' when earliest is today (1 <= 1)", async () => {
+    // requestedDays = 1, availableDays = 1. Strict `>` comparison means
+    // equal windows don't trigger the label — only true plateaus do.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(0); // today
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickTodayPreset(dom);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    if (label) {
+      expect(label.textContent!.trim()).toBe("");
+    }
+  });
+
+  it("pluralizes 'day' when availableDays === 1", async () => {
+    // earliest = today → 1 day of data, requested = 14 → label uses singular
+    // "day" not "days".
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(0);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickPresetDays(dom, 14);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    expect(label).not.toBeNull();
+    expect(label!.textContent!.trim()).toBe("showing 1 day of data");
+  });
+});
+>>>>>>> 81e89c7 (Add failing tests for data-availability label on analytics UI)

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2359,3 +2359,351 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
     expect(finalQS.to).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// URL persistence parity — these tests cover state-mutating paths and URL
+// re-sync semantics that the original URL-persistence implementation missed.
+//
+// Covered:
+//   - Daily-bar drill-down must call writeWindowToUrl() like every other
+//     state-mutating path (preset, Today, Apply). Without this, a refresh or
+//     deep link silently reverts the drill-down.
+//   - applyUrlWindowOnMount must re-sync the URL after clamping an overlarge
+//     ?days=, or after rejecting invalid input and falling back to the
+//     default, so the address bar always reflects the effective state.
+//   - URL_MAX_DAYS must equal ALL_TIME_DAYS — a single source of truth keeps
+//     the "All time" pill label and the URL clamp aligned.
+//   - Apply handler must reject future dates, matching readWindowFromUrl's
+//     contract (otherwise interactive Apply and URL deep-link diverge).
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — URL persistence parity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  // Variant of loadDashboard that lets a test supply a custom page URL so we
+  // can mount with ?days=N / ?from=&to= / ?days=99999 etc. Duplicated from
+  // the URL-persisted describe block so these tests stay isolated; duplication
+  // is cheap and keeps the two blocks independently skippable.
+  async function loadDashboardAtUrl(
+    pageUrl: string,
+    handlers: Record<string, (qs: string) => HandlerResult>,
+  ): Promise<{
+    dom: JSDOM;
+    win: Window & typeof globalThis;
+    calls: string[];
+    chartInstances: Array<{ type: string; data: unknown; options: unknown }>;
+  }> {
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: pageUrl,
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    const { instances } = installChartStub(win);
+    const { fetchFn, calls } = buildFetchStub(handlers);
+    Object.assign(win, { fetch: fetchFn });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    if (!scriptEl) throw new Error("inline script not found in analytics.html");
+    const code = scriptEl.textContent ?? "";
+    dom.window.eval(code);
+
+    await flushAsync();
+
+    return { dom, win, calls, chartInstances: instances };
+  }
+
+  // Finding 1 — daily-bar drill-down must persist to URL.
+  it("daily-bar drill-down writes from=<day>&to=<day> to the URL (no days=)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(3, 500).summary,
+      "/api/analytics/tool-counts": () => canned(3, 500).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win, chartInstances } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+
+    // Spy on history.replaceState AFTER mount so applyUrlWindowOnMount's
+    // initial call (if any) isn't counted. Preserve the real impl so jsdom's
+    // location mirror updates.
+    const realReplace = win.history.replaceState.bind(win.history);
+    const replaceSpy = vi.fn(
+      (data: unknown, unused: string, url?: string | null) => {
+        realReplace(data, unused, url ?? undefined);
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (win.history as any).replaceState = replaceSpy;
+
+    const barChart = [...chartInstances]
+      .reverse()
+      .find((c) => c.type === "bar") as
+      | (typeof chartInstances)[number]
+      | undefined;
+    expect(barChart).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labels = (barChart as any).data.labels as string[];
+    const targetDay = labels[0];
+    expect(/^\d{4}-\d{2}-\d{2}$/.test(targetDay)).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onClick = (barChart as any).options.onClick as (
+      evt: unknown,
+      elements: Array<{ index: number }>,
+    ) => void;
+    onClick({}, [{ index: 0 }]);
+    await flushAsync();
+
+    // The drill-down must have written the new window to the URL. Pre-fix
+    // this spy is never called because the onClick handler never invokes
+    // writeWindowToUrl().
+    expect(replaceSpy).toHaveBeenCalled();
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.from).toBe(targetDay);
+    expect(finalQS.to).toBe(targetDay);
+    expect(finalQS.days).toBeUndefined();
+  });
+
+  // Finding 2 — clamp re-sync. Mount with overlarge ?days= and assert the
+  // URL is rewritten to the clamped value.
+  it("mount with ?days=999999 re-syncs the URL to the clamped value", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(1, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { win } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=999999",
+      endpoints,
+    );
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    // After fix (Finding 3) URL_MAX_DAYS === ALL_TIME_DAYS === 99999.
+    expect(finalQS.days).toBe("99999");
+  });
+
+  // Finding 2 (second half) — invalid input re-sync. Mount with garbage,
+  // assert the URL is rewritten to the 7-day default.
+  it("mount with ?days=garbage re-syncs the URL to days=7 (default)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { win } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=garbage",
+      endpoints,
+    );
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    // Post-fix we always emit the effective state. Default is 7 days.
+    expect(finalQS.days).toBe("7");
+    expect(finalQS.from).toBeUndefined();
+    expect(finalQS.to).toBeUndefined();
+  });
+
+  // Finding 3 — URL_MAX_DAYS must equal ALL_TIME_DAYS. Mount with ?days=99999
+  // and confirm the pill reads "All time" AND no clamp was applied.
+  it("mount with ?days=99999 labels the pill 'All time' and emits days=99999 unchanged", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=99999",
+      endpoints,
+    );
+
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toBe("All time");
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.days).toBe("99999");
+  });
+
+  // Finding 3 (second half) — mount with ?days=100000 should clamp to the
+  // ALL_TIME_DAYS sentinel (99999) after the fix.
+  it("mount with ?days=100000 clamps to 99999 (URL_MAX_DAYS === ALL_TIME_DAYS)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=100000",
+      endpoints,
+    );
+
+    // URL is re-synced to the clamped value (via Finding 2 fix).
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.days).toBe("99999");
+
+    // Outbound summary fetch uses the clamped value too.
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const outQs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(outQs.days).toBe("99999");
+
+    // And the pill renders as "All time".
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toBe("All time");
+  });
+
+  // Finding 4 — parseISODate and roundTrip use UTC consistently, so the
+  // future-date comparison against todayISO() (UTC) is frame-aligned. This is
+  // a direct unit test of the two helpers exposed via the same eval pattern
+  // the file uses. The ambient TZ-sensitive variant (setSystemTime + mount)
+  // is hard to reproduce reliably inside jsdom, so we assert the invariant
+  // directly: parseISODate("2026-04-21") must produce {y,m,d} = {2026,4,21}
+  // in BOTH local and UTC calendar frames.
+  it("parseISODate and roundTrip operate in UTC (frame-aligned with todayISO)", async () => {
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: "http://localhost/analytics",
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    installChartStub(win);
+    // No fetch needed — we only evaluate the helpers.
+    Object.assign(win, { fetch: vi.fn(() => Promise.reject(new Error("n/a"))) });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    const code = scriptEl!.textContent ?? "";
+    dom.window.eval(code);
+    await flushAsync();
+
+    // Probe parseISODate in the window context. After the fix, the resulting
+    // Date's UTC accessors must match the input Y/M/D exactly.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const d = (win as any).eval('parseISODate("2026-04-21")') as Date;
+    expect(d).toBeInstanceOf(Date);
+    expect(d.getUTCFullYear()).toBe(2026);
+    expect(d.getUTCMonth()).toBe(3); // zero-based: April
+    expect(d.getUTCDate()).toBe(21);
+  });
+
+  // Finding 5 — Apply handler must reject future dates.
+  it("Apply handler rejects a future-dated range with an inline error and no fetch", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+    const fetchCountBefore = calls.length;
+
+    // Silence warn the handler emits on rejection.
+    vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
+
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromEl.value = "2099-01-01";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2099-01-10";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    // No new fetch — handler early-returned.
+    expect(calls.length).toBe(fetchCountBefore);
+    // Popover still open with inline error surfaced.
+    const dateErr = dom.window.document.getElementById(
+      "dateError",
+    ) as HTMLElement | null;
+    expect(dateErr).not.toBeNull();
+    expect(dateErr!.style.display).toBe("block");
+    expect(dateErr!.textContent).toBe("End date cannot be in the future.");
+    // URL unchanged (no writeWindowToUrl fired).
+    expect(window.location.search).not.toContain("2099");
+  });
+});

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -3110,4 +3110,3 @@ describe("analytics dashboard UI — data availability label", () => {
     expect(label!.textContent!.trim()).toBe("showing 1 day of data");
   });
 });
->>>>>>> 81e89c7 (Add failing tests for data-availability label on analytics UI)

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -1983,3 +1983,379 @@ describe("analytics dashboard UI — fetchJson stale-401 generation guard", () =
     errSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// URL-persisted time window: the selected window (days preset or from/to
+// custom range) should be mirrored into the page URL via
+// history.replaceState so refresh / deep-link preserves the selection.
+// These tests load analytics.html with a variety of ?days= / ?from=&to=
+// query strings and assert:
+//   - on mount, the active window matches the URL
+//   - clicks on presets / custom-apply update the URL via replaceState
+//   - invalid URL inputs fall back to the 7-day default
+//   - other query params (e.g. preview=1) are preserved across writes
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — URL-persisted time window", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Variant of loadDashboard that lets a test supply a custom page URL so we
+  // can mount with ?days=N / ?from=&to= query strings. Mirrors the regular
+  // helper's wiring (Chart stub, fetch stub, inline-script eval, microtask
+  // flush) but exposes the jsdom window so tests can spy on
+  // history.replaceState before the click-driven branch runs.
+  async function loadDashboardAtUrl(
+    pageUrl: string,
+    handlers: Record<string, (qs: string) => HandlerResult>,
+  ): Promise<{
+    dom: JSDOM;
+    win: Window & typeof globalThis;
+    calls: string[];
+    chartInstances: Array<{ type: string; data: unknown; options: unknown }>;
+  }> {
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: pageUrl,
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    const { instances } = installChartStub(win);
+    const { fetchFn, calls } = buildFetchStub(handlers);
+    Object.assign(win, { fetch: fetchFn });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    if (!scriptEl) throw new Error("inline script not found in analytics.html");
+    const code = scriptEl.textContent ?? "";
+    dom.window.eval(code);
+
+    await flushAsync();
+
+    return { dom, win, calls, chartInstances: instances };
+  }
+
+  it("mount with ?days=30 sends days=30 on outbound summary fetch and labels the pill 'Last 30 days'", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": (qs: string) => {
+        const p = parseQS(qs);
+        const days = p.days ? parseInt(p.days, 10) : 7;
+        return canned(days, 4242).summary;
+      },
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=30",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.days).toBe("30");
+    expect(qs.from).toBeUndefined();
+    expect(qs.to).toBeUndefined();
+
+    // Pill label reflects the parsed 30-day window.
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toBe("Last 30 days");
+  });
+
+  it("mount with ?from=&to= sends that range on outbound fetch and uses range-format pill label", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(10, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2026-04-01&to=2026-04-10",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.from).toBe("2026-04-01");
+    expect(qs.to).toBe("2026-04-10");
+    expect(qs.days).toBeUndefined();
+
+    // Range pill uses short-date format: "Apr 1 – Apr 10" (locale-dependent,
+    // so match by the en-dash separator rather than the exact label).
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toContain("–"); // en-dash between from and to
+    // Must NOT contain any "Last N days" wording.
+    expect(pillLabel).not.toMatch(/Last \d+ days/);
+  });
+
+  it("clicking the '14 days' preset updates the URL via replaceState with days=14 and drops from/to", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win } = await loadDashboardAtUrl(
+      // Seed from/to in the URL so we can assert the preset click CLEARS them.
+      "http://localhost/analytics?from=2026-04-01&to=2026-04-05",
+      endpoints,
+    );
+
+    // Spy on history.replaceState AFTER mount so we only capture the click-
+    // driven calls. Preserve the real implementation so jsdom's URL updates.
+    const realReplace = win.history.replaceState.bind(win.history);
+    const replaceSpy = vi.fn(
+      (data: unknown, unused: string, url?: string | null) => {
+        realReplace(data, unused, url ?? undefined);
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (win.history as any).replaceState = replaceSpy;
+
+    // Open popover + click "14 days" preset.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const fourteen = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === "14") as HTMLElement;
+    fourteen.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+
+    expect(replaceSpy).toHaveBeenCalled();
+    // jsdom's location reflects the replaceState url. Inspect the last
+    // written URL so we confirm both: days=14 is added AND from/to are
+    // dropped in the same write.
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.days).toBe("14");
+    expect(finalQS.from).toBeUndefined();
+    expect(finalQS.to).toBeUndefined();
+  });
+
+  it("clicking Apply on a valid custom range updates the URL with from/to (no days)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(3, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win } = await loadDashboardAtUrl(
+      // Seed days= in the URL so we can assert Apply CLEARS it.
+      "http://localhost/analytics?days=30",
+      endpoints,
+    );
+
+    // Open popover, reveal custom, fill inputs, click Apply.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromEl.value = "2024-02-10";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2024-02-20";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.from).toBe("2024-02-10");
+    expect(finalQS.to).toBe("2024-02-20");
+    expect(finalQS.days).toBeUndefined();
+  });
+
+  it("mount with ?days=garbage falls back to 7-day default (outbound days=7)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=garbage",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.days).toBe("7");
+    expect(qs.from).toBeUndefined();
+    expect(qs.to).toBeUndefined();
+  });
+
+  it.each([
+    ["?days=0", "zero"],
+    ["?days=-1", "negative"],
+    ["?days=3.5", "non-integer"],
+  ])(
+    "mount with %s falls back to 7-day default (rejects %s)",
+    async (query) => {
+      const endpoints = {
+        "/api/analytics/auth-mode": () => ({ dev: true }),
+        "/api/analytics/summary": () => canned(7, 100).summary,
+        "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+        "/api/analytics/queries": () => [],
+        "/api/analytics/empty-queries": () => [],
+      };
+
+      const { calls } = await loadDashboardAtUrl(
+        "http://localhost/analytics" + query,
+        endpoints,
+      );
+
+      const summaryCall = calls.find((u) =>
+        u.startsWith("/api/analytics/summary"),
+      );
+      expect(summaryCall).toBeDefined();
+      const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+      expect(qs.days).toBe("7");
+    },
+  );
+
+  it("mount with a future from/to falls back to 7-day default (rejects future dates)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2099-01-01&to=2099-01-10",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.days).toBe("7");
+    expect(qs.from).toBeUndefined();
+    expect(qs.to).toBeUndefined();
+  });
+
+  it("preserves ?preview=1 alongside ?days when a preset is clicked", async () => {
+    // Preview mode installs its own canned-response fetch, so we don't need
+    // to supply handlers — mount with ?preview=1&days=30, then click "14
+    // days" and assert the URL retains preview=1 AND updates days=14.
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: "http://localhost/analytics?preview=1&days=30",
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    if (typeof (win as { Response?: unknown }).Response === "undefined") {
+      Object.assign(win, { Response: globalThis.Response });
+    }
+    installChartStub(win);
+    // Preview IIFE captures originalFetch via window.fetch.bind(window); if
+    // the jsdom window doesn't expose fetch (depending on version), bind
+    // throws. Install a noop fetch spy so the IIFE can capture and then
+    // override it. Preview's own handler short-circuits every analytics URL
+    // so the stub's noop impl is never invoked for app paths.
+    const noopFetch = vi.fn(() => Promise.reject(new Error("noop fetch")));
+    Object.assign(win, { fetch: noopFetch });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    if (!scriptEl) throw new Error("inline script not found in analytics.html");
+    const code = scriptEl.textContent ?? "";
+    dom.window.eval(code);
+
+    // Flush many rounds since preview init is several async hops deep.
+    for (let i = 0; i < 10; i++) await flushAsync();
+
+    // Click "14 days" preset.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const fourteen = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === "14") as HTMLElement;
+    fourteen.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    for (let i = 0; i < 5; i++) await flushAsync();
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.preview).toBe("1");
+    expect(finalQS.days).toBe("14");
+    expect(finalQS.from).toBeUndefined();
+    expect(finalQS.to).toBeUndefined();
+  });
+});

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -19,7 +19,11 @@ import {
 import type { QueryLogEntry } from "../db/analytics.js";
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks) so any queued `.mockResolvedValueOnce`
+  // implementations also clear between tests. A test that queues N mocks for
+  // one pool.query() call chain but the code only consumes M (<N) would
+  // otherwise leak the remaining N-M implementations into the next test.
+  vi.resetAllMocks();
 });
 
 // ---------------------------------------------------------------------------
@@ -219,6 +223,85 @@ describe("getAnalyticsSummary", () => {
     const perDaySql = perDayCall![0] as string;
     expect(perDaySql).toMatch(/generate_series/i);
     expect(perDaySql).toMatch(/LEFT JOIN/i);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// earliest_query_day — data-availability probe for the UI
+//
+// The dashboard surfaces a "showing N days of data" subtext whenever the
+// requested window exceeds the actual query_log depth. To compute N the UI
+// needs the earliest row's date regardless of the current filter — picking a
+// 90-day window shouldn't hide the fact that data only stretches back 9 days.
+// The field is therefore sourced from an UNFILTERED MIN(created_at) query and
+// lives alongside the windowed aggregates on the same summary response.
+// ---------------------------------------------------------------------------
+
+describe("getAnalyticsSummary earliest_query_day", () => {
+  it("returns the earliest day from query_log as a YYYY-MM-DD string", async () => {
+    // 5 existing subqueries + 1 new earliest-day subquery (6th call).
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 1000 }] }) // total
+      .mockResolvedValueOnce({
+        rows: [{ total: 200, empty: 10, avg_latency: 45 }],
+      }) // windowed summary
+      .mockResolvedValueOnce({ rows: [] }) // latency rows
+      .mockResolvedValueOnce({ rows: [] }) // by source
+      .mockResolvedValueOnce({ rows: [] }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: "2026-04-12" }] }); // earliest day
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.earliest_query_day).toBe("2026-04-12");
+  });
+
+  it("returns null when query_log is empty", async () => {
+    // An empty query_log makes MIN(created_at) return NULL — surface that as
+    // `null` on the response so the UI can skip the label entirely rather
+    // than rendering "showing NaN days of data".
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 0, empty: 0, avg_latency: 0 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.earliest_query_day).toBeNull();
+  });
+
+  it("queries the unfiltered earliest created_at (no filter/window applied)", async () => {
+    // The label describes data availability in absolute terms — picking a
+    // tool_type, source, or narrow from/to window must NOT change the reported
+    // earliest day. Verify the SQL for the earliest-day subquery has no WHERE
+    // clause and no filter params are bound to it.
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 0, empty: 0, avg_latency: 0 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: "2026-03-01" }] });
+
+    await getAnalyticsSummary(
+      { tool_type: "search", source: "docs" },
+      30,
+    );
+
+    // Index 5 is the new earliest-day subquery (0=total, 1=summary, 2=latency,
+    // 3=by-source, 4=per-day, 5=earliest-day).
+    const [sql, params] = mockQuery.mock.calls[5];
+    expect(sql).toMatch(/min\(created_at/i);
+    expect(sql).toMatch(/FROM query_log/i);
+    expect(sql).not.toMatch(/WHERE/i);
+    // No filter or window params bound to the earliest-day query.
+    expect(params ?? []).toEqual([]);
   });
 });
 

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -927,23 +927,24 @@ describe("getAnalyticsSummary honors days window", () => {
     await getAnalyticsSummary({}, 30);
 
     // Skip mock.calls[0] — the totals query has no date window.
-    // Skip mock.calls[4] — the per-day query uses the gap-fill helper
-    // (buildPerDayWindow), which emits a generate_series + LEFT JOIN with
-    // `(NOW() AT TIME ZONE 'UTC')::date - (LEAST($N, 366) - 1)` rather
-    // than the shared `NOW() - INTERVAL '1 day' * $N` window. The `days`
-    // param is still bound correctly (asserted below); only the SQL text
-    // differs.
+    // All windowed subqueries (summary, latency, by-source, per-day) now
+    // share the same UTC-calendar-day rolling shape:
+    //   created_at >= (NOW() AT TIME ZONE 'UTC')::date - (LEAST($N, 366) - 1)
+    // The per-day query additionally wraps its inner WHERE in a
+    // generate_series + LEFT JOIN.
     // With no filter params, days is the first (and only) param on each
     // windowed subquery. Assert directly on params[0] rather than using
     // `.not.toContain(7)`, which could accidentally pass for any other
     // reason a `7` is absent.
     for (let i = 1; i < 4; i++) {
       const [sql, params] = mockQuery.mock.calls[i];
-      expect(sql).toContain("NOW() - INTERVAL");
+      expect(sql).toContain("(NOW() AT TIME ZONE 'UTC')::date");
+      expect(sql).toContain("LEAST");
+      expect(sql).not.toContain("NOW() - INTERVAL");
       expect(params[0]).toBe(30);
     }
-    // Per-day subquery: still receives `days=30` but in the generate_series
-    // + LEAST expression rather than NOW() - INTERVAL.
+    // Per-day subquery: still receives `days=30`, now in BOTH the outer
+    // series AND the inner WHERE (same UTC-midnight LEAST expression).
     const [perDaySql, perDayParams] = mockQuery.mock.calls[4];
     expect(perDaySql).toContain("generate_series");
     expect(perDaySql).toContain("LEAST");
@@ -1011,27 +1012,32 @@ describe("getAnalyticsSummary with from/to range", () => {
     }
   });
 
-  it("falls back to NOW() - INTERVAL window when from/to are not set", async () => {
+  it("falls back to UTC-calendar-day rolling window when from/to are not set", async () => {
     mockSummaryQueries();
     await getAnalyticsSummary({});
 
     // Indexes 1..3 (summary, latency, by-source) share buildDateWindow's
-    // `NOW() - INTERVAL` rolling window.
+    // UTC-calendar-day rolling window. Old shape (`NOW() - INTERVAL`) is
+    // gone: it drifted from the per-day series bounds whenever NOW() wasn't
+    // exactly UTC midnight, causing sum(queries_per_day_window) to under-
+    // count total_queries_window by up to traffic_rate * hours_into_UTC_day.
     for (let i = 1; i < 4; i++) {
       const [sql] = mockQuery.mock.calls[i];
-      expect(sql).toContain("NOW() - INTERVAL");
-      expect(sql).not.toContain("created_at >=");
+      expect(sql).toContain("created_at >=");
+      expect(sql).toContain("(NOW() AT TIME ZONE 'UTC')::date");
+      expect(sql).toContain("LEAST");
+      expect(sql).not.toContain("NOW() - INTERVAL");
     }
     // Index 4 (per-day) uses the gap-fill helper: generate_series over
     // UTC-midnight calendar days for the outer series, plus the exact
-    // buildDateWindow WHERE (rolling `NOW() - INTERVAL`) reused verbatim on
-    // the inner aggregate. The inner reuse is what keeps sum-of-bars
-    // aligned with total_queries_window — previously the per-day helper
-    // had its own date-based WHERE and drifted from the summary window.
+    // buildDateWindow WHERE (now also UTC-calendar-day bounded) reused
+    // verbatim on the inner aggregate. The inner reuse is what keeps
+    // sum-of-bars EXACTLY aligned with total_queries_window.
     const [perDaySql] = mockQuery.mock.calls[4];
     expect(perDaySql).toContain("generate_series");
     expect(perDaySql).toContain("(NOW() AT TIME ZONE 'UTC')::date");
-    expect(perDaySql).toContain("NOW() - INTERVAL");
+    expect(perDaySql).toContain("LEAST");
+    expect(perDaySql).not.toContain("NOW() - INTERVAL");
     // Inner grouping must be UTC-normalized so bars align with the UTC
     // series regardless of server TimeZone GUC.
     expect(perDaySql).toContain("AT TIME ZONE 'UTC'");
@@ -1100,12 +1106,18 @@ describe("getToolCounts with from/to range", () => {
     expect(params).toEqual([from, to]);
   });
 
-  it("falls back to days window when no range filter provided", async () => {
+  it("falls back to UTC-calendar-day rolling window when no range filter provided", async () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
     await getToolCounts(14);
 
     const [sql, params] = mockQuery.mock.calls[0];
-    expect(sql).toContain("NOW() - INTERVAL");
+    // Rolling mode is now UTC-calendar-day bounded so all windowed
+    // aggregates (getToolCounts included) align with the per-day gap-fill
+    // series. Old `NOW() - INTERVAL` shape is gone.
+    expect(sql).toContain("created_at >=");
+    expect(sql).toContain("(NOW() AT TIME ZONE 'UTC')::date");
+    expect(sql).toContain("LEAST");
+    expect(sql).not.toContain("NOW() - INTERVAL");
     expect(params).toEqual([14]);
   });
 });

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -185,6 +185,41 @@ describe("getAnalyticsSummary", () => {
     expect(result.queries_by_source).toEqual([]);
     expect(result.queries_per_day_window).toEqual([]);
   });
+
+  it("per-day SQL uses generate_series + LEFT JOIN so zero-count days stay in the result", async () => {
+    // Regression: pre-fix, the per-day subquery was a plain GROUP BY over
+    // date_trunc('day', created_at), so days with zero matching rows were
+    // silently dropped. That caused the "Last 14 days" chart to render
+    // fewer bars than the window length on sparse data. The gap-fill
+    // rewrite LEFT JOINs against generate_series so every day in the
+    // window gets a row (with count=0 when empty).
+    //
+    // We identify the per-day call by SQL content ("GROUP BY day" on the
+    // inner aggregate) rather than by hard-coded call index so that
+    // reordering other subqueries in getAnalyticsSummary can't silently
+    // invalidate this assertion.
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 0, empty: 0, avg_latency: 0 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    await getAnalyticsSummary({}, 14);
+
+    const perDayCall = mockQuery.mock.calls.find(
+      (call) =>
+        typeof call[0] === "string" &&
+        /GROUP BY day/i.test(call[0]) &&
+        !/tool_name/i.test(call[0]), // not getTopQueries-style grouping
+    );
+    expect(perDayCall, "per-day query not found").toBeDefined();
+    const perDaySql = perDayCall![0] as string;
+    expect(perDaySql).toMatch(/generate_series/i);
+    expect(perDaySql).toMatch(/LEFT JOIN/i);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -1022,13 +1022,19 @@ describe("getAnalyticsSummary with from/to range", () => {
       expect(sql).toContain("NOW() - INTERVAL");
       expect(sql).not.toContain("created_at >=");
     }
-    // Index 4 (per-day) uses the gap-fill helper: generate_series
-    // + `(NOW() AT TIME ZONE 'UTC')::date - (LEAST($N, 366) - 1)` in
-    // rolling mode. It does contain `created_at >=` (on the inner
-    // narrowing WHERE) but does not use `NOW() - INTERVAL`.
+    // Index 4 (per-day) uses the gap-fill helper: generate_series over
+    // UTC-midnight calendar days for the outer series, plus the exact
+    // buildDateWindow WHERE (rolling `NOW() - INTERVAL`) reused verbatim on
+    // the inner aggregate. The inner reuse is what keeps sum-of-bars
+    // aligned with total_queries_window — previously the per-day helper
+    // had its own date-based WHERE and drifted from the summary window.
     const [perDaySql] = mockQuery.mock.calls[4];
     expect(perDaySql).toContain("generate_series");
-    expect(perDaySql).not.toContain("NOW() - INTERVAL");
+    expect(perDaySql).toContain("(NOW() AT TIME ZONE 'UTC')::date");
+    expect(perDaySql).toContain("NOW() - INTERVAL");
+    // Inner grouping must be UTC-normalized so bars align with the UTC
+    // series regardless of server TimeZone GUC.
+    expect(perDaySql).toContain("AT TIME ZONE 'UTC'");
   });
 });
 

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -154,7 +154,8 @@ describe("getAnalyticsSummary", () => {
           { day: "2026-04-10", count: 30 },
           { day: "2026-04-11", count: 25 },
         ],
-      }); // per day
+      }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: "2026-04-10" }] }); // earliest day
 
     const result = await getAnalyticsSummary();
 
@@ -179,7 +180,8 @@ describe("getAnalyticsSummary", () => {
       })
       .mockResolvedValueOnce({ rows: [] }) // empty latency rows
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
 
@@ -318,7 +320,8 @@ describe("p95 computation edge cases", () => {
       })
       .mockResolvedValueOnce({ rows: [{ latency_ms: 42 }] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
     expect(result.p95_latency_ms_window).toBe(42);
@@ -334,7 +337,8 @@ describe("p95 computation edge cases", () => {
         rows: Array.from({ length: 100 }, () => ({ latency_ms: 50 })),
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
     expect(result.p95_latency_ms_window).toBe(50);
@@ -350,7 +354,8 @@ describe("p95 computation edge cases", () => {
         rows: [{ latency_ms: 50 }, { latency_ms: 100 }],
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
     // floor(2 * 0.95) = 1, sorted[1] = 100
@@ -669,7 +674,8 @@ describe("windowed aggregates exclude backfilled rows (latency_ms >= 0)", () => 
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("getAnalyticsSummary: all four windowed subqueries filter latency_ms >= 0", async () => {
@@ -729,7 +735,8 @@ describe("getAnalyticsSummary p95 latency row cap", () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("emits ORDER BY random() LIMIT on the latency subquery and binds P95_LATENCY_ROW_CAP", async () => {
@@ -771,7 +778,8 @@ describe("getAnalyticsSummary p95 latency row cap", () => {
         })),
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
     const result = await getAnalyticsSummary({});
     const logged = warnSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(logged).toContain("[analytics]");
@@ -796,7 +804,8 @@ describe("getAnalyticsSummary p95 latency row cap", () => {
         rows: [{ latency_ms: 10 }, { latency_ms: 20 }, { latency_ms: 30 }],
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
     const result = await getAnalyticsSummary({});
     expect(result.p95_latency_sampled).toBeUndefined();
   });
@@ -811,7 +820,8 @@ describe("getAnalyticsSummary per-day excludes redacted rows", () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("per-day subquery filters query_text != REDACTED_QUERY_TEXT (consistency with top/empty)", async () => {
@@ -854,7 +864,8 @@ describe("getAnalyticsSummary with filters", () => {
       }) // windowed summary
       .mockResolvedValueOnce({ rows: [] }) // latency rows
       .mockResolvedValueOnce({ rows: [] }) // by source
-      .mockResolvedValueOnce({ rows: [] }); // per day
+      .mockResolvedValueOnce({ rows: [] }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("passes tool_type filter as LIKE clause to all queries", async () => {
@@ -1002,7 +1013,8 @@ describe("getAnalyticsSummary honors days window", () => {
       }) // windowed summary
       .mockResolvedValueOnce({ rows: [] }) // latency rows
       .mockResolvedValueOnce({ rows: [] }) // by source
-      .mockResolvedValueOnce({ rows: [] }); // per day
+      .mockResolvedValueOnce({ rows: [] }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("passes the requested `days` value to every windowed subquery", async () => {
@@ -1071,7 +1083,8 @@ describe("getAnalyticsSummary with from/to range", () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("generates created_at >= / <= range clause and passes Date params", async () => {

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -211,7 +211,8 @@ describe("getAnalyticsSummary", () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     await getAnalyticsSummary({}, 14);
 
@@ -291,10 +292,7 @@ describe("getAnalyticsSummary earliest_query_day", () => {
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [{ earliest_day: "2026-03-01" }] });
 
-    await getAnalyticsSummary(
-      { tool_type: "search", source: "docs" },
-      30,
-    );
+    await getAnalyticsSummary({ tool_type: "search", source: "docs" }, 30);
 
     // Index 5 is the new earliest-day subquery (0=total, 1=summary, 2=latency,
     // 3=by-source, 4=per-day, 5=earliest-day).

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -927,15 +927,27 @@ describe("getAnalyticsSummary honors days window", () => {
     await getAnalyticsSummary({}, 30);
 
     // Skip mock.calls[0] — the totals query has no date window.
+    // Skip mock.calls[4] — the per-day query uses the gap-fill helper
+    // (buildPerDayWindow), which emits a generate_series + LEFT JOIN with
+    // `(NOW() AT TIME ZONE 'UTC')::date - (LEAST($N, 366) - 1)` rather
+    // than the shared `NOW() - INTERVAL '1 day' * $N` window. The `days`
+    // param is still bound correctly (asserted below); only the SQL text
+    // differs.
     // With no filter params, days is the first (and only) param on each
     // windowed subquery. Assert directly on params[0] rather than using
     // `.not.toContain(7)`, which could accidentally pass for any other
     // reason a `7` is absent.
-    for (let i = 1; i < 5; i++) {
+    for (let i = 1; i < 4; i++) {
       const [sql, params] = mockQuery.mock.calls[i];
       expect(sql).toContain("NOW() - INTERVAL");
       expect(params[0]).toBe(30);
     }
+    // Per-day subquery: still receives `days=30` but in the generate_series
+    // + LEAST expression rather than NOW() - INTERVAL.
+    const [perDaySql, perDayParams] = mockQuery.mock.calls[4];
+    expect(perDaySql).toContain("generate_series");
+    expect(perDaySql).toContain("LEAST");
+    expect(perDayParams[0]).toBe(30);
   });
 
   it("defaults `days` to 7 when not provided (backward compatible)", async () => {
@@ -1003,11 +1015,20 @@ describe("getAnalyticsSummary with from/to range", () => {
     mockSummaryQueries();
     await getAnalyticsSummary({});
 
-    for (let i = 1; i < 5; i++) {
+    // Indexes 1..3 (summary, latency, by-source) share buildDateWindow's
+    // `NOW() - INTERVAL` rolling window.
+    for (let i = 1; i < 4; i++) {
       const [sql] = mockQuery.mock.calls[i];
       expect(sql).toContain("NOW() - INTERVAL");
       expect(sql).not.toContain("created_at >=");
     }
+    // Index 4 (per-day) uses the gap-fill helper: generate_series
+    // + `(NOW() AT TIME ZONE 'UTC')::date - (LEAST($N, 366) - 1)` in
+    // rolling mode. It does contain `created_at >=` (on the inner
+    // narrowing WHERE) but does not use `NOW() - INTERVAL`.
+    const [perDaySql] = mockQuery.mock.calls[4];
+    expect(perDaySql).toContain("generate_series");
+    expect(perDaySql).not.toContain("NOW() - INTERVAL");
   });
 });
 

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -199,13 +199,37 @@ function whereAnd(baseClauses: string[], filterClauses: string[]): string {
 }
 
 /**
+ * Rolling-window cap, applied to every days-based windowed aggregate
+ * (summary totals, latency, by-source, per-day, top/empty-queries, tool
+ * counts). The per-day chart renders one bar per day so a year of bars is
+ * already beyond any useful granularity; bigger windows are payload bloat
+ * with no UI benefit. Other aggregates share the cap so `days=1000` on a
+ * rolling window produces consistent results across every card on the
+ * dashboard. Explicit from/to ranges are user-chosen bounds and pass
+ * through uncapped.
+ */
+const ROLLING_WINDOW_CAP_DAYS = 366;
+
+/**
  * Build a date-window clause + params for the given filter, falling back to
- * a rolling "last N days" window when `from`/`to` are not provided.
+ * a rolling UTC-calendar-day window when `from`/`to` are not provided.
  *
  * - When `filter.from` and `filter.to` are both set, returns
  *   `created_at >= $N AND created_at <= $N+1` with the two Date params.
- * - Otherwise, returns `created_at > NOW() - INTERVAL '1 day' * $N` with the
- *   `days` number param.
+ * - Otherwise, returns a UTC-calendar-day-bounded rolling window:
+ *   `created_at >= (NOW() AT TIME ZONE 'UTC')::date - (LEAST($N, 366) - 1)`
+ *   with the `days` number param. Rolling mode semantics: "last N days"
+ *   means "today + the previous N-1 UTC calendar days" = N UTC calendar
+ *   days inclusive of today. Capped at {@link ROLLING_WINDOW_CAP_DAYS}.
+ *
+ *   The UTC-calendar alignment is load-bearing: the per-day chart emits a
+ *   UTC-midnight `generate_series`, so the summary/latency/by-source WHERE
+ *   must also be UTC-calendar-bounded or `sum(queries_per_day_window)`
+ *   drifts below `total_queries_window` by up to
+ *   `traffic_rate * hours_into_UTC_day` on every read. Previously the
+ *   rolling WHERE was `created_at > NOW() - INTERVAL '1 day' * $N` — a
+ *   NOW()-relative slide that admitted partial-UTC-day rows the outer
+ *   series never emitted, dropping them silently in the LEFT JOIN.
  *
  * `startIdx` is the next available `$` placeholder index. The returned
  * `nextIdx` is the next index to use after this clause.
@@ -222,44 +246,39 @@ function buildDateWindow(
       nextIdx: startIdx + 2,
     };
   }
+  // Rolling: UTC-calendar-day-aligned. LEAST caps the span at
+  // ROLLING_WINDOW_CAP_DAYS so `days=huge` can't produce an unbounded
+  // subtraction. `-1` gives an inclusive N-day window ending today
+  // (today-(N-1) .. today). Reused verbatim by buildPerDayWindow so the
+  // per-day bars can never drift from the summary window.
   return {
-    clauses: [`created_at > NOW() - INTERVAL '1 day' * $${startIdx}`],
+    clauses: [
+      `created_at >= (NOW() AT TIME ZONE 'UTC')::date - (LEAST($${startIdx}, ${ROLLING_WINDOW_CAP_DAYS}) - 1)`,
+    ],
     params: [days],
     nextIdx: startIdx + 1,
   };
 }
 
 /**
- * Per-day-chart cap, capped at 366 days to bound response payload; other
- * aggregates still respect the full window. The analytics bar chart renders
- * one bar per day so a year of bars is already well beyond any useful
- * granularity — anything larger is just payload bloat and wasted layout
- * work for the UI. Only applied on rolling (days-based) windows; explicit
- * from/to ranges are user-chosen bounds and pass through uncapped.
- */
-const PER_DAY_WINDOW_CAP_DAYS = 366;
-
-/**
  * Build a series expression + narrowed WHERE clause for the per-day chart.
  *
  * The inner WHERE is delegated to {@link buildDateWindow} so the per-day
- * aggregate counts the EXACT same rows as the summary window — guaranteeing
- * sum(queries_per_day_window[].count) matches total_queries_window whenever
- * the rolling window fits inside the 366-day cap (see cap-regime note below).
- * Any drift between the two WHERE forms showed up in production as "my bars
- * add up to less than my summary card"; reusing buildDateWindow removes the
- * whole class of bug.
+ * aggregate counts the EXACT same rows as the summary window. With both
+ * sides now UTC-calendar-day aligned in rolling mode (since buildDateWindow
+ * switched off NOW()-relative intervals), `sum(queries_per_day_window)` ==
+ * `total_queries_window` exactly — no drift regardless of what time of UTC
+ * day the read happens to land. Any future divergence between the two
+ * WHERE forms would show up in production as "my bars add up to less than
+ * my summary card"; reusing buildDateWindow removes the whole class of bug.
  *
  * The SERIES is emitted separately as UTC-midnight calendar days so that the
  * LEFT JOIN renders one bar per day even when no rows were logged. Rolling
- * mode caps the series at PER_DAY_WINDOW_CAP_DAYS to bound payload size;
- * range mode passes through uncapped (user explicitly chose bounds).
- *
- * Cap regime: when `$days > PER_DAY_WINDOW_CAP_DAYS`, the series is truncated
- * but the inner WHERE still counts every row back to NOW()-$days. In that
- * regime sum-of-bars ≤ total_queries_window — by design. The 366-day cap
- * exists to bound UI payload; total_queries_window is expected to reflect
- * the full caller-requested window.
+ * mode caps the series at ROLLING_WINDOW_CAP_DAYS (shared with
+ * buildDateWindow) so a huge `days` value can't bloat the payload. Range
+ * mode passes through uncapped (user explicitly chose bounds) and forces
+ * UTC on the series ::date cast so a non-UTC session TimeZone GUC can't
+ * shift the series one day earlier than intended.
  *
  * `startIdx` is the next available `$` placeholder index; `nextIdx` is the
  * next index to use after this helper's params.
@@ -283,22 +302,30 @@ function buildPerDayWindow(
 
   if (filter.from && filter.to) {
     return {
-      // Range: `$from::date .. $to::date`. Date coercion uses UTC semantics
-      // in Postgres when the TimeZone GUC is UTC; combined with the UTC-
-      // normalized date_trunc in the inner aggregate (see getAnalyticsSummary)
-      // this keeps bars aligned regardless of session TZ.
-      seriesExpr: `generate_series($${startIdx}::date, $${startIdx + 1}::date, '1 day'::interval)`,
+      // Range: `($from AT TIME ZONE 'UTC')::date .. ($to AT TIME ZONE
+      // 'UTC')::date`. The `AT TIME ZONE 'UTC'` forces the timestamptz to
+      // be interpreted in UTC before the ::date cast; without it, a
+      // non-UTC session TimeZone GUC (common on managed Postgres that
+      // inherit a regional default) coerces `'2026-04-15T00:00:00Z'::date`
+      // to the session-local day `2026-04-14`, shifting the series one
+      // day earlier than the caller intended. Combined with the UTC-
+      // normalized date_trunc in the inner aggregate (see
+      // getAnalyticsSummary), this keeps bars aligned regardless of TZ.
+      seriesExpr: `generate_series(($${startIdx}::timestamptz AT TIME ZONE 'UTC')::date, ($${startIdx + 1}::timestamptz AT TIME ZONE 'UTC')::date, '1 day'::interval)`,
       whereClause,
       params: dw.params,
       nextIdx: dw.nextIdx,
     };
   }
 
-  // Rolling. Emit today-(N-1) .. today in UTC, capped at PER_DAY_WINDOW_CAP_DAYS
-  // so a huge $days value can't bloat the payload. The cap lives in SQL
-  // (LEAST in the series expression) and reuses the same $days placeholder
-  // that buildDateWindow binds — no extra param needed.
-  const cappedExpr = `LEAST($${startIdx}, ${PER_DAY_WINDOW_CAP_DAYS})`;
+  // Rolling. Emit today-(N-1) .. today in UTC, capped at
+  // ROLLING_WINDOW_CAP_DAYS so a huge $days value can't bloat the payload.
+  // The cap lives in SQL (LEAST in the series expression) and reuses the
+  // same $days placeholder that buildDateWindow binds — no extra param
+  // needed. Both the series lower bound and the buildDateWindow WHERE now
+  // apply the same `(NOW() AT TIME ZONE 'UTC')::date - (LEAST($N, cap) - 1)`
+  // expression, so sum-of-bars == total_queries_window exactly.
+  const cappedExpr = `LEAST($${startIdx}, ${ROLLING_WINDOW_CAP_DAYS})`;
   return {
     seriesExpr: `generate_series((NOW() AT TIME ZONE 'UTC')::date - (${cappedExpr} - 1), (NOW() AT TIME ZONE 'UTC')::date, '1 day'::interval)`,
     whereClause,
@@ -729,10 +756,11 @@ export async function cleanupOldQueryLogs(
     );
   }
   const pool = getPool();
-  // Reads use strict `>`, so the edge row `created_at == NOW() - INTERVAL '1 day' * N`
-  // is invisible to reads. If cleanup also used strict `<`, that edge row would never
-  // be visible OR purged — effectively immortal. Using `<=` here closes the partition
-  // so every row past the retention cutoff is reachable by cleanup.
+  // Cleanup is a retention purge anchored to wall-clock NOW(), independent
+  // of the UTC-calendar-day-aligned read window buildDateWindow emits. The
+  // `<=` (non-strict) boundary means any row at or past the retention
+  // cutoff is reachable by cleanup; we never want a row to be invisible to
+  // reads AND immune to purge at the same time.
   try {
     const result = await pool.query(
       `DELETE FROM query_log WHERE created_at <= NOW() - INTERVAL '1 day' * $1`,

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -242,24 +242,24 @@ const PER_DAY_WINDOW_CAP_DAYS = 366;
 /**
  * Build a series expression + narrowed WHERE clause for the per-day chart.
  *
- * Unlike {@link buildDateWindow}, this helper returns a `generate_series`
- * expression plus an aligned inner WHERE so the gap-fill LEFT JOIN emits
- * one row per day in the window even when zero rows were logged that day.
+ * The inner WHERE is delegated to {@link buildDateWindow} so the per-day
+ * aggregate counts the EXACT same rows as the summary window — guaranteeing
+ * sum(queries_per_day_window[].count) matches total_queries_window whenever
+ * the rolling window fits inside the 366-day cap (see cap-regime note below).
+ * Any drift between the two WHERE forms showed up in production as "my bars
+ * add up to less than my summary card"; reusing buildDateWindow removes the
+ * whole class of bug.
  *
- * Kept separate from buildDateWindow because other aggregates (summary,
- * latency, by-source, getToolCounts, getTopQueries, getEmptyQueries) pin
- * buildDateWindow's exact semantics and must not be affected by the
- * gap-fill cap or series alignment.
+ * The SERIES is emitted separately as UTC-midnight calendar days so that the
+ * LEFT JOIN renders one bar per day even when no rows were logged. Rolling
+ * mode caps the series at PER_DAY_WINDOW_CAP_DAYS to bound payload size;
+ * range mode passes through uncapped (user explicitly chose bounds).
  *
- * - Rolling mode: `generate_series((NOW() AT TIME ZONE 'UTC')::date -
- *   (LEAST($days, 366) - 1), (NOW() AT TIME ZONE 'UTC')::date,
- *   '1 day'::interval)` — UTC-normalized so the output matches
- *   `date_trunc('day', created_at)::date` regardless of server TZ GUC.
- *   The matching inner WHERE narrows to `created_at >= (NOW() AT TIME
- *   ZONE 'UTC')::date - (LEAST($days, 366) - 1)` so rows outside the
- *   gap-fill series can't leak into the inner aggregate.
- * - Range mode: `generate_series($from::date, $to::date,
- *   '1 day'::interval)` — uncapped; user explicitly chose bounds.
+ * Cap regime: when `$days > PER_DAY_WINDOW_CAP_DAYS`, the series is truncated
+ * but the inner WHERE still counts every row back to NOW()-$days. In that
+ * regime sum-of-bars ≤ total_queries_window — by design. The 366-day cap
+ * exists to bound UI payload; total_queries_window is expected to reflect
+ * the full caller-requested window.
  *
  * `startIdx` is the next available `$` placeholder index; `nextIdx` is the
  * next index to use after this helper's params.
@@ -274,23 +274,36 @@ function buildPerDayWindow(
   params: unknown[];
   nextIdx: number;
 } {
+  // Inner WHERE is byte-identical to the summary window. For rolling mode
+  // buildDateWindow binds $startIdx = days; for range mode it binds
+  // $startIdx = from and $startIdx+1 = to. The series below reuses those
+  // exact placeholders so the two sides can never drift apart.
+  const dw = buildDateWindow(filter, days, startIdx);
+  const whereClause = dw.clauses.join(" AND ");
+
   if (filter.from && filter.to) {
     return {
+      // Range: `$from::date .. $to::date`. Date coercion uses UTC semantics
+      // in Postgres when the TimeZone GUC is UTC; combined with the UTC-
+      // normalized date_trunc in the inner aggregate (see getAnalyticsSummary)
+      // this keeps bars aligned regardless of session TZ.
       seriesExpr: `generate_series($${startIdx}::date, $${startIdx + 1}::date, '1 day'::interval)`,
-      whereClause: `created_at >= $${startIdx} AND created_at <= $${startIdx + 1}`,
-      params: [filter.from, filter.to],
-      nextIdx: startIdx + 2,
+      whereClause,
+      params: dw.params,
+      nextIdx: dw.nextIdx,
     };
   }
-  // Rolling. Cap at PER_DAY_WINDOW_CAP_DAYS to bound payload size. LEAST()
-  // runs inside SQL (same parameter used for series + WHERE) so the two
-  // bounds can never drift.
+
+  // Rolling. Emit today-(N-1) .. today in UTC, capped at PER_DAY_WINDOW_CAP_DAYS
+  // so a huge $days value can't bloat the payload. The cap lives in SQL
+  // (LEAST in the series expression) and reuses the same $days placeholder
+  // that buildDateWindow binds — no extra param needed.
   const cappedExpr = `LEAST($${startIdx}, ${PER_DAY_WINDOW_CAP_DAYS})`;
   return {
     seriesExpr: `generate_series((NOW() AT TIME ZONE 'UTC')::date - (${cappedExpr} - 1), (NOW() AT TIME ZONE 'UTC')::date, '1 day'::interval)`,
-    whereClause: `created_at >= (NOW() AT TIME ZONE 'UTC')::date - (${cappedExpr} - 1)`,
-    params: [days],
-    nextIdx: startIdx + 1,
+    whereClause,
+    params: dw.params,
+    nextIdx: dw.nextIdx,
   };
 }
 
@@ -462,12 +475,21 @@ export async function getAnalyticsSummary(
     `query_text != $${redactedIdx5}`,
   ];
   const dayWhere = whereAnd(dayBase, fc5);
+  // Inner grouping is normalized to UTC via `AT TIME ZONE 'UTC'` so the
+  // aggregated bucket column aligns with the UTC-midnight series regardless
+  // of the session's `TimeZone` GUC. Without the cast, production Postgres
+  // sessions whose TimeZone != UTC (common on managed instances that
+  // inherit a regional default) silently bucket rows by local-day, the
+  // LEFT JOIN misses the corresponding series day, and bars go to zero.
+  // PGlite defaults to UTC so this diverges only in production — the
+  // non-UTC TZ test in analytics-gap-fill.test.ts is the regression guard.
   const perDayRes = await pool.query(
     `SELECT to_char(d.day, 'YYYY-MM-DD') AS day,
             COALESCE(q.count, 0)::int AS count
      FROM ${pdw.seriesExpr} AS d(day)
      LEFT JOIN (
-       SELECT date_trunc('day', created_at)::date AS day, count(*)::int AS count
+       SELECT date_trunc('day', created_at AT TIME ZONE 'UTC')::date AS day,
+              count(*)::int AS count
        FROM query_log
        ${dayWhere}
        GROUP BY day

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -59,6 +59,16 @@ export interface AnalyticsSummary {
   p95_latency_sampled?: boolean;
   queries_by_source: Array<{ source_name: string; count: number }>;
   queries_per_day_window: Array<{ day: string; count: number }>;
+  /**
+   * ISO UTC date (YYYY-MM-DD) of the oldest query_log row, or null if
+   * query_log is empty. Sourced from an UNFILTERED MIN(created_at) — no
+   * tool_type/source/days/from/to filters apply — because the UI uses
+   * this to label windows that exceed actual data depth (e.g. "showing
+   * 9 days of data" when the user picks a 30-day window on a 9-day
+   * install). Filter-dependent values would conflate "no data for this
+   * filter" with "no data at all".
+   */
+  earliest_query_day: string | null;
 }
 
 export interface TopQuery {
@@ -525,10 +535,32 @@ export async function getAnalyticsSummary(
     [...fp5, ...pdw.params, REDACTED_QUERY_TEXT],
   );
 
+  // Earliest query day (UNFILTERED — the UI uses this to label windows
+  // that have plateaued against actual data depth, which is an absolute
+  // property of the table, not relative to the current filter. Keeping
+  // this subquery sequential with the others preserves the existing
+  // ordering (tests assert on mock.calls[5] as the earliest-day query);
+  // parallelizing would need the rest of getAnalyticsSummary to move to
+  // Promise.all at the same time, which is out of scope here.
+  //
+  // date_trunc → cast to date → cast to text produces a bare YYYY-MM-DD
+  // string regardless of the session timezone. Cast at `created_at AT
+  // TIME ZONE 'UTC'` so the "day" boundary is always UTC and matches
+  // the per-day bars + client-side Date comparisons the UI already
+  // does in UTC.
+  const earliestRes = await pool.query(
+    `SELECT min(created_at AT TIME ZONE 'UTC')::date::text AS earliest_day FROM query_log`,
+  );
+
   const totalQueries = totalRes.rows[0]?.count ?? 0;
   const s = summaryRes.rows[0] ?? {};
   const totalWindow = s.total ?? 0;
   const emptyWindow = s.empty ?? 0;
+  // Normalize undefined (truly missing) to null so consumers get a
+  // consistent shape regardless of whether the DB returned an empty
+  // row, a row with NULL, or no row at all.
+  const earliestDay =
+    (earliestRes.rows[0]?.earliest_day as string | null | undefined) ?? null;
 
   // Compute p95 in application code. Slice back to the cap so the extra
   // "overflow probe" row fetched above doesn't skew the sample size.
@@ -557,6 +589,7 @@ export async function getAnalyticsSummary(
         count: r.count as number,
       }),
     ),
+    earliest_query_day: earliestDay,
   };
 }
 

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -229,6 +229,71 @@ function buildDateWindow(
   };
 }
 
+/**
+ * Per-day-chart cap, capped at 366 days to bound response payload; other
+ * aggregates still respect the full window. The analytics bar chart renders
+ * one bar per day so a year of bars is already well beyond any useful
+ * granularity — anything larger is just payload bloat and wasted layout
+ * work for the UI. Only applied on rolling (days-based) windows; explicit
+ * from/to ranges are user-chosen bounds and pass through uncapped.
+ */
+const PER_DAY_WINDOW_CAP_DAYS = 366;
+
+/**
+ * Build a series expression + narrowed WHERE clause for the per-day chart.
+ *
+ * Unlike {@link buildDateWindow}, this helper returns a `generate_series`
+ * expression plus an aligned inner WHERE so the gap-fill LEFT JOIN emits
+ * one row per day in the window even when zero rows were logged that day.
+ *
+ * Kept separate from buildDateWindow because other aggregates (summary,
+ * latency, by-source, getToolCounts, getTopQueries, getEmptyQueries) pin
+ * buildDateWindow's exact semantics and must not be affected by the
+ * gap-fill cap or series alignment.
+ *
+ * - Rolling mode: `generate_series((NOW() AT TIME ZONE 'UTC')::date -
+ *   (LEAST($days, 366) - 1), (NOW() AT TIME ZONE 'UTC')::date,
+ *   '1 day'::interval)` — UTC-normalized so the output matches
+ *   `date_trunc('day', created_at)::date` regardless of server TZ GUC.
+ *   The matching inner WHERE narrows to `created_at >= (NOW() AT TIME
+ *   ZONE 'UTC')::date - (LEAST($days, 366) - 1)` so rows outside the
+ *   gap-fill series can't leak into the inner aggregate.
+ * - Range mode: `generate_series($from::date, $to::date,
+ *   '1 day'::interval)` — uncapped; user explicitly chose bounds.
+ *
+ * `startIdx` is the next available `$` placeholder index; `nextIdx` is the
+ * next index to use after this helper's params.
+ */
+function buildPerDayWindow(
+  filter: AnalyticsFilter,
+  days: number,
+  startIdx: number,
+): {
+  seriesExpr: string;
+  whereClause: string;
+  params: unknown[];
+  nextIdx: number;
+} {
+  if (filter.from && filter.to) {
+    return {
+      seriesExpr: `generate_series($${startIdx}::date, $${startIdx + 1}::date, '1 day'::interval)`,
+      whereClause: `created_at >= $${startIdx} AND created_at <= $${startIdx + 1}`,
+      params: [filter.from, filter.to],
+      nextIdx: startIdx + 2,
+    };
+  }
+  // Rolling. Cap at PER_DAY_WINDOW_CAP_DAYS to bound payload size. LEAST()
+  // runs inside SQL (same parameter used for series + WHERE) so the two
+  // bounds can never drift.
+  const cappedExpr = `LEAST($${startIdx}, ${PER_DAY_WINDOW_CAP_DAYS})`;
+  return {
+    seriesExpr: `generate_series((NOW() AT TIME ZONE 'UTC')::date - (${cappedExpr} - 1), (NOW() AT TIME ZONE 'UTC')::date, '1 day'::interval)`,
+    whereClause: `created_at >= (NOW() AT TIME ZONE 'UTC')::date - (${cappedExpr} - 1)`,
+    params: [days],
+    nextIdx: startIdx + 1,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // Read
 // ---------------------------------------------------------------------------
@@ -373,26 +438,42 @@ export async function getAnalyticsSummary(
     [...fp4, ...dw4.params],
   );
 
-  // Per day (filtered). Excludes backfilled rows (latency_ms < 0) AND
-  // redacted rows (query_text = REDACTED_QUERY_TEXT) so the per-day bars
+  // Per day (filtered). LEFT JOIN against generate_series so every day in
+  // the window emits a row — even when zero queries were logged that day.
+  // Pre-fix, a plain GROUP BY silently dropped zero-count days, so sparse
+  // data rendered fewer bars than the window length ("Last 14 days" → 10
+  // bars on sparse data). See buildPerDayWindow for the series bounds.
+  //
+  // Inner subquery preserves the same filters as the pre-fix path:
+  // backfilled rows (latency_ms < 0) AND redacted rows
+  // (query_text = REDACTED_QUERY_TEXT) are excluded so the per-day bars
   // match the summary/latency aggregates above AND the top-queries /
   // empty-queries tables below — all of which filter redacted out.
+  //
+  // dayWhere filters live ONLY on the inner subquery. Applying them on the
+  // outer LEFT JOIN would turn it back into an inner join and re-drop the
+  // zero-count days the gap-fill exists to surface.
   const { clauses: fc5, params: fp5, nextIdx: n5 } = buildFilterClauses(filter);
-  const dw5 = buildDateWindow(filter, days, n5);
-  const redactedIdx5 = dw5.nextIdx;
+  const pdw = buildPerDayWindow(filter, days, n5);
+  const redactedIdx5 = pdw.nextIdx;
   const dayBase = [
-    ...dw5.clauses,
+    pdw.whereClause,
     "latency_ms >= 0",
     `query_text != $${redactedIdx5}`,
   ];
   const dayWhere = whereAnd(dayBase, fc5);
   const perDayRes = await pool.query(
-    `SELECT date_trunc('day', created_at)::date::text AS day, count(*)::int AS count
-    FROM query_log
-    ${dayWhere}
-    GROUP BY day
-    ORDER BY day`,
-    [...fp5, ...dw5.params, REDACTED_QUERY_TEXT],
+    `SELECT to_char(d.day, 'YYYY-MM-DD') AS day,
+            COALESCE(q.count, 0)::int AS count
+     FROM ${pdw.seriesExpr} AS d(day)
+     LEFT JOIN (
+       SELECT date_trunc('day', created_at)::date AS day, count(*)::int AS count
+       FROM query_log
+       ${dayWhere}
+       GROUP BY day
+     ) q ON q.day = d.day::date
+     ORDER BY d.day`,
+    [...fp5, ...pdw.params, REDACTED_QUERY_TEXT],
   );
 
   const totalQueries = totalRes.rows[0]?.count ?? 0;

--- a/src/db/client.ts
+++ b/src/db/client.ts
@@ -236,3 +236,38 @@ export async function closePool(): Promise<void> {
     await p.end();
   }
 }
+
+// ---------------------------------------------------------------------------
+// Test-only hooks (NOT part of the public API)
+// ---------------------------------------------------------------------------
+//
+// These exports let tests swap the module-level pool with a pg.Pool-shaped
+// stand-in (for example a PGlite-backed wrapper like the one in
+// initializePGlite above) without touching DATABASE_URL or spinning up a
+// real Postgres. Production code MUST NOT import these.
+//
+// The double-underscore prefix signals "test-only" — it is the only contract
+// we have short of splitting the module; any production use is a bug.
+
+/**
+ * Test-only: replace the module-level singleton with an override so the next
+ * and all subsequent getPool() calls return it. Does not close the existing
+ * pool — tests own lifecycle management and should tear down their override
+ * via __resetPoolForTesting() in afterAll/afterEach.
+ *
+ * Accepts anything pg.Pool-shaped; in practice tests pass a minimal
+ * { query, connect, end } wrapper around PGlite. The cast is intentional so
+ * tests don't have to fabricate unused pg.Pool methods (on(), totalCount,
+ * etc.) just to satisfy the type.
+ */
+export function __setPoolForTesting(override: unknown): void {
+  pool = override as pg.Pool;
+}
+
+/**
+ * Test-only: drop the override so the next getPool() call falls back to
+ * constructing a real pool from DATABASE_URL (or throws if unset).
+ */
+export function __resetPoolForTesting(): void {
+  pool = null;
+}


### PR DESCRIPTION
Consolidated fix for the analytics dashboard time-window bug report ("selecting a non-7-day window doesn't update the chart/pie/cards"). Three related concerns rolled into one PR with commits grouped by area.

## Summary

### Backend (src/db/analytics.ts)
- Rewrite per-day chart SQL to `LEFT JOIN generate_series` so days with zero queries render as zero-height bars (was: silently omitted).
- Align all rolling aggregates to UTC calendar days via `buildDateWindow`, eliminating sum(bars) ≠ total_queries_window drift at rolling-window edges.
- Cap rolling windows at 366 days to bound payload for `days=100000` API callers.
- UTC-safe cast on range-mode series bounds (`($from::timestamptz AT TIME ZONE 'UTC')::date`) so labels don't shift on non-UTC Postgres sessions.
- New `earliest_query_day: string | null` field on `AnalyticsSummary` (unfiltered `MIN(created_at)`) so the UI can surface true data depth.
- Test-only pool injection hooks (`__setPoolForTesting` / `__resetPoolForTesting`) to enable PGlite-backed integration tests.

### Frontend URL persistence (docs/analytics.html)
- Mirror the selected window (preset days / Today / from-to range) into the URL as `?days=N` or `?from=ISO&to=ISO` via `history.replaceState`.
- Parse and apply these params on mount via `applyUrlWindowOnMount`; rewrite the URL to reflect the effective state after clamping or fallback.
- Persist drill-down clicks on the daily chart (previously updated state but not URL).
- Switch `parseISODate` / round-trip validation to UTC to match server-side UTC comparison.
- Allow dates up to today + 1 UTC day so UTC+ timezone users (Tokyo, Sydney) can deep-link their local "today".
- Align `URL_MAX_DAYS` with `ALL_TIME_DAYS` (99999); preserve `?preview=1` and other non-window params.

### Data-availability label (docs/analytics.html)
- When requested window > actual data depth, show a "showing N days of data" subtext next to the date pill so users understand why bumping 7d → 14d → 30d on a fresh install produces identical values.

## Test plan
- [x] `npm run build` clean (tsc)
- [x] `npm test` — 3232/3232 passing
- [x] Red-green regression tests added for every behavioral change:
  - Gap-fill rolling/range UTC correctness; non-UTC session TZ
  - 366-day cap sum-invariant
  - URL mount from `?days=` / `?from=&to=`, invalid input fallback, drill-down URL write
  - `today_UTC + 1` eastern-TZ acceptance; `today_UTC + 2` still rejected
  - Preview-mode URL preservation
  - `earliest_query_day` backend presence; UI label appears/hides correctly
- [ ] Manual browser verification on local dev server post-merge

## Behavioral notes
- Rolling window semantic shifts from "last N×24h" to "last N UTC calendar days including today". All aggregates (summary, latency, by-source, top/empty/tool counts) inherit.
- 366-day cap now applies symmetrically across all rolling aggregates; direct API callers passing `days > 366` will see capped results.
- Fresh visits to `/analytics` now get `?days=7` appended so refresh preserves the default selection.
- `shortDateFmt` on the custom-range pill now uses `timeZone: "UTC"` to match the UTC-first UI semantics.