### PR TITLE
chore(docs): add RB2B + Reo + PostHog pixels to docs site

### DIFF
--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -371,6 +371,7 @@
         font-style: italic;
       }
     </style>
+  <script src="/pixels.js" defer></script>
   </head>
   <body>
     <h1>Pathfinder Analytics</h1>

--- a/docs/clients/index.html
+++ b/docs/clients/index.html
@@ -226,6 +226,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -219,6 +219,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/deploy/index.html
+++ b/docs/deploy/index.html
@@ -232,6 +232,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -269,6 +269,7 @@ footer { padding: 3rem 0; border-top: 1px solid var(--border); text-align:center
     .nav-links { display:none !important; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/migrate-from-gitbook/index.html
+++ b/docs/migrate-from-gitbook/index.html
@@ -252,6 +252,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/migrate-from-local-rag/index.html
+++ b/docs/migrate-from-local-rag/index.html
@@ -249,6 +249,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/migrate-from-mintlify/index.html
+++ b/docs/migrate-from-mintlify/index.html
@@ -252,6 +252,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/migrate-from-ragdocs/index.html
+++ b/docs/migrate-from-ragdocs/index.html
@@ -251,6 +251,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/pixels.js
+++ b/docs/pixels.js
@@ -1,0 +1,50 @@
+// Marketing pixels: PostHog + RB2B + Reo. Source of truth lives in
+// ../website/src/app/(default)/layout.tsx and the PHProvider component —
+// keep keys in sync with that file.
+(function () {
+  !function(t,e){var o,n,p,r;e.__SV||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug getPageViewId captureTraceFeedback captureTraceMetric".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+  posthog.init('phc_XZdymVYjrph9Mi0xZYGNyCKexxgblXRR1jMENCtdz5Q', { api_host: 'https://eu.posthog.com', defaults: '2025-05-24' });
+
+  !function () {
+    var reb2b = window.reb2b = window.reb2b || [];
+    if (reb2b.invoked) return;
+    reb2b.invoked = true;
+    reb2b.methods = ["identify", "collect"];
+    reb2b.factory = function (method) {
+      return function () {
+        var args = Array.prototype.slice.call(arguments);
+        args.unshift(method);
+        reb2b.push(args);
+        return reb2b;
+      };
+    };
+    for (var i = 0; i < reb2b.methods.length; i++) {
+      var key = reb2b.methods[i];
+      reb2b[key] = reb2b.factory(key);
+    }
+    reb2b.load = function (key) {
+      var script = document.createElement("script");
+      script.type = "text/javascript";
+      script.async = true;
+      script.src = "https://b2bjsstore.s3.us-west-2.amazonaws.com/b/" + key + "/GOYPYHVD49OX.js.gz";
+      var first = document.getElementsByTagName("script")[0];
+      first.parentNode.insertBefore(script, first);
+    };
+    reb2b.SNIPPET_VERSION = "1.0.1";
+    reb2b.load("GOYPYHVD49OX");
+  }();
+
+  !function () {
+    var e = "f6eae27a6f1c6bb";
+    var t = function () {
+      if (window.Reo) {
+        window.Reo.init({ clientID: e });
+      }
+    };
+    var n = document.createElement("script");
+    n.src = "https://static.reo.dev/" + e + "/reo.js";
+    n.defer = true;
+    n.onload = t;
+    document.head.appendChild(n);
+  }();
+})();

--- a/docs/search/index.html
+++ b/docs/search/index.html
@@ -227,6 +227,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 

--- a/docs/usage/index.html
+++ b/docs/usage/index.html
@@ -239,6 +239,7 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
     .code-block { font-size: 11px; padding: 12px 14px; }
 }
 </style>
+<script src="/pixels.js" defer></script>
 </head>
 <body>
 


### PR DESCRIPTION
## Summary

- Adds the marketing pixels used by the main copilotkit.ai website (RB2B, Reo, PostHog) to the pathfinder docs site at `pathfinder.copilotkit.dev`, so visits flow into the same analytics + lead-attribution surfaces.
- Implementation: a single `docs/pixels.js` loaded via `<script src="/pixels.js" defer>` from every HTML `<head>`. Keys are hardcoded — they're inherently public.

## Test plan

- [ ] After merge, load https://pathfinder.copilotkit.dev/ and confirm in DevTools Network that requests fire to `static.reo.dev/...`, `b2bjsstore...amazonaws.com/...`, and `eu.posthog.com/...`
- [ ] Confirm no console errors on load
- [ ] Spot-check one subpage (e.g. `/usage`) — script should load via the same absolute path

🤖 Generated with [Claude Code](https://claude.com/claude-code)