### PR TITLE
Enable JSON responses on Streamable HTTP for Codex CLI compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @copilotkit/pathfinder
 
+## 1.13.1
+
+### Patch Changes
+
+- **Streamable HTTP JSON Response**: Enabled `enableJsonResponse` on the Streamable HTTP MCP transport for compatibility with clients that cannot parse SSE-formatted responses (notably OpenAI Codex CLI). Fully MCP spec-compliant — the spec allows servers to return either `application/json` or `text/event-stream` for single-message responses
+
 ## 1.13.0
 
 ### Minor Changes

--- a/docs/clients/index.html
+++ b/docs/clients/index.html
@@ -379,6 +379,32 @@ body::before { content:''; position:fixed; top:0; left:0; width:100%; height:100
 
     <p>Try asking your agent to run a simple command like <code>find / -name "*.md" | head -5</code> to verify the bash tool is working, or ask a question about your docs to test semantic search.</p>
 
+    <h2>Known Concerns</h2>
+
+    <h3>SSE Parsing Bugs in Some MCP Clients</h3>
+
+    <p>Some MCP clients have bugs handling SSE-formatted responses from Streamable HTTP endpoints. This can cause initialization failures, connection drops, or cryptic errors when connecting to Pathfinder's <code>/mcp</code> endpoint.</p>
+
+    <p>The most notable example is <strong>OpenAI Codex CLI</strong>, which uses the <code>rmcp</code> Rust SDK internally. That SDK's SSE parser does not correctly handle the <code>text/event-stream</code> content type that MCP servers typically return for single-message exchanges over Streamable HTTP.</p>
+
+    <h3>Pathfinder's Mitigation</h3>
+
+    <p>Pathfinder enables <code>enableJsonResponse: true</code> on its Streamable HTTP transport. This causes the server to return <code>Content-Type: application/json</code> instead of SSE-wrapped responses for single-message exchanges (i.e., requests where the server sends exactly one response and does not need to stream). This is fully compliant with the MCP specification, which states that servers MAY return either format for non-streaming responses.</p>
+
+    <p>This setting works around the client-side bugs transparently — no configuration needed on your end.</p>
+
+    <h3>stdio Bridge Workaround</h3>
+
+    <p>If you still encounter connection issues with a particular client, you can use <a href="https://github.com/anthropics/mcp-remote">mcp-remote</a> as a stdio bridge. This converts the HTTP transport into a local stdio pipe, which every MCP client supports reliably:</p>
+
+    <div class="code-block"><span class="comment"># Codex CLI — ~/.codex/config.toml</span>
+
+[<span class="key">mcp_servers.pathfinder</span>]
+<span class="key">command</span> = <span class="value">"npx"</span>
+<span class="key">args</span> = [<span class="value">"mcp-remote@latest"</span>, <span class="value">"--http"</span>, <span class="value">"--allow-http"</span>, <span class="value">"https://mcp.copilotkit.ai/mcp"</span>]</div>
+
+    <p>Replace the URL with your own Pathfinder instance's <code>/mcp</code> endpoint. The <code>--http</code> flag tells mcp-remote to use Streamable HTTP (not SSE), and <code>--allow-http</code> permits non-TLS connections if you're running locally.</p>
+
   </main>
   <aside class="page-toc" id="page-toc"></aside>
 </div>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "@copilotkit/pathfinder",
-    "version": "1.13.0",
+    "version": "1.13.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "@copilotkit/pathfinder",
-            "version": "1.13.0",
+            "version": "1.13.1",
             "license": "Elastic-2.0",
             "dependencies": {
                 "@discordjs/rest": "^2.6.1",
@@ -3768,7 +3768,7 @@
             }
         },
         "node_modules/magic-bytes.js": {
-            "version": "1.13.0",
+            "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/magic-bytes.js/-/magic-bytes.js-1.13.0.tgz",
             "integrity": "sha512-afO2mnxW7GDTXMm5/AoN1WuOcdoKhtgXjIvHmobqTD1grNplhGdv3PFOyjCVmrnOZBIT/gD/koDKpYG+0mvHcg==",
             "license": "MIT"
@@ -4367,7 +4367,7 @@
             }
         },
         "node_modules/pg-protocol": {
-            "version": "1.13.0",
+            "version": "1.13.1",
             "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
             "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
             "license": "MIT"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/pathfinder",
-  "version": "1.13.0",
+  "version": "1.13.1",
   "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
   "type": "module",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("The knowledge server for AI agents")
-  .version("1.13.0");
+  .version("1.13.1");
 
 program
   .command("init")

--- a/src/server.ts
+++ b/src/server.ts
@@ -1626,6 +1626,7 @@ app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {
       const initOutcome: { rejected: boolean } = { rejected: false };
       const transport = new StreamableHTTPServerTransport({
         sessionIdGenerator: () => preSid,
+        enableJsonResponse: true,
         onsessioninitialized: (sid) => {
           // Registration moved here intentionally — we can't populate
           // transports[sid] before the transport object exists, and the SDK


### PR DESCRIPTION
## Summary

A community user reported that Pathfinder's MCP server doesn't work with OpenAI Codex CLI — initialization fails with connection drops. Confirmed working with Claude Code.

**Root cause:** Codex CLI uses the `rmcp` Rust MCP SDK, which has open bugs ([#5619](https://github.com/openai/codex/issues/5619), [#11284](https://github.com/openai/codex/issues/11284)) around parsing SSE-formatted responses from Streamable HTTP endpoints. Pathfinder was returning `Content-Type: text/event-stream` for all responses (including simple request/response like `initialize` and `tools/list`), which rmcp fails to parse — it closes the connection before reading the response data.

**Fix:** The MCP SDK's `StreamableHTTPServerTransport` has an `enableJsonResponse` option (default: `false`). When enabled, the server responds with `Content-Type: application/json` instead of SSE-wrapping for single-message exchanges. This is one line:

```typescript
const transport = new StreamableHTTPServerTransport({
    sessionIdGenerator: () => preSid,
    enableJsonResponse: true,  // ← new
    ...
});
```

**Spec compliance:** Fully compliant. The MCP spec (2025-06-18) explicitly states: "If the input is a JSON-RPC request, the server MUST either return `Content-Type: text/event-stream`, to initiate an SSE stream, or `Content-Type: application/json`, to return one JSON object. The client MUST support both these cases." The server gets to choose.

**Tradeoff:** Loses the ability to send server-initiated notifications mid-request via SSE. Pathfinder's tools are all request/response — none stream intermediate results. The GET SSE endpoint still works for server-initiated messages.

**No impact on Claude Code** or any other spec-compliant client, since they're required to handle both formats.

## Changes

- `src/server.ts`: Add `enableJsonResponse: true` to `StreamableHTTPServerTransport` constructor
- `docs/clients/index.html`: Add Known Concerns section documenting SSE parsing bugs in some MCP clients, our mitigation, and the `mcp-remote` stdio bridge workaround for any remaining edge cases
- Version bump to 1.13.1 (`package.json`, `src/cli.ts`, `package-lock.json`, `CHANGELOG.md`)

## Test plan

- [x] Started Pathfinder locally with breeze-docs fixture
- [x] Verified `/mcp` POST returns `Content-Type: application/json` (previously returned `text/event-stream`)
- [x] Verified response body is plain JSON-RPC (`{"result":{"protocolVersion":"2025-06-18",...},"jsonrpc":"2.0","id":1}`) — not SSE-wrapped (`event: message\ndata: {...}\n\n`)
- [x] Ran `codex exec` against local Pathfinder — successfully initialized and discovered MCP tools (`search_breeze_docs`, `submit_breeze_feedback`)
- [x] Claude Code connectivity unaffected (spec-compliant clients handle both formats)