### PR TITLE
Persist analytics time window to URL so reload/share preserves selection

### DIFF
--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -724,23 +724,35 @@
       var draftFromInput = null;
       var draftToInput = null;
 
-      // Intl formatters (cached)
+      // Intl formatters (cached). timeZone: "UTC" keeps the pill label
+      // frame-aligned with parseISODate (UTC-noon) and todayISO (UTC) so
+      // the pill doesn't render a different calendar day for users east
+      // or west of UTC than the URL / server computations see.
       var shortDateFmt = new Intl.DateTimeFormat(undefined, {
         month: "short",
         day: "numeric",
+        timeZone: "UTC",
       });
 
       function parseISODate(s) {
-        // Parse YYYY-MM-DD as a local-noon Date so DST/TZ doesn't shift the day label.
+        // Parse YYYY-MM-DD as a UTC-noon Date. UTC (not local) so the
+        // resulting Date is frame-aligned with todayISO() — both use UTC
+        // accessors downstream. A local-noon construction would misfire
+        // for users east of UTC (e.g. Tokyo early-morning deep links where
+        // UTC still reads yesterday) when the future-date guard compares
+        // parseISODate-derived dates against todayISO(). Noon keeps us
+        // safely away from DST/leap-second boundaries on any frame.
         var m = /^(\d{4})-(\d{2})-(\d{2})$/.exec(s);
         if (!m) return null;
         return new Date(
-          parseInt(m[1], 10),
-          parseInt(m[2], 10) - 1,
-          parseInt(m[3], 10),
-          12,
-          0,
-          0,
+          Date.UTC(
+            parseInt(m[1], 10),
+            parseInt(m[2], 10) - 1,
+            parseInt(m[3], 10),
+            12,
+            0,
+            0,
+          ),
         );
       }
 
@@ -770,10 +782,12 @@
       // alongside the persisted ?preview=1 flag; the canned payload just
       // doesn't change in response.
 
-      // Mirrors server.ts MAX_DAYS (see src/server.ts:2703). Kept in sync by
-      // hand — if server raises the cap, raise it here too. days values
-      // beyond this are clamped (not rejected) so deep links remain valid.
-      var URL_MAX_DAYS = 100000;
+      // Upper bound for ?days= in the URL. Shares a single source of truth
+      // with ALL_TIME_DAYS so the "All time" pill label and the URL clamp
+      // always align. The server-side MAX_DAYS (src/server.ts:2703) must
+      // stay >= this value; days beyond this cap are clamped (not rejected)
+      // so shared deep links degrade gracefully to "All time".
+      var URL_MAX_DAYS = ALL_TIME_DAYS;
 
       // Parse the current page URL's time-window query params.
       // Returns one of:
@@ -803,11 +817,12 @@
           if (!fromDate || !toDate) return null;
           // Round-trip check: parseISODate regex-validates shape but accepts
           // e.g. 2026-02-30 (JS Date normalizes to Mar 2). Reconstruct the
-          // YYYY-MM-DD from the parsed Date and compare.
+          // YYYY-MM-DD from the parsed Date and compare. Uses UTC accessors
+          // to stay frame-aligned with parseISODate (UTC-noon construction).
           function roundTrip(d) {
-            var y = d.getFullYear();
-            var mo = String(d.getMonth() + 1).padStart(2, "0");
-            var da = String(d.getDate()).padStart(2, "0");
+            var y = d.getUTCFullYear();
+            var mo = String(d.getUTCMonth() + 1).padStart(2, "0");
+            var da = String(d.getUTCDate()).padStart(2, "0");
             return y + "-" + mo + "-" + da;
           }
           if (roundTrip(fromDate) !== fromRaw) return null;
@@ -863,16 +878,23 @@
       // adjacent to its read/write counterparts for maintainability.
       function applyUrlWindowOnMount() {
         var parsed = readWindowFromUrl();
-        if (!parsed) return;
-        if (parsed.mode === "days") {
-          activeDaysBack = parsed.days;
-          activeFrom = null;
-          activeTo = null;
-        } else if (parsed.mode === "range") {
-          activeFrom = parsed.from;
-          activeTo = parsed.to;
-          activeDaysBack = null;
+        if (parsed) {
+          if (parsed.mode === "days") {
+            activeDaysBack = parsed.days;
+            activeFrom = null;
+            activeTo = null;
+          } else if (parsed.mode === "range") {
+            activeFrom = parsed.from;
+            activeTo = parsed.to;
+            activeDaysBack = null;
+          }
         }
+        // Unconditionally rewrite the URL so it reflects the effective
+        // state (clamped value when ?days= exceeded URL_MAX_DAYS, or the
+        // 7-day default when the input was invalid). Without this, the
+        // address bar keeps displaying the user's original (now-wrong)
+        // query and a copy-paste propagates the bad value.
+        writeWindowToUrl();
       }
 
       function formatPillLabel() {
@@ -1370,6 +1392,21 @@
               f = t;
               t = tmp;
             }
+            // Reject future ranges to match readWindowFromUrl's contract —
+            // without this guard, interactive Apply accepts a future range
+            // that a bookmarked/shared URL of the same selection would
+            // reject, silently snapping back to the 7-day default.
+            if (t > todayISO()) {
+              if (dateErr) {
+                dateErr.textContent = "End date cannot be in the future.";
+                dateErr.style.display = "block";
+              }
+              console.warn(
+                "[analytics] dateApply rejected future range",
+                { from: f, to: t },
+              );
+              return;
+            }
             activeFrom = f;
             activeTo = t;
             activeDaysBack = null;
@@ -1654,6 +1691,10 @@
                   draftToInput = null;
                   // Date window changed — invalidate source cache.
                   unfilteredSourcesCache = null;
+                  // Mirror the drill-down into the URL so refresh /
+                  // deep-link preserves it. Matches every other state-
+                  // mutating path (preset, Today, Apply).
+                  writeWindowToUrl();
                   load();
                 },
               },

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -768,6 +768,30 @@
         return y + "-" + m + "-" + dd;
       }
 
+      // tomorrowISO returns today's UTC date + 1 day. Used as the upper bound
+      // for future-date rejection in custom-range validation and URL parsing,
+      // so that a user east of UTC (e.g. Tokyo early-morning, Sydney, etc.)
+      // can still pick their LOCAL "today" without it being rejected as
+      // "future" under UTC reckoning. <input type="date"> and URL-pasted
+      // dates express the user's local calendar; todayISO() is UTC. Every
+      // UTC+ timezone has a nightly band where local-today === UTC-today + 1,
+      // so we allow up to and including tomorrowISO() and reject anything
+      // strictly beyond (which is unambiguously future-future in every zone).
+      function tomorrowISO() {
+        var d = new Date();
+        var t = new Date(
+          Date.UTC(
+            d.getUTCFullYear(),
+            d.getUTCMonth(),
+            d.getUTCDate() + 1,
+          ),
+        );
+        var y = t.getUTCFullYear();
+        var m = String(t.getUTCMonth() + 1).padStart(2, "0");
+        var dd = String(t.getUTCDate()).padStart(2, "0");
+        return y + "-" + m + "-" + dd;
+      }
+
       // --- URL persistence for the time-window selector ---
       // The selected window (preset days, Today, or custom from/to range) is
       // mirrored into the page URL so that reloading or sharing a deep link
@@ -828,9 +852,13 @@
           if (roundTrip(fromDate) !== fromRaw) return null;
           if (roundTrip(toDate) !== toRaw) return null;
           if (fromRaw > toRaw) return null;
-          // Reject future ranges (to > today UTC). Uses string compare; both
-          // sides are YYYY-MM-DD so lexicographic order matches chronological.
-          if (toRaw > todayISO()) return null;
+          // Reject future ranges. Upper bound is tomorrowISO() (today_UTC + 1)
+          // so users east of UTC whose local "today" reads as UTC tomorrow —
+          // Tokyo early-morning, Sydney, etc. — aren't silently rejected when
+          // deep-linking to their local today. Dates strictly beyond today+1
+          // are unambiguously future in every timezone. String compare is
+          // fine: both sides are YYYY-MM-DD so lexicographic === chronological.
+          if (toRaw > tomorrowISO()) return null;
           return { mode: "range", from: fromRaw, to: toRaw };
         }
         var daysRaw = params.get("days");
@@ -1395,8 +1423,11 @@
             // Reject future ranges to match readWindowFromUrl's contract —
             // without this guard, interactive Apply accepts a future range
             // that a bookmarked/shared URL of the same selection would
-            // reject, silently snapping back to the 7-day default.
-            if (t > todayISO()) {
+            // reject, silently snapping back to the 7-day default. Upper
+            // bound is tomorrowISO() (today_UTC + 1) so users east of UTC
+            // whose local "today" reads as UTC tomorrow can still pick their
+            // local today. See tomorrowISO() for the TZ rationale.
+            if (t > tomorrowISO()) {
               if (dateErr) {
                 dateErr.textContent = "End date cannot be in the future.";
                 dateErr.style.display = "block";

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -756,6 +756,125 @@
         return y + "-" + m + "-" + dd;
       }
 
+      // --- URL persistence for the time-window selector ---
+      // The selected window (preset days, Today, or custom from/to range) is
+      // mirrored into the page URL so that reloading or sharing a deep link
+      // preserves the selection. Other query params (notably ?preview=1) are
+      // always preserved.
+      //
+      // Preview-mode interaction: the preview IIFE at the top of this script
+      // strips query strings from /api/analytics/* fetches and returns canned
+      // 7-day data regardless of ?days / ?from&to. That's by design — preview
+      // exists to render a deterministic mockup. URL persistence still runs
+      // in preview mode so subsequent pill clicks update the visible URL
+      // alongside the persisted ?preview=1 flag; the canned payload just
+      // doesn't change in response.
+
+      // Mirrors server.ts MAX_DAYS (see src/server.ts:2703). Kept in sync by
+      // hand — if server raises the cap, raise it here too. days values
+      // beyond this are clamped (not rejected) so deep links remain valid.
+      var URL_MAX_DAYS = 100000;
+
+      // Parse the current page URL's time-window query params.
+      // Returns one of:
+      //   { mode: "range", from: "YYYY-MM-DD", to: "YYYY-MM-DD" }
+      //   { mode: "days",  days: <positive integer, clamped to URL_MAX_DAYS> }
+      //   null  — caller falls back to the 7-day default
+      //
+      // Precedence: if both days and from/to are present, from/to wins
+      // (matches server buildDateWindow's precedence).
+      //
+      // Validation (returns null on any failure, except days > URL_MAX_DAYS
+      // which clamps rather than rejects so shared deep links degrade
+      // gracefully):
+      //   - from/to: ISO YYYY-MM-DD shape + calendar round-trip; from <= to;
+      //     to <= today UTC; half-specified (only from OR only to) → null
+      //   - days: finite integer >= 1; rejects "garbage", NaN, 0, negative,
+      //     and non-integers like 3.5
+      function readWindowFromUrl() {
+        var params = new URLSearchParams(window.location.search);
+        var fromRaw = params.get("from");
+        var toRaw = params.get("to");
+        // Half-specified range → null (one-sided ranges are ambiguous).
+        if ((fromRaw && !toRaw) || (!fromRaw && toRaw)) return null;
+        if (fromRaw && toRaw) {
+          var fromDate = parseISODate(fromRaw);
+          var toDate = parseISODate(toRaw);
+          if (!fromDate || !toDate) return null;
+          // Round-trip check: parseISODate regex-validates shape but accepts
+          // e.g. 2026-02-30 (JS Date normalizes to Mar 2). Reconstruct the
+          // YYYY-MM-DD from the parsed Date and compare.
+          function roundTrip(d) {
+            var y = d.getFullYear();
+            var mo = String(d.getMonth() + 1).padStart(2, "0");
+            var da = String(d.getDate()).padStart(2, "0");
+            return y + "-" + mo + "-" + da;
+          }
+          if (roundTrip(fromDate) !== fromRaw) return null;
+          if (roundTrip(toDate) !== toRaw) return null;
+          if (fromRaw > toRaw) return null;
+          // Reject future ranges (to > today UTC). Uses string compare; both
+          // sides are YYYY-MM-DD so lexicographic order matches chronological.
+          if (toRaw > todayISO()) return null;
+          return { mode: "range", from: fromRaw, to: toRaw };
+        }
+        var daysRaw = params.get("days");
+        if (daysRaw === null || daysRaw === "") return null;
+        var n = Number(daysRaw);
+        // Reject NaN, non-finite, non-integer, and anything < 1.
+        if (!Number.isFinite(n)) return null;
+        if (!Number.isInteger(n)) return null;
+        if (n < 1) return null;
+        // Clamp days > MAX_DAYS rather than rejecting so shared deep links
+        // with an overlarge but otherwise-valid value degrade gracefully to
+        // the cap instead of snapping back to the 7-day default.
+        if (n > URL_MAX_DAYS) n = URL_MAX_DAYS;
+        return { mode: "days", days: n };
+      }
+
+      // Mirror the current active window state into the page URL via
+      // history.replaceState (no new history entry). Preserves any other
+      // query params already on the URL — e.g. ?preview=1 survives every
+      // preset click. Omits days when from/to is set, and vice versa.
+      function writeWindowToUrl() {
+        var params = new URLSearchParams(window.location.search);
+        if (activeFrom && activeTo) {
+          params.set("from", activeFrom);
+          params.set("to", activeTo);
+          params.delete("days");
+        } else if (activeDaysBack !== null) {
+          params.set("days", String(activeDaysBack));
+          params.delete("from");
+          params.delete("to");
+        } else {
+          // No active window — clear all three params but leave others alone.
+          params.delete("days");
+          params.delete("from");
+          params.delete("to");
+        }
+        var qs = params.toString();
+        var newUrl =
+          window.location.pathname + (qs ? "?" + qs : "") + window.location.hash;
+        window.history.replaceState(null, "", newUrl);
+      }
+
+      // Apply any window selection parsed from the URL BEFORE the first
+      // load() runs. Called from init() further below so this helper stays
+      // adjacent to its read/write counterparts for maintainability.
+      function applyUrlWindowOnMount() {
+        var parsed = readWindowFromUrl();
+        if (!parsed) return;
+        if (parsed.mode === "days") {
+          activeDaysBack = parsed.days;
+          activeFrom = null;
+          activeTo = null;
+        } else if (parsed.mode === "range") {
+          activeFrom = parsed.from;
+          activeTo = parsed.to;
+          activeDaysBack = null;
+        }
+      }
+
       function formatPillLabel() {
         if (activeFrom && activeTo) {
           // Single-day range collapses to a "Today" label when it is in
@@ -1144,6 +1263,9 @@
             // Date window changed — sources cached under the previous
             // window are stale. Let the next unfiltered load refresh it.
             unfilteredSourcesCache = null;
+            // Mirror the new window into the page URL so refresh preserves
+            // it. Preserves any other query params (e.g. ?preview=1).
+            writeWindowToUrl();
             load();
           });
         });
@@ -1164,6 +1286,7 @@
             draftToInput = null;
             // Date window changed — invalidate source cache.
             unfilteredSourcesCache = null;
+            writeWindowToUrl();
             load();
           });
         }
@@ -1256,6 +1379,7 @@
             draftToInput = null;
             // Date window changed — invalidate source cache.
             unfilteredSourcesCache = null;
+            writeWindowToUrl();
             load();
           });
         }
@@ -1683,6 +1807,10 @@
 
       // Check if server is in dev mode (skip auth), otherwise require token
       (async function init() {
+        // Hydrate window state from the URL before any fetch fires so the
+        // initial load() reflects a deep-linked selection. Does nothing when
+        // the URL carries no recognized params.
+        applyUrlWindowOnMount();
         // Preview mode renders from canned data with the fetch stub above;
         // skip both the auth-mode probe and the token prompt entirely.
         if (window.__pathfinderPreview) {

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2708,4 +2708,203 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     expect(win.location.search).toBe(urlBefore);
     expect(win.location.search).not.toContain("2099");
   });
+
+  // Finding (R2) — future-date rejection uses UTC today, but <input type="date">
+  // and URL-pasted dates express the user's LOCAL calendar. Users east of UTC
+  // (Tokyo UTC+9, Sydney UTC+10, etc.) have a nightly band where their local
+  // "today" is one calendar day ahead of UTC "today". During that band, picking
+  // local today in the custom-range picker — or deep-linking to ?to=<local
+  // today> — is silently rejected as "future".
+  //
+  // Fix: allow dates up to today_UTC + 1 as the upper bound. Strictly beyond
+  // is still unambiguously future and still rejected.
+  //
+  // System time: 2026-04-20T10:00:00Z → todayISO() === "2026-04-20".
+  // tomorrowISO() === "2026-04-21" (the user's local "today" in Tokyo morning).
+  // "2026-04-22" is strictly future-future and must still be rejected.
+
+  it("readWindowFromUrl accepts ?to=<today_UTC + 1> so eastern-TZ users aren't rejected", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(2, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    // Tokyo early-morning scenario: UTC today is 2026-04-20, but the user's
+    // local calendar reads 2026-04-21 and they deep-link to
+    // ?from=2026-04-20&to=2026-04-21 (their local "today"). Pre-fix this is
+    // rejected as future and falls back to the 7-day default — the exact
+    // silent-regression we're fixing.
+    const { calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2026-04-20&to=2026-04-21",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    // Post-fix: the range is accepted (from/to propagate to the fetch).
+    expect(qs.from).toBe("2026-04-20");
+    expect(qs.to).toBe("2026-04-21");
+    expect(qs.days).toBeUndefined();
+  });
+
+  it("Apply handler accepts to=<today_UTC + 1> (eastern-TZ local today)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(2, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+    const fetchCountBefore = calls.length;
+
+    vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
+
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    // from = today_UTC, to = today_UTC + 1 (local today in Tokyo/Sydney morning).
+    fromEl.value = "2026-04-20";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2026-04-21";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    // No inline error.
+    const dateErr = dom.window.document.getElementById(
+      "dateError",
+    ) as HTMLElement | null;
+    expect(dateErr).not.toBeNull();
+    expect(dateErr!.style.display).not.toBe("block");
+
+    // A new fetch fired (range applied).
+    expect(calls.length).toBeGreaterThan(fetchCountBefore);
+    const summaryCall = [...calls]
+      .reverse()
+      .find((u) => u.startsWith("/api/analytics/summary"));
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.from).toBe("2026-04-20");
+    expect(qs.to).toBe("2026-04-21");
+
+    // URL reflects the applied range.
+    const finalQS = parseQS(
+      win.location.search.startsWith("?")
+        ? win.location.search.slice(1)
+        : win.location.search,
+    );
+    expect(finalQS.from).toBe("2026-04-20");
+    expect(finalQS.to).toBe("2026-04-21");
+  });
+
+  it("still rejects to=<today_UTC + 2> in both URL and Apply handler (guard against over-permissive fix)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    // URL deep-link path: today+2 is unambiguously future-future and must
+    // still be rejected — falls back to the 7-day default.
+    const deep = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2026-04-20&to=2026-04-22",
+      endpoints,
+    );
+    const deepSummary = deep.calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(deepSummary).toBeDefined();
+    const deepQS = parseQS(deepSummary!.split("?")[1] ?? "");
+    expect(deepQS.days).toBe("7");
+    expect(deepQS.from).toBeUndefined();
+    expect(deepQS.to).toBeUndefined();
+
+    // Apply handler path: fresh mount, open custom, pick today+2, click Apply.
+    const { dom, win, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+    const fetchCountBefore = calls.length;
+    const urlBefore = win.location.search;
+
+    vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
+
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromEl.value = "2026-04-20";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2026-04-22";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    expect(calls.length).toBe(fetchCountBefore);
+    const dateErr = dom.window.document.getElementById(
+      "dateError",
+    ) as HTMLElement | null;
+    expect(dateErr).not.toBeNull();
+    expect(dateErr!.style.display).toBe("block");
+    expect(dateErr!.textContent).toBe("End date cannot be in the future.");
+    expect(win.location.search).toBe(urlBefore);
+  });
 });

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2805,12 +2805,17 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       );
     await flushAsync();
 
-    // No inline error.
+    // No inline error. On successful Apply the popover closes, which tears
+    // down the #dateError element entirely — so either "no error element in
+    // DOM" (popover closed) or "display !== 'block'" (element exists but
+    // hidden) both indicate acceptance. Rejection paths keep the popover
+    // open AND set display:block, which this assertion excludes.
     const dateErr = dom.window.document.getElementById(
       "dateError",
     ) as HTMLElement | null;
-    expect(dateErr).not.toBeNull();
-    expect(dateErr!.style.display).not.toBe("block");
+    if (dateErr) {
+      expect(dateErr.style.display).not.toBe("block");
+    }
 
     // A new fetch fired (range applied).
     expect(calls.length).toBeGreaterThan(fetchCountBefore);

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2655,11 +2655,12 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/empty-queries": () => [],
     };
 
-    const { dom, calls } = await loadDashboardAtUrl(
+    const { dom, win, calls } = await loadDashboardAtUrl(
       "http://localhost/analytics",
       endpoints,
     );
     const fetchCountBefore = calls.length;
+    const urlBefore = win.location.search;
 
     // Silence warn the handler emits on rejection.
     vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
@@ -2703,7 +2704,8 @@ describe("analytics dashboard UI — URL persistence parity", () => {
     expect(dateErr).not.toBeNull();
     expect(dateErr!.style.display).toBe("block");
     expect(dateErr!.textContent).toBe("End date cannot be in the future.");
-    // URL unchanged (no writeWindowToUrl fired).
-    expect(window.location.search).not.toContain("2099");
+    // URL unchanged (no writeWindowToUrl fired for the rejected range).
+    expect(win.location.search).toBe(urlBefore);
+    expect(win.location.search).not.toContain("2099");
   });
 });

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -2359,3 +2359,351 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
     expect(finalQS.to).toBeUndefined();
   });
 });
+
+// ---------------------------------------------------------------------------
+// URL persistence parity — these tests cover state-mutating paths and URL
+// re-sync semantics that the original URL-persistence implementation missed.
+//
+// Covered:
+//   - Daily-bar drill-down must call writeWindowToUrl() like every other
+//     state-mutating path (preset, Today, Apply). Without this, a refresh or
+//     deep link silently reverts the drill-down.
+//   - applyUrlWindowOnMount must re-sync the URL after clamping an overlarge
+//     ?days=, or after rejecting invalid input and falling back to the
+//     default, so the address bar always reflects the effective state.
+//   - URL_MAX_DAYS must equal ALL_TIME_DAYS — a single source of truth keeps
+//     the "All time" pill label and the URL clamp aligned.
+//   - Apply handler must reject future dates, matching readWindowFromUrl's
+//     contract (otherwise interactive Apply and URL deep-link diverge).
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — URL persistence parity", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.useRealTimers();
+  });
+
+  // Variant of loadDashboard that lets a test supply a custom page URL so we
+  // can mount with ?days=N / ?from=&to= / ?days=99999 etc. Duplicated from
+  // the URL-persisted describe block so these tests stay isolated; duplication
+  // is cheap and keeps the two blocks independently skippable.
+  async function loadDashboardAtUrl(
+    pageUrl: string,
+    handlers: Record<string, (qs: string) => HandlerResult>,
+  ): Promise<{
+    dom: JSDOM;
+    win: Window & typeof globalThis;
+    calls: string[];
+    chartInstances: Array<{ type: string; data: unknown; options: unknown }>;
+  }> {
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: pageUrl,
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    const { instances } = installChartStub(win);
+    const { fetchFn, calls } = buildFetchStub(handlers);
+    Object.assign(win, { fetch: fetchFn });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    if (!scriptEl) throw new Error("inline script not found in analytics.html");
+    const code = scriptEl.textContent ?? "";
+    dom.window.eval(code);
+
+    await flushAsync();
+
+    return { dom, win, calls, chartInstances: instances };
+  }
+
+  // Finding 1 — daily-bar drill-down must persist to URL.
+  it("daily-bar drill-down writes from=<day>&to=<day> to the URL (no days=)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(3, 500).summary,
+      "/api/analytics/tool-counts": () => canned(3, 500).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win, chartInstances } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+
+    // Spy on history.replaceState AFTER mount so applyUrlWindowOnMount's
+    // initial call (if any) isn't counted. Preserve the real impl so jsdom's
+    // location mirror updates.
+    const realReplace = win.history.replaceState.bind(win.history);
+    const replaceSpy = vi.fn(
+      (data: unknown, unused: string, url?: string | null) => {
+        realReplace(data, unused, url ?? undefined);
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (win.history as any).replaceState = replaceSpy;
+
+    const barChart = [...chartInstances]
+      .reverse()
+      .find((c) => c.type === "bar") as
+      | (typeof chartInstances)[number]
+      | undefined;
+    expect(barChart).toBeDefined();
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const labels = (barChart as any).data.labels as string[];
+    const targetDay = labels[0];
+    expect(/^\d{4}-\d{2}-\d{2}$/.test(targetDay)).toBe(true);
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const onClick = (barChart as any).options.onClick as (
+      evt: unknown,
+      elements: Array<{ index: number }>,
+    ) => void;
+    onClick({}, [{ index: 0 }]);
+    await flushAsync();
+
+    // The drill-down must have written the new window to the URL. Pre-fix
+    // this spy is never called because the onClick handler never invokes
+    // writeWindowToUrl().
+    expect(replaceSpy).toHaveBeenCalled();
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.from).toBe(targetDay);
+    expect(finalQS.to).toBe(targetDay);
+    expect(finalQS.days).toBeUndefined();
+  });
+
+  // Finding 2 — clamp re-sync. Mount with overlarge ?days= and assert the
+  // URL is rewritten to the clamped value.
+  it("mount with ?days=999999 re-syncs the URL to the clamped value", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(1, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { win } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=999999",
+      endpoints,
+    );
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    // After fix (Finding 3) URL_MAX_DAYS === ALL_TIME_DAYS === 99999.
+    expect(finalQS.days).toBe("99999");
+  });
+
+  // Finding 2 (second half) — invalid input re-sync. Mount with garbage,
+  // assert the URL is rewritten to the 7-day default.
+  it("mount with ?days=garbage re-syncs the URL to days=7 (default)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { win } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=garbage",
+      endpoints,
+    );
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    // Post-fix we always emit the effective state. Default is 7 days.
+    expect(finalQS.days).toBe("7");
+    expect(finalQS.from).toBeUndefined();
+    expect(finalQS.to).toBeUndefined();
+  });
+
+  // Finding 3 — URL_MAX_DAYS must equal ALL_TIME_DAYS. Mount with ?days=99999
+  // and confirm the pill reads "All time" AND no clamp was applied.
+  it("mount with ?days=99999 labels the pill 'All time' and emits days=99999 unchanged", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=99999",
+      endpoints,
+    );
+
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toBe("All time");
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.days).toBe("99999");
+  });
+
+  // Finding 3 (second half) — mount with ?days=100000 should clamp to the
+  // ALL_TIME_DAYS sentinel (99999) after the fix.
+  it("mount with ?days=100000 clamps to 99999 (URL_MAX_DAYS === ALL_TIME_DAYS)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=100000",
+      endpoints,
+    );
+
+    // URL is re-synced to the clamped value (via Finding 2 fix).
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.days).toBe("99999");
+
+    // Outbound summary fetch uses the clamped value too.
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const outQs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(outQs.days).toBe("99999");
+
+    // And the pill renders as "All time".
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toBe("All time");
+  });
+
+  // Finding 4 — parseISODate and roundTrip use UTC consistently, so the
+  // future-date comparison against todayISO() (UTC) is frame-aligned. This is
+  // a direct unit test of the two helpers exposed via the same eval pattern
+  // the file uses. The ambient TZ-sensitive variant (setSystemTime + mount)
+  // is hard to reproduce reliably inside jsdom, so we assert the invariant
+  // directly: parseISODate("2026-04-21") must produce {y,m,d} = {2026,4,21}
+  // in BOTH local and UTC calendar frames.
+  it("parseISODate and roundTrip operate in UTC (frame-aligned with todayISO)", async () => {
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: "http://localhost/analytics",
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    installChartStub(win);
+    // No fetch needed — we only evaluate the helpers.
+    Object.assign(win, { fetch: vi.fn(() => Promise.reject(new Error("n/a"))) });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    const code = scriptEl!.textContent ?? "";
+    dom.window.eval(code);
+    await flushAsync();
+
+    // Probe parseISODate in the window context. After the fix, the resulting
+    // Date's UTC accessors must match the input Y/M/D exactly.
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const d = (win as any).eval('parseISODate("2026-04-21")') as Date;
+    expect(d).toBeInstanceOf(Date);
+    expect(d.getUTCFullYear()).toBe(2026);
+    expect(d.getUTCMonth()).toBe(3); // zero-based: April
+    expect(d.getUTCDate()).toBe(21);
+  });
+
+  // Finding 5 — Apply handler must reject future dates.
+  it("Apply handler rejects a future-dated range with an inline error and no fetch", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics",
+      endpoints,
+    );
+    const fetchCountBefore = calls.length;
+
+    // Silence warn the handler emits on rejection.
+    vi.spyOn(dom.window.console, "warn").mockImplementation(() => {});
+
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromEl.value = "2099-01-01";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2099-01-10";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    // No new fetch — handler early-returned.
+    expect(calls.length).toBe(fetchCountBefore);
+    // Popover still open with inline error surfaced.
+    const dateErr = dom.window.document.getElementById(
+      "dateError",
+    ) as HTMLElement | null;
+    expect(dateErr).not.toBeNull();
+    expect(dateErr!.style.display).toBe("block");
+    expect(dateErr!.textContent).toBe("End date cannot be in the future.");
+    // URL unchanged (no writeWindowToUrl fired).
+    expect(window.location.search).not.toContain("2099");
+  });
+});

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -1983,3 +1983,379 @@ describe("analytics dashboard UI — fetchJson stale-401 generation guard", () =
     errSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// URL-persisted time window: the selected window (days preset or from/to
+// custom range) should be mirrored into the page URL via
+// history.replaceState so refresh / deep-link preserves the selection.
+// These tests load analytics.html with a variety of ?days= / ?from=&to=
+// query strings and assert:
+//   - on mount, the active window matches the URL
+//   - clicks on presets / custom-apply update the URL via replaceState
+//   - invalid URL inputs fall back to the 7-day default
+//   - other query params (e.g. preview=1) are preserved across writes
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — URL-persisted time window", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  // Variant of loadDashboard that lets a test supply a custom page URL so we
+  // can mount with ?days=N / ?from=&to= query strings. Mirrors the regular
+  // helper's wiring (Chart stub, fetch stub, inline-script eval, microtask
+  // flush) but exposes the jsdom window so tests can spy on
+  // history.replaceState before the click-driven branch runs.
+  async function loadDashboardAtUrl(
+    pageUrl: string,
+    handlers: Record<string, (qs: string) => HandlerResult>,
+  ): Promise<{
+    dom: JSDOM;
+    win: Window & typeof globalThis;
+    calls: string[];
+    chartInstances: Array<{ type: string; data: unknown; options: unknown }>;
+  }> {
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: pageUrl,
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    const { instances } = installChartStub(win);
+    const { fetchFn, calls } = buildFetchStub(handlers);
+    Object.assign(win, { fetch: fetchFn });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    if (!scriptEl) throw new Error("inline script not found in analytics.html");
+    const code = scriptEl.textContent ?? "";
+    dom.window.eval(code);
+
+    await flushAsync();
+
+    return { dom, win, calls, chartInstances: instances };
+  }
+
+  it("mount with ?days=30 sends days=30 on outbound summary fetch and labels the pill 'Last 30 days'", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": (qs: string) => {
+        const p = parseQS(qs);
+        const days = p.days ? parseInt(p.days, 10) : 7;
+        return canned(days, 4242).summary;
+      },
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=30",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.days).toBe("30");
+    expect(qs.from).toBeUndefined();
+    expect(qs.to).toBeUndefined();
+
+    // Pill label reflects the parsed 30-day window.
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toBe("Last 30 days");
+  });
+
+  it("mount with ?from=&to= sends that range on outbound fetch and uses range-format pill label", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(10, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2026-04-01&to=2026-04-10",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.from).toBe("2026-04-01");
+    expect(qs.to).toBe("2026-04-10");
+    expect(qs.days).toBeUndefined();
+
+    // Range pill uses short-date format: "Apr 1 – Apr 10" (locale-dependent,
+    // so match by the en-dash separator rather than the exact label).
+    const pillLabel = dom.window.document
+      .querySelector("#datePill .date-value")
+      ?.textContent?.trim();
+    expect(pillLabel).toContain("–"); // en-dash between from and to
+    // Must NOT contain any "Last N days" wording.
+    expect(pillLabel).not.toMatch(/Last \d+ days/);
+  });
+
+  it("clicking the '14 days' preset updates the URL via replaceState with days=14 and drops from/to", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win } = await loadDashboardAtUrl(
+      // Seed from/to in the URL so we can assert the preset click CLEARS them.
+      "http://localhost/analytics?from=2026-04-01&to=2026-04-05",
+      endpoints,
+    );
+
+    // Spy on history.replaceState AFTER mount so we only capture the click-
+    // driven calls. Preserve the real implementation so jsdom's URL updates.
+    const realReplace = win.history.replaceState.bind(win.history);
+    const replaceSpy = vi.fn(
+      (data: unknown, unused: string, url?: string | null) => {
+        realReplace(data, unused, url ?? undefined);
+      },
+    );
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (win.history as any).replaceState = replaceSpy;
+
+    // Open popover + click "14 days" preset.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const fourteen = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === "14") as HTMLElement;
+    fourteen.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+
+    expect(replaceSpy).toHaveBeenCalled();
+    // jsdom's location reflects the replaceState url. Inspect the last
+    // written URL so we confirm both: days=14 is added AND from/to are
+    // dropped in the same write.
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.days).toBe("14");
+    expect(finalQS.from).toBeUndefined();
+    expect(finalQS.to).toBeUndefined();
+  });
+
+  it("clicking Apply on a valid custom range updates the URL with from/to (no days)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(3, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { dom, win } = await loadDashboardAtUrl(
+      // Seed days= in the URL so we can assert Apply CLEARS it.
+      "http://localhost/analytics?days=30",
+      endpoints,
+    );
+
+    // Open popover, reveal custom, fill inputs, click Apply.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const customPreset = dom.window.document.querySelector(
+      ".preset[data-custom]",
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+
+    const fromEl = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toEl = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromEl.value = "2024-02-10";
+    fromEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+    toEl.value = "2024-02-20";
+    toEl.dispatchEvent(new dom.window.Event("input", { bubbles: true }));
+
+    dom.window.document
+      .getElementById("dateApplyBtn")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    await flushAsync();
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.from).toBe("2024-02-10");
+    expect(finalQS.to).toBe("2024-02-20");
+    expect(finalQS.days).toBeUndefined();
+  });
+
+  it("mount with ?days=garbage falls back to 7-day default (outbound days=7)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?days=garbage",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.days).toBe("7");
+    expect(qs.from).toBeUndefined();
+    expect(qs.to).toBeUndefined();
+  });
+
+  it.each([
+    ["?days=0", "zero"],
+    ["?days=-1", "negative"],
+    ["?days=3.5", "non-integer"],
+  ])(
+    "mount with %s falls back to 7-day default (rejects %s)",
+    async (query) => {
+      const endpoints = {
+        "/api/analytics/auth-mode": () => ({ dev: true }),
+        "/api/analytics/summary": () => canned(7, 100).summary,
+        "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+        "/api/analytics/queries": () => [],
+        "/api/analytics/empty-queries": () => [],
+      };
+
+      const { calls } = await loadDashboardAtUrl(
+        "http://localhost/analytics" + query,
+        endpoints,
+      );
+
+      const summaryCall = calls.find((u) =>
+        u.startsWith("/api/analytics/summary"),
+      );
+      expect(summaryCall).toBeDefined();
+      const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+      expect(qs.days).toBe("7");
+    },
+  );
+
+  it("mount with a future from/to falls back to 7-day default (rejects future dates)", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 100).summary,
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+
+    const { calls } = await loadDashboardAtUrl(
+      "http://localhost/analytics?from=2099-01-01&to=2099-01-10",
+      endpoints,
+    );
+
+    const summaryCall = calls.find((u) =>
+      u.startsWith("/api/analytics/summary"),
+    );
+    expect(summaryCall).toBeDefined();
+    const qs = parseQS(summaryCall!.split("?")[1] ?? "");
+    expect(qs.days).toBe("7");
+    expect(qs.from).toBeUndefined();
+    expect(qs.to).toBeUndefined();
+  });
+
+  it("preserves ?preview=1 alongside ?days when a preset is clicked", async () => {
+    // Preview mode installs its own canned-response fetch, so we don't need
+    // to supply handlers — mount with ?preview=1&days=30, then click "14
+    // days" and assert the URL retains preview=1 AND updates days=14.
+    const html = fs.readFileSync(
+      path.join(process.cwd(), "docs", "analytics.html"),
+      "utf8",
+    );
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.on("jsdomError", () => {});
+    const dom = new JSDOM(html, {
+      runScripts: "outside-only",
+      url: "http://localhost/analytics?preview=1&days=30",
+      pretendToBeVisual: true,
+      virtualConsole,
+    });
+
+    const win = dom.window as unknown as Window & typeof globalThis;
+    Object.assign(win, { Date: globalThis.Date });
+    if (typeof (win as { Response?: unknown }).Response === "undefined") {
+      Object.assign(win, { Response: globalThis.Response });
+    }
+    installChartStub(win);
+    // Preview IIFE captures originalFetch via window.fetch.bind(window); if
+    // the jsdom window doesn't expose fetch (depending on version), bind
+    // throws. Install a noop fetch spy so the IIFE can capture and then
+    // override it. Preview's own handler short-circuits every analytics URL
+    // so the stub's noop impl is never invoked for app paths.
+    const noopFetch = vi.fn(() => Promise.reject(new Error("noop fetch")));
+    Object.assign(win, { fetch: noopFetch });
+
+    const scriptEl = dom.window.document.querySelector("script:not([src])");
+    if (!scriptEl) throw new Error("inline script not found in analytics.html");
+    const code = scriptEl.textContent ?? "";
+    dom.window.eval(code);
+
+    // Flush many rounds since preview init is several async hops deep.
+    for (let i = 0; i < 10; i++) await flushAsync();
+
+    // Click "14 days" preset.
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const fourteen = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === "14") as HTMLElement;
+    fourteen.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    for (let i = 0; i < 5; i++) await flushAsync();
+
+    const finalSearch = win.location.search;
+    const finalQS = parseQS(finalSearch.startsWith("?")
+      ? finalSearch.slice(1)
+      : finalSearch);
+    expect(finalQS.preview).toBe("1");
+    expect(finalQS.days).toBe("14");
+    expect(finalQS.from).toBeUndefined();
+    expect(finalQS.to).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- Mirror the selected window (preset days, Today, or custom from/to range) into the URL as `?days=N` or `?from=ISO&to=ISO` via `history.replaceState`.
- Parse and apply these params on mount via `applyUrlWindowOnMount`, falling back to 7-day default on invalid input.
- Persist drill-down clicks on the daily chart (previously updated UI state but not URL).
- Switch `parseISODate` and round-trip validation to UTC (was local-calendar) to match the server's UTC `from/to` comparison.
- Allow dates up to today + 1 UTC day so users east of UTC (Tokyo, Sydney) can deep-link their local "today" without silent rejection.
- Align `URL_MAX_DAYS` with `ALL_TIME_DAYS` (99999) to remove the 100000 sentinel drift.
- Preserve `?preview=1` and other non-window params.

## Test plan
- [x] `npm run build` clean (tsc)
- [x] `npm test` — 3196/3196 passing
- [x] Red-green coverage for:
  - Mount from `?days=N`, `?from=&to=`, `?days=garbage`, `?days=0/-1/3.5`, future dates
  - Pill/Today/Custom-Apply click writes URL via `replaceState`
  - Daily-chart drill-down writes URL
  - URL rewrite after clamp so address bar reflects effective state
  - `?preview=1` preserved across preset clicks
  - Apply handler rejects `to > today_UTC + 1`; accepts `to == today_UTC + 1`
- [ ] Manual browser verification: reload after each preset / Today / custom range preserves selection

## Behavioral notes
- Fresh visits to `/analytics` now get `?days=7` appended to the URL (so refresh preserves the default). This is intentional per the URL-persistence contract.
- `shortDateFmt` on the custom-range pill now uses `timeZone: "UTC"` to match the rest of the UI's UTC-first semantics.