### PR TITLE
Show 'showing N days of data' label when window exceeds available data

### DIFF
--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -184,6 +184,11 @@
       .filter-row .filter-group.source-group {
         margin-left: auto;
       }
+      .filter-row .data-availability {
+        color: #64748b;
+        font-size: 0.74rem;
+        margin-left: 6px;
+      }
 
       /* Date range selector */
       .date-pill .date-value {
@@ -1023,6 +1028,72 @@
         }
         var customVisibleStyle = dateCustomMode ? "" : "display:none;";
 
+        // "Showing N days of data" subtext next to the date pill.
+        // Renders only when earliest_query_day is known AND the requested
+        // window strictly exceeds the actual data depth. Strict `>` means
+        // a same-size window (user picks 9-day range on a 9-day install)
+        // stays quiet — the plateau signal is specifically for the case
+        // where bumping 7d → 14d → 30d produces identical numbers.
+        var dataAvailabilityHtml = "";
+        if (currentEarliestQueryDay) {
+          var earliestDate = parseISODate(currentEarliestQueryDay);
+          if (earliestDate) {
+            // Compare as UTC-midnight dates so timezone offsets don't shift
+            // the day count. parseISODate returns a local-noon Date; using
+            // the numeric year/month/day back out via Date.UTC keeps the
+            // arithmetic timezone-neutral.
+            var earliestUTC = Date.UTC(
+              earliestDate.getFullYear(),
+              earliestDate.getMonth(),
+              earliestDate.getDate(),
+            );
+            var now = new Date();
+            var todayUTC = Date.UTC(
+              now.getUTCFullYear(),
+              now.getUTCMonth(),
+              now.getUTCDate(),
+            );
+            var MS_PER_DAY = 86400000;
+            var availableDays =
+              Math.floor((todayUTC - earliestUTC) / MS_PER_DAY) + 1;
+            var requestedDays = null;
+            if (activeFrom && activeTo) {
+              var fromDate = parseISODate(activeFrom);
+              var toDate = parseISODate(activeTo);
+              if (fromDate && toDate) {
+                var fromUTC = Date.UTC(
+                  fromDate.getFullYear(),
+                  fromDate.getMonth(),
+                  fromDate.getDate(),
+                );
+                var toUTC = Date.UTC(
+                  toDate.getFullYear(),
+                  toDate.getMonth(),
+                  toDate.getDate(),
+                );
+                requestedDays = Math.floor((toUTC - fromUTC) / MS_PER_DAY) + 1;
+              }
+            } else if (activeDaysBack !== null) {
+              requestedDays = activeDaysBack;
+            }
+            if (
+              typeof requestedDays === "number" &&
+              availableDays >= 1 &&
+              requestedDays > availableDays
+            ) {
+              var unit = availableDays === 1 ? "day" : "days";
+              dataAvailabilityHtml =
+                '<span class="data-availability" id="dataAvailability">' +
+                "showing " +
+                esc(String(availableDays)) +
+                " " +
+                unit +
+                " of data" +
+                "</span>";
+            }
+          }
+        }
+
         var dateHtml =
           "" +
           '<div class="filter-group date-group" id="dateGroup">' +
@@ -1066,6 +1137,7 @@
               "</div>" +
               "</div>"
             : "") +
+          dataAvailabilityHtml +
           "</div>";
 
         // Source group (right)
@@ -1288,6 +1360,12 @@
       // Cached so date-popover interactions can re-render without another fetch.
       var currentToolCounts = [];
       var currentSources = [];
+      // Earliest query_log day (YYYY-MM-DD) or null. Set from
+      // summary.earliest_query_day on each successful load(). Renders the
+      // "showing N days of data" subtext in the filter row when the
+      // requested window exceeds the actual data depth. Null = no data or
+      // server hasn't responded yet — skip the label entirely.
+      var currentEarliestQueryDay = null;
 
       // --- Main load ---
       async function load() {
@@ -1327,6 +1405,16 @@
 
           // Cache for non-fetching re-renders (e.g. toggling the date popover)
           currentToolCounts = toolCounts;
+          // Track earliest query day so renderFilters can decide whether the
+          // "showing N days of data" subtext belongs next to the date pill.
+          // Coerce anything other than a YYYY-MM-DD string to null so a
+          // malformed server response doesn't turn into "showing NaN days
+          // of data".
+          currentEarliestQueryDay =
+            typeof summary.earliest_query_day === "string" &&
+            /^\d{4}-\d{2}-\d{2}$/.test(summary.earliest_query_day)
+              ? summary.earliest_query_day
+              : null;
           // When NO filters are active, the summary.queries_by_source
           // reflects the full set. Snapshot it so that later, when a
           // tool-type or source filter shrinks the response, the source

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -1983,3 +1983,200 @@ describe("analytics dashboard UI — fetchJson stale-401 generation guard", () =
     errSpy.mockRestore();
   });
 });
+
+// ---------------------------------------------------------------------------
+// Data-availability label: when the requested window exceeds the actual
+// query_log depth, show "showing N days of data" next to the date pill so
+// users understand why bumping 7d → 14d → 30d produces identical numbers.
+// ---------------------------------------------------------------------------
+
+describe("analytics dashboard UI — data availability label", () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  /**
+   * Build a Date offset from today-UTC by N days and return YYYY-MM-DD.
+   * Positive N = days before today. Used so the canned `earliest_query_day`
+   * payloads line up with the frozen system time.
+   */
+  function daysBeforeTodayUTC(n: number): string {
+    const d = new Date();
+    d.setUTCDate(d.getUTCDate() - n);
+    const y = d.getUTCFullYear();
+    const m = String(d.getUTCMonth() + 1).padStart(2, "0");
+    const day = String(d.getUTCDate()).padStart(2, "0");
+    return `${y}-${m}-${day}`;
+  }
+
+  function makeSummaryEndpoint(earliest: string | null) {
+    return (qs: string) => {
+      const p = parseQS(qs);
+      const days = p.days ? parseInt(p.days, 10) : 7;
+      const base = canned(Math.min(days, 9), 1234).summary;
+      return { ...base, earliest_query_day: earliest };
+    };
+  }
+
+  function makeEndpoints(earliest: string | null) {
+    return {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": makeSummaryEndpoint(earliest),
+      "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+    };
+  }
+
+  async function clickPresetDays(dom: JSDOM, days: number): Promise<void> {
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const preset = Array.from(
+      dom.window.document.querySelectorAll(".preset[data-days]"),
+    ).find((el) => el.getAttribute("data-days") === String(days)) as
+      | HTMLElement
+      | undefined;
+    preset!.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+  }
+
+  async function clickTodayPreset(dom: JSDOM): Promise<void> {
+    dom.window.document
+      .getElementById("datePill")!
+      .dispatchEvent(
+        new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+      );
+    const todayPreset = dom.window.document.querySelector(
+      '.preset[data-preset="today"]',
+    ) as HTMLElement;
+    todayPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+  }
+
+  it("shows 'showing 9 days of data' when earliest is 8 days ago and window=14", async () => {
+    // earliest = today - 8 days → 9 days inclusive. Default window is 7,
+    // so switch to 14 before asserting.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(8);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickPresetDays(dom, 14);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    expect(label).not.toBeNull();
+    expect(label!.textContent!.trim()).toBe("showing 9 days of data");
+  });
+
+  it("hides the label when earliest is older than the requested window", async () => {
+    // earliest = 30 days ago, window = 14. availableDays (31) > requestedDays
+    // (14), so the label must NOT render — the user already sees all the
+    // data their window asked for.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(30);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickPresetDays(dom, 14);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    // Either absent or empty — both acceptable; assert a stable "no content"
+    // condition rather than pinning on element presence so minor DOM
+    // restructurings (container hide/show vs. removal) still pass.
+    if (label) {
+      expect(label.textContent!.trim()).toBe("");
+    }
+  });
+
+  it("hides the label when earliest_query_day is null (empty table)", async () => {
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const { dom } = await loadDashboard(makeEndpoints(null));
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    if (label) {
+      expect(label.textContent!.trim()).toBe("");
+    }
+  });
+
+  it("computes availableDays inclusively for explicit from/to range", async () => {
+    // Custom range spanning 10 UTC days, earliest 5 days ago → 6 days of
+    // data. Requested = 10, available = 6, label = "showing 6 days of data".
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(5);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+
+    // Open popover → enter custom mode → set from/to.
+    const datePill = dom.window.document.getElementById("datePill")!;
+    datePill.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    const customPreset = dom.window.document.querySelector(
+      '.preset[data-custom="1"]',
+    ) as HTMLElement;
+    customPreset.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    const fromInput = dom.window.document.getElementById(
+      "dateFromInput",
+    ) as HTMLInputElement;
+    const toInput = dom.window.document.getElementById(
+      "dateToInput",
+    ) as HTMLInputElement;
+    fromInput.value = "2026-04-11";
+    toInput.value = "2026-04-20";
+    const applyBtn = dom.window.document.getElementById(
+      "dateApplyBtn",
+    ) as HTMLElement;
+    applyBtn.dispatchEvent(
+      new dom.window.MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await flushAsync();
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    expect(label).not.toBeNull();
+    expect(label!.textContent!.trim()).toBe("showing 6 days of data");
+  });
+
+  it("hides the label for 'Today' when earliest is today (1 <= 1)", async () => {
+    // requestedDays = 1, availableDays = 1. Strict `>` comparison means
+    // equal windows don't trigger the label — only true plateaus do.
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(0); // today
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickTodayPreset(dom);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    if (label) {
+      expect(label.textContent!.trim()).toBe("");
+    }
+  });
+
+  it("pluralizes 'day' when availableDays === 1", async () => {
+    // earliest = today → 1 day of data, requested = 14 → label uses singular
+    // "day" not "days".
+    vi.useFakeTimers({ toFake: ["Date"] });
+    vi.setSystemTime(new Date("2026-04-20T10:00:00.000Z"));
+
+    const earliest = daysBeforeTodayUTC(0);
+    const { dom } = await loadDashboard(makeEndpoints(earliest));
+    await clickPresetDays(dom, 14);
+
+    const label = dom.window.document.getElementById("dataAvailability");
+    expect(label).not.toBeNull();
+    expect(label!.textContent!.trim()).toBe("showing 1 day of data");
+  });
+});

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -19,7 +19,11 @@ import {
 import type { QueryLogEntry } from "../db/analytics.js";
 
 beforeEach(() => {
-  vi.clearAllMocks();
+  // resetAllMocks (not clearAllMocks) so any queued `.mockResolvedValueOnce`
+  // implementations also clear between tests. A test that queues N mocks for
+  // one pool.query() call chain but the code only consumes M (<N) would
+  // otherwise leak the remaining N-M implementations into the next test.
+  vi.resetAllMocks();
 });
 
 // ---------------------------------------------------------------------------
@@ -184,6 +188,85 @@ describe("getAnalyticsSummary", () => {
     expect(result.p95_latency_ms_window).toBe(0);
     expect(result.queries_by_source).toEqual([]);
     expect(result.queries_per_day_window).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// earliest_query_day — data-availability probe for the UI
+//
+// The dashboard surfaces a "showing N days of data" subtext whenever the
+// requested window exceeds the actual query_log depth. To compute N the UI
+// needs the earliest row's date regardless of the current filter — picking a
+// 90-day window shouldn't hide the fact that data only stretches back 9 days.
+// The field is therefore sourced from an UNFILTERED MIN(created_at) query and
+// lives alongside the windowed aggregates on the same summary response.
+// ---------------------------------------------------------------------------
+
+describe("getAnalyticsSummary earliest_query_day", () => {
+  it("returns the earliest day from query_log as a YYYY-MM-DD string", async () => {
+    // 5 existing subqueries + 1 new earliest-day subquery (6th call).
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 1000 }] }) // total
+      .mockResolvedValueOnce({
+        rows: [{ total: 200, empty: 10, avg_latency: 45 }],
+      }) // windowed summary
+      .mockResolvedValueOnce({ rows: [] }) // latency rows
+      .mockResolvedValueOnce({ rows: [] }) // by source
+      .mockResolvedValueOnce({ rows: [] }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: "2026-04-12" }] }); // earliest day
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.earliest_query_day).toBe("2026-04-12");
+  });
+
+  it("returns null when query_log is empty", async () => {
+    // An empty query_log makes MIN(created_at) return NULL — surface that as
+    // `null` on the response so the UI can skip the label entirely rather
+    // than rendering "showing NaN days of data".
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 0, empty: 0, avg_latency: 0 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
+
+    const result = await getAnalyticsSummary();
+
+    expect(result.earliest_query_day).toBeNull();
+  });
+
+  it("queries the unfiltered earliest created_at (no filter/window applied)", async () => {
+    // The label describes data availability in absolute terms — picking a
+    // tool_type, source, or narrow from/to window must NOT change the reported
+    // earliest day. Verify the SQL for the earliest-day subquery has no WHERE
+    // clause and no filter params are bound to it.
+    mockQuery
+      .mockResolvedValueOnce({ rows: [{ count: 0 }] })
+      .mockResolvedValueOnce({
+        rows: [{ total: 0, empty: 0, avg_latency: 0 }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: "2026-03-01" }] });
+
+    await getAnalyticsSummary(
+      { tool_type: "search", source: "docs" },
+      30,
+    );
+
+    // Index 5 is the new earliest-day subquery (0=total, 1=summary, 2=latency,
+    // 3=by-source, 4=per-day, 5=earliest-day).
+    const [sql, params] = mockQuery.mock.calls[5];
+    expect(sql).toMatch(/min\(created_at/i);
+    expect(sql).toMatch(/FROM query_log/i);
+    expect(sql).not.toMatch(/WHERE/i);
+    // No filter or window params bound to the earliest-day query.
+    expect(params ?? []).toEqual([]);
   });
 });
 

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -154,7 +154,8 @@ describe("getAnalyticsSummary", () => {
           { day: "2026-04-10", count: 30 },
           { day: "2026-04-11", count: 25 },
         ],
-      }); // per day
+      }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: "2026-04-10" }] }); // earliest day
 
     const result = await getAnalyticsSummary();
 
@@ -179,7 +180,8 @@ describe("getAnalyticsSummary", () => {
       })
       .mockResolvedValueOnce({ rows: [] }) // empty latency rows
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
 
@@ -283,7 +285,8 @@ describe("p95 computation edge cases", () => {
       })
       .mockResolvedValueOnce({ rows: [{ latency_ms: 42 }] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
     expect(result.p95_latency_ms_window).toBe(42);
@@ -299,7 +302,8 @@ describe("p95 computation edge cases", () => {
         rows: Array.from({ length: 100 }, () => ({ latency_ms: 50 })),
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
     expect(result.p95_latency_ms_window).toBe(50);
@@ -315,7 +319,8 @@ describe("p95 computation edge cases", () => {
         rows: [{ latency_ms: 50 }, { latency_ms: 100 }],
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
 
     const result = await getAnalyticsSummary();
     // floor(2 * 0.95) = 1, sorted[1] = 100
@@ -634,7 +639,8 @@ describe("windowed aggregates exclude backfilled rows (latency_ms >= 0)", () => 
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("getAnalyticsSummary: all four windowed subqueries filter latency_ms >= 0", async () => {
@@ -694,7 +700,8 @@ describe("getAnalyticsSummary p95 latency row cap", () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("emits ORDER BY random() LIMIT on the latency subquery and binds P95_LATENCY_ROW_CAP", async () => {
@@ -736,7 +743,8 @@ describe("getAnalyticsSummary p95 latency row cap", () => {
         })),
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
     const result = await getAnalyticsSummary({});
     const logged = warnSpy.mock.calls.map((c) => c[0]).join("\n");
     expect(logged).toContain("[analytics]");
@@ -761,7 +769,8 @@ describe("getAnalyticsSummary p95 latency row cap", () => {
         rows: [{ latency_ms: 10 }, { latency_ms: 20 }, { latency_ms: 30 }],
       })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] });
     const result = await getAnalyticsSummary({});
     expect(result.p95_latency_sampled).toBeUndefined();
   });
@@ -776,7 +785,8 @@ describe("getAnalyticsSummary per-day excludes redacted rows", () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("per-day subquery filters query_text != REDACTED_QUERY_TEXT (consistency with top/empty)", async () => {
@@ -819,7 +829,8 @@ describe("getAnalyticsSummary with filters", () => {
       }) // windowed summary
       .mockResolvedValueOnce({ rows: [] }) // latency rows
       .mockResolvedValueOnce({ rows: [] }) // by source
-      .mockResolvedValueOnce({ rows: [] }); // per day
+      .mockResolvedValueOnce({ rows: [] }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("passes tool_type filter as LIKE clause to all queries", async () => {
@@ -967,7 +978,8 @@ describe("getAnalyticsSummary honors days window", () => {
       }) // windowed summary
       .mockResolvedValueOnce({ rows: [] }) // latency rows
       .mockResolvedValueOnce({ rows: [] }) // by source
-      .mockResolvedValueOnce({ rows: [] }); // per day
+      .mockResolvedValueOnce({ rows: [] }) // per day
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("passes the requested `days` value to every windowed subquery", async () => {
@@ -1023,7 +1035,8 @@ describe("getAnalyticsSummary with from/to range", () => {
       })
       .mockResolvedValueOnce({ rows: [] })
       .mockResolvedValueOnce({ rows: [] })
-      .mockResolvedValueOnce({ rows: [] });
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [{ earliest_day: null }] }); // earliest day
   }
 
   it("generates created_at >= / <= range clause and passes Date params", async () => {

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -59,6 +59,16 @@ export interface AnalyticsSummary {
   p95_latency_sampled?: boolean;
   queries_by_source: Array<{ source_name: string; count: number }>;
   queries_per_day_window: Array<{ day: string; count: number }>;
+  /**
+   * ISO UTC date (YYYY-MM-DD) of the oldest query_log row, or null if
+   * query_log is empty. Sourced from an UNFILTERED MIN(created_at) — no
+   * tool_type/source/days/from/to filters apply — because the UI uses
+   * this to label windows that exceed actual data depth (e.g. "showing
+   * 9 days of data" when the user picks a 30-day window on a 9-day
+   * install). Filter-dependent values would conflate "no data for this
+   * filter" with "no data at all".
+   */
+  earliest_query_day: string | null;
 }
 
 export interface TopQuery {
@@ -395,10 +405,32 @@ export async function getAnalyticsSummary(
     [...fp5, ...dw5.params, REDACTED_QUERY_TEXT],
   );
 
+  // Earliest query day (UNFILTERED — the UI uses this to label windows
+  // that have plateaued against actual data depth, which is an absolute
+  // property of the table, not relative to the current filter. Keeping
+  // this subquery sequential with the others preserves the existing
+  // ordering (tests assert on mock.calls[5] as the earliest-day query);
+  // parallelizing would need the rest of getAnalyticsSummary to move to
+  // Promise.all at the same time, which is out of scope here.
+  //
+  // date_trunc → cast to date → cast to text produces a bare YYYY-MM-DD
+  // string regardless of the session timezone. Cast at `created_at AT
+  // TIME ZONE 'UTC'` so the "day" boundary is always UTC and matches
+  // the per-day bars + client-side Date comparisons the UI already
+  // does in UTC.
+  const earliestRes = await pool.query(
+    `SELECT min(created_at AT TIME ZONE 'UTC')::date::text AS earliest_day FROM query_log`,
+  );
+
   const totalQueries = totalRes.rows[0]?.count ?? 0;
   const s = summaryRes.rows[0] ?? {};
   const totalWindow = s.total ?? 0;
   const emptyWindow = s.empty ?? 0;
+  // Normalize undefined (truly missing) to null so consumers get a
+  // consistent shape regardless of whether the DB returned an empty
+  // row, a row with NULL, or no row at all.
+  const earliestDay =
+    (earliestRes.rows[0]?.earliest_day as string | null | undefined) ?? null;
 
   // Compute p95 in application code. Slice back to the cap so the extra
   // "overflow probe" row fetched above doesn't skew the sample size.
@@ -427,6 +459,7 @@ export async function getAnalyticsSummary(
         count: r.count as number,
       }),
     ),
+    earliest_query_day: earliestDay,
   };
 }
 


### PR DESCRIPTION
## Summary
- Add `earliest_query_day: string | null` to `AnalyticsSummary`, computed server-side as `min(created_at AT TIME ZONE 'UTC')::date` over `query_log` (unfiltered — absolute data depth).
- Client computes `availableDays = today_UTC - earliest_UTC + 1`.
- When the selected window exceeds `availableDays`, show a subtle "showing N days of data" note next to the date pill so users understand why larger windows (14d / 30d / 90d) show identical numbers on a fresh install.

## Test plan
- [x] `npm run build` clean (tsc)
- [x] `npm test` — 3174/3174 passing
- [x] Red-green coverage for:
  - Backend: `earliest_query_day` populated from MIN query; null when table empty; unfiltered across tool_type/source/from-to/days
  - Frontend: label appears when requested > available (`days=14` with 8-day-old earliest → "showing 9 days of data")
  - Label hides when requested ≤ available
  - Label hides when `earliest_query_day` is null
  - Custom-range windows compute inclusive day counts correctly
- [ ] Manual browser verification on production (currently 9 days of data, `days=30` should show the label)

## Motivation
User feedback: "the pie chart looks the same across 14d/30d/90d windows, what's broken?" It's not broken — production has only 9 days of logged data, so windows ≥ 9 days capture the full table. This PR surfaces that context inline.