### PR TITLE
Fix og:image for social platform compatibility

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -10,13 +10,13 @@
 <meta property="og:url" content="https://pathfinder.copilotkit.dev/">
 <meta property="og:title" content="Pathfinder — The knowledge server for AI agents">
 <meta property="og:description" content="Docs, code, and conversations — one knowledge server for AI agents. Source-available, self-hosted, free to use.">
-<meta property="og:image" content="https://pathfinder.copilotkit.dev/og-image.svg">
+<meta property="og:image" content="https://pathfinder.copilotkit.dev/og-image.png">
 <meta property="og:image:width" content="1200">
 <meta property="og:image:height" content="630">
 <meta name="twitter:card" content="summary_large_image">
 <meta name="twitter:title" content="Pathfinder — The knowledge server for AI agents">
 <meta name="twitter:description" content="Docs, code, and conversations — one knowledge server for AI agents. Source-available, self-hosted, free to use.">
-<meta name="twitter:image" content="https://pathfinder.copilotkit.dev/og-image.svg">
+<meta name="twitter:image" content="https://pathfinder.copilotkit.dev/og-image.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=JetBrains+Mono:ital,wght@0,300;0,400;0,500;0,600;0,700;1,400&family=Instrument+Sans:wght@400;500;600;700&display=swap" rel="stylesheet">


### PR DESCRIPTION
## Summary
- Updated og:image and twitter:image meta tags to reference existing PNG instead of SVG
- PNG was already present in the repo but meta tags pointed to SVG
- Most social platforms (Twitter/X, Slack, Discord, LinkedIn, iMessage) don't render SVG og:images

## Test plan
- Share https://pathfinder.copilotkit.dev on Slack/Twitter and verify the preview card renders