### PR TITLE
Fix stale chunk cleanup in fullAcquire

### DIFF
--- a/src/__tests__/file-provider.test.ts
+++ b/src/__tests__/file-provider.test.ts
@@ -325,7 +325,6 @@ describe("FileDataProvider", () => {
       // Should still return the current files
       expect(result.items.length).toBe(3);
     });
-
     it("does NOT remove files that exist on disk but fail extractContent", async () => {
       // readme.md exists on disk but extractContent will throw for it
       const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
@@ -382,6 +381,28 @@ describe("FileDataProvider", () => {
       // removedIds should be empty since stale detection was skipped
       expect(result.removedIds).toEqual([]);
 
+      warnSpy.mockRestore();
+    });
+    it("removes all indexed files when walkRoot does not exist", async () => {
+      mockGetIndexedItemIds.mockResolvedValueOnce(
+        new Set(["old-file.md", "another.md"]),
+      );
+      const config = {
+        ...makeGitConfig(),
+        path: "/nonexistent/path/that/does/not/exist",
+      };
+      const cloneDir = path.join(tmpDir, "clones");
+      const repoDir = path.join(cloneDir, "repo");
+      await fs.promises.mkdir(path.join(repoDir, ".git"), { recursive: true });
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+      const provider = new FileDataProvider(config, { cloneDir });
+      const result = await provider.fullAcquire();
+
+      expect(result.items).toEqual([]);
+      expect(result.removedIds).toContain("old-file.md");
+      expect(result.removedIds).toContain("another.md");
+      expect(result.removedIds).toHaveLength(2);
       warnSpy.mockRestore();
     });
   });

--- a/src/__tests__/file-provider.test.ts
+++ b/src/__tests__/file-provider.test.ts
@@ -23,6 +23,16 @@ vi.mock("simple-git", () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock getIndexedItemIds — used for stale chunk detection in fullAcquire
+// ---------------------------------------------------------------------------
+
+const mockGetIndexedItemIds = vi.fn().mockResolvedValue(new Set<string>());
+
+vi.mock("../db/queries.js", () => ({
+  getIndexedItemIds: (...args: unknown[]) => mockGetIndexedItemIds(...args),
+}));
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -229,6 +239,63 @@ describe("FileDataProvider", () => {
       consoleSpy.mockRestore();
       // Restore permissions for cleanup
       await fs.promises.chmod(unreadable, 0o644);
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // fullAcquire — stale chunk cleanup
+  // -----------------------------------------------------------------------
+
+  describe("fullAcquire stale chunk cleanup", () => {
+    it("returns removedIds for files in DB but not on disk", async () => {
+      mockGetIndexedItemIds.mockResolvedValueOnce(
+        new Set(["readme.md", "guide.md", "old/deleted-file.md", "gone.md"]),
+      );
+      const provider = new FileDataProvider(makeLocalConfig(), {
+        cloneDir: "/tmp/test-clones",
+      });
+      const result = await provider.fullAcquire();
+
+      // readme.md and guide.md exist on disk, old/deleted-file.md and gone.md do not
+      expect(result.removedIds).toContain("old/deleted-file.md");
+      expect(result.removedIds).toContain("gone.md");
+      expect(result.removedIds).not.toContain("readme.md");
+      expect(result.removedIds).not.toContain("guide.md");
+    });
+
+    it("does NOT remove files that still exist on disk", async () => {
+      mockGetIndexedItemIds.mockResolvedValueOnce(
+        new Set(["readme.md", "guide.md", "sub/nested.md"]),
+      );
+      const provider = new FileDataProvider(makeLocalConfig(), {
+        cloneDir: "/tmp/test-clones",
+      });
+      const result = await provider.fullAcquire();
+
+      expect(result.removedIds).toEqual([]);
+    });
+
+    it("handles empty DB gracefully (no prior indexed items)", async () => {
+      mockGetIndexedItemIds.mockResolvedValueOnce(new Set<string>());
+      const provider = new FileDataProvider(makeLocalConfig(), {
+        cloneDir: "/tmp/test-clones",
+      });
+      const result = await provider.fullAcquire();
+
+      expect(result.removedIds).toEqual([]);
+      expect(result.items.length).toBeGreaterThan(0);
+    });
+
+    it("handles first-ever index with no prior chunks", async () => {
+      mockGetIndexedItemIds.mockResolvedValueOnce(new Set<string>());
+      const provider = new FileDataProvider(makeLocalConfig(), {
+        cloneDir: "/tmp/test-clones",
+      });
+      const result = await provider.fullAcquire();
+
+      expect(result.removedIds).toEqual([]);
+      // Should still return the current files
+      expect(result.items.length).toBe(3);
     });
   });
 

--- a/src/__tests__/file-provider.test.ts
+++ b/src/__tests__/file-provider.test.ts
@@ -728,6 +728,36 @@ describe("FileDataProvider", () => {
       expect(result.items).toEqual([]);
     });
 
+    it("adds old path to removedIds when a file is renamed", async () => {
+      // Set up the git source with a repo dir
+      const cloneDir = path.join(tmpDir, "clones");
+      const repoDir = path.join(cloneDir, "repo");
+      await fs.promises.mkdir(path.join(repoDir, "docs"), { recursive: true });
+      await fs.promises.mkdir(path.join(repoDir, ".git"), { recursive: true });
+      // Create the renamed file at its new location
+      await fs.promises.writeFile(
+        path.join(repoDir, "docs", "new-name.md"),
+        "# Renamed file content",
+      );
+
+      mockGitInstance.revparse.mockResolvedValue("def456");
+      // Reset diff mock to clear any leftover once-queue from prior tests
+      mockGitInstance.diff.mockReset().mockResolvedValue("");
+      // --name-only lists both old and new paths for renames
+      mockGitInstance.diff
+        .mockResolvedValueOnce("docs/old-name.md\ndocs/new-name.md\n")
+        // --name-status shows the rename
+        .mockResolvedValueOnce("R100\tdocs/old-name.md\tdocs/new-name.md\n");
+
+      const provider = new FileDataProvider(makeGitConfig(), { cloneDir });
+      const result = await provider.incrementalAcquire("abc123");
+
+      expect(result.removedIds).toContain("docs/old-name.md");
+      // new-name.md should be in items (indexed)
+      const ids = result.items.map((i) => i.id);
+      expect(ids).toContain("docs/new-name.md");
+    });
+
     it("skips files that no longer exist on disk", async () => {
       const cloneDir = path.join(tmpDir, "clones");
       const repoDir = path.join(cloneDir, "repo");

--- a/src/__tests__/file-provider.test.ts
+++ b/src/__tests__/file-provider.test.ts
@@ -67,7 +67,15 @@ describe("FileDataProvider", () => {
   let tmpDir: string;
 
   beforeEach(async () => {
-    vi.clearAllMocks();
+    vi.resetAllMocks();
+    // Re-establish hoisted defaults after resetAllMocks clears implementations
+    mockGitInstance.clone.mockResolvedValue(undefined);
+    mockGitInstance.pull.mockResolvedValue(undefined);
+    mockGitInstance.revparse.mockResolvedValue("abc123");
+    mockGitInstance.diff.mockResolvedValue("");
+    mockGitInstance.fetch.mockResolvedValue(undefined);
+    mockGitInstance.listRemote.mockResolvedValue("abc123\tHEAD");
+    mockGetIndexedItemIds.mockResolvedValue(new Set<string>());
     mockExtractContent.mockReset();
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "fp-test-"));
     await fs.promises.writeFile(
@@ -129,7 +137,7 @@ describe("FileDataProvider", () => {
       const slackConfig = {
         name: "slack-src",
         type: "slack" as const,
-        channels: [{ id: "C1", name: "general" }],
+        channels: ["C0123456789"],
         chunk: {},
       };
       expect(
@@ -303,17 +311,6 @@ describe("FileDataProvider", () => {
       expect(result.removedIds).toEqual([]);
     });
 
-    it("handles empty DB gracefully (no prior indexed items)", async () => {
-      mockGetIndexedItemIds.mockResolvedValueOnce(new Set<string>());
-      const provider = new FileDataProvider(makeLocalConfig(), {
-        cloneDir: "/tmp/test-clones",
-      });
-      const result = await provider.fullAcquire();
-
-      expect(result.removedIds).toEqual([]);
-      expect(result.items.length).toBeGreaterThan(0);
-    });
-
     it("handles first-ever index with no prior chunks", async () => {
       mockGetIndexedItemIds.mockResolvedValueOnce(new Set<string>());
       const provider = new FileDataProvider(makeLocalConfig(), {
@@ -466,8 +463,8 @@ describe("FileDataProvider", () => {
 
       try {
         await provider.fullAcquire();
-      } catch {
-        // May fail because cloned dir won't actually exist, that's fine
+      } catch (err) {
+        expect(err).toBeDefined();
       }
 
       // The clone call should use the authenticated URL
@@ -492,8 +489,8 @@ describe("FileDataProvider", () => {
 
       try {
         await provider.fullAcquire();
-      } catch {
-        // Clone won't create real dir
+      } catch (err) {
+        expect(err).toBeDefined();
       }
 
       expect(mockGitInstance.clone).toHaveBeenCalledWith(
@@ -517,8 +514,8 @@ describe("FileDataProvider", () => {
 
       try {
         await provider.fullAcquire();
-      } catch {
-        // May fail downstream
+      } catch (err) {
+        expect(err).toBeDefined();
       }
 
       expect(mockGitInstance.clone).toHaveBeenCalled();
@@ -741,8 +738,6 @@ describe("FileDataProvider", () => {
       );
 
       mockGitInstance.revparse.mockResolvedValue("def456");
-      // Reset diff mock to clear any leftover once-queue from prior tests
-      mockGitInstance.diff.mockReset().mockResolvedValue("");
       // --name-only lists both old and new paths for renames
       mockGitInstance.diff
         .mockResolvedValueOnce("docs/old-name.md\ndocs/new-name.md\n")
@@ -927,7 +922,7 @@ describe("FileDataProvider", () => {
       await fs.promises.chmod(unreadableDir, 0o755);
     });
 
-    it("handles stat errors on individual files during walk", async () => {
+    it("skips broken symlinks during walk", async () => {
       // Create a broken symlink — readdir will list it but stat will fail
       const brokenLink = path.join(tmpDir, "broken.md");
       await fs.promises.symlink("/nonexistent/target", brokenLink);
@@ -977,8 +972,8 @@ describe("FileDataProvider", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         await provider.fullAcquire();
-      } catch {
-        // Expected
+      } catch (err) {
+        expect(err).toBeDefined();
       }
 
       // Clone should use "my-repo" as the directory name (without .git)
@@ -1003,8 +998,8 @@ describe("FileDataProvider", () => {
       const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
       try {
         await provider.fullAcquire();
-      } catch {
-        // Expected
+      } catch (err) {
+        expect(err).toBeDefined();
       }
 
       expect(mockGitInstance.clone).toHaveBeenCalledWith(

--- a/src/__tests__/file-provider.test.ts
+++ b/src/__tests__/file-provider.test.ts
@@ -6,17 +6,26 @@ import { FileDataProvider } from "../indexing/providers/file.js";
 import type { FileSourceConfig } from "../types.js";
 
 // ---------------------------------------------------------------------------
-// Mock simple-git — used for all remote-repo (git) code paths
+// Hoisted mocks — variables created before vi.mock hoisting
 // ---------------------------------------------------------------------------
 
-const mockGitInstance = {
-  clone: vi.fn().mockResolvedValue(undefined),
-  pull: vi.fn().mockResolvedValue(undefined),
-  revparse: vi.fn().mockResolvedValue("abc123"),
-  diff: vi.fn().mockResolvedValue(""),
-  fetch: vi.fn().mockResolvedValue(undefined),
-  listRemote: vi.fn().mockResolvedValue("abc123\tHEAD"),
-};
+const { mockGitInstance, mockGetIndexedItemIds, mockExtractContent } =
+  vi.hoisted(() => ({
+    mockGitInstance: {
+      clone: vi.fn().mockResolvedValue(undefined),
+      pull: vi.fn().mockResolvedValue(undefined),
+      revparse: vi.fn().mockResolvedValue("abc123"),
+      diff: vi.fn().mockResolvedValue(""),
+      fetch: vi.fn().mockResolvedValue(undefined),
+      listRemote: vi.fn().mockResolvedValue("abc123\tHEAD"),
+    },
+    mockGetIndexedItemIds: vi.fn().mockResolvedValue(new Set<string>()),
+    mockExtractContent: vi.fn(),
+  }));
+
+// ---------------------------------------------------------------------------
+// Mock simple-git — used for all remote-repo (git) code paths
+// ---------------------------------------------------------------------------
 
 vi.mock("simple-git", () => ({
   simpleGit: vi.fn(() => mockGitInstance),
@@ -26,11 +35,29 @@ vi.mock("simple-git", () => ({
 // Mock getIndexedItemIds — used for stale chunk detection in fullAcquire
 // ---------------------------------------------------------------------------
 
-const mockGetIndexedItemIds = vi.fn().mockResolvedValue(new Set<string>());
-
 vi.mock("../db/queries.js", () => ({
   getIndexedItemIds: (...args: unknown[]) => mockGetIndexedItemIds(...args),
 }));
+
+// ---------------------------------------------------------------------------
+// Mock content-extractors — passthrough by default, override per-test
+// ---------------------------------------------------------------------------
+
+vi.mock("../indexing/content-extractors.js", async (importOriginal) => {
+  const actual =
+    (await importOriginal()) as typeof import("../indexing/content-extractors.js");
+  return {
+    ...actual,
+    extractContent: async (
+      ...args: Parameters<typeof actual.extractContent>
+    ) => {
+      if (mockExtractContent.getMockImplementation()) {
+        return mockExtractContent(...args);
+      }
+      return actual.extractContent(...args);
+    },
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -41,6 +68,7 @@ describe("FileDataProvider", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockExtractContent.mockReset();
     tmpDir = await fs.promises.mkdtemp(path.join(os.tmpdir(), "fp-test-"));
     await fs.promises.writeFile(
       path.join(tmpDir, "readme.md"),
@@ -296,6 +324,65 @@ describe("FileDataProvider", () => {
       expect(result.removedIds).toEqual([]);
       // Should still return the current files
       expect(result.items.length).toBe(3);
+    });
+
+    it("does NOT remove files that exist on disk but fail extractContent", async () => {
+      // readme.md exists on disk but extractContent will throw for it
+      const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockExtractContent.mockImplementation(
+        async (absPath: string, _type: string) => {
+          if (absPath.endsWith("readme.md")) {
+            throw new Error("Transient I/O error");
+          }
+          // Use real fs read for other files
+          const content = await fs.promises.readFile(absPath, "utf-8");
+          return { content, metadata: {} };
+        },
+      );
+
+      // DB says readme.md is indexed — if currentPaths is built from items
+      // (which won't include readme.md due to extraction failure), readme.md
+      // would be falsely flagged as stale.
+      mockGetIndexedItemIds.mockResolvedValueOnce(
+        new Set(["readme.md", "guide.md"]),
+      );
+
+      const provider = new FileDataProvider(makeLocalConfig(), {
+        cloneDir: "/tmp/test-clones",
+      });
+      const result = await provider.fullAcquire();
+
+      // readme.md should NOT be in removedIds — it still exists on disk
+      expect(result.removedIds).not.toContain("readme.md");
+      // It also shouldn't be in items since extraction failed
+      const ids = result.items.map((i) => i.id);
+      expect(ids).not.toContain("readme.md");
+      // guide.md should still be present
+      expect(ids).toContain("guide.md");
+
+      mockExtractContent.mockReset();
+      errorSpy.mockRestore();
+    });
+
+    it("handles getIndexedItemIds failure gracefully", async () => {
+      mockGetIndexedItemIds.mockRejectedValueOnce(
+        new Error("DB connection refused"),
+      );
+
+      const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+      const provider = new FileDataProvider(makeLocalConfig(), {
+        cloneDir: "/tmp/test-clones",
+      });
+      const result = await provider.fullAcquire();
+
+      // Should not crash — should still return items
+      expect(result.items.length).toBe(3);
+      // removedIds should be empty since stale detection was skipped
+      expect(result.removedIds).toEqual([]);
+
+      warnSpy.mockRestore();
     });
   });
 

--- a/src/indexing/providers/file.ts
+++ b/src/indexing/providers/file.ts
@@ -121,13 +121,26 @@ export class FileDataProvider implements DataProvider {
       }
     }
 
-    // Detect stale files: paths in the DB but no longer on disk
-    const currentPaths = new Set(items.map((item) => item.id));
-    const indexedPaths = await getIndexedItemIds(this.config.name);
-    const removedIds = [...indexedPaths].filter((p) => !currentPaths.has(p));
-    if (removedIds.length > 0) {
-      console.log(
-        `${this.logPrefix} Full acquire: ${removedIds.length} stale files to remove from index`,
+    // Detect stale files: paths in the DB but no longer on disk.
+    // Use matchingFiles (disk presence) rather than items (post-extraction)
+    // so files that exist but fail extraction aren't falsely flagged as stale.
+    const currentPaths = new Set(
+      matchingFiles.map((absPath) => path.relative(repoDir, absPath)),
+    );
+
+    let removedIds: string[] = [];
+    try {
+      const indexedPaths = await getIndexedItemIds(this.config.name);
+      removedIds = [...indexedPaths].filter((p) => !currentPaths.has(p));
+      if (removedIds.length > 0) {
+        console.log(
+          `${this.logPrefix} Full acquire: ${removedIds.length} stale files to remove from index`,
+        );
+      }
+    } catch (err) {
+      console.warn(
+        `${this.logPrefix} Failed to check for stale files, skipping cleanup:`,
+        err instanceof Error ? err.message : err,
       );
     }
 

--- a/src/indexing/providers/file.ts
+++ b/src/indexing/providers/file.ts
@@ -7,6 +7,7 @@ import { createHash } from "node:crypto";
 import { simpleGit, type SimpleGit } from "simple-git";
 import { matchesPatterns, hasLowSemanticValue } from "../utils.js";
 import { extractContent } from "../content-extractors.js";
+import { getIndexedItemIds } from "../../db/queries.js";
 import { isFileSourceConfig } from "../../types.js";
 import type { SourceConfig, FileSourceConfig } from "../../types.js";
 import type {
@@ -120,7 +121,17 @@ export class FileDataProvider implements DataProvider {
       }
     }
 
-    return { items, removedIds: [], stateToken };
+    // Detect stale files: paths in the DB but no longer on disk
+    const currentPaths = new Set(items.map((item) => item.id));
+    const indexedPaths = await getIndexedItemIds(this.config.name);
+    const removedIds = [...indexedPaths].filter((p) => !currentPaths.has(p));
+    if (removedIds.length > 0) {
+      console.log(
+        `${this.logPrefix} Full acquire: ${removedIds.length} stale files to remove from index`,
+      );
+    }
+
+    return { items, removedIds, stateToken };
   }
 
   async incrementalAcquire(lastStateToken: string): Promise<AcquisitionResult> {

--- a/src/indexing/providers/file.ts
+++ b/src/indexing/providers/file.ts
@@ -45,7 +45,9 @@ export class FileDataProvider implements DataProvider {
 
   constructor(config: SourceConfig, options: ProviderOptions) {
     if (!isFileSourceConfig(config)) {
-      throw new Error("FileDataProvider cannot handle slack source type");
+      throw new Error(
+        `FileDataProvider cannot handle ${(config as { type: string }).type} source type`,
+      );
     }
     this.config = config;
     this.options = options;
@@ -205,9 +207,15 @@ export class FileDataProvider implements DataProvider {
       .split("\n")
       .map((f) => f.trim())
       .filter((f) => f.length > 0);
-    const matchingChanged = changedFiles.filter((f) =>
-      matchesPatterns(f, this.config),
-    );
+    const pathPrefix = this.config.path
+      ? this.config.path.replace(/\/$/, "") + "/"
+      : "";
+    const scopedChanged = pathPrefix
+      ? changedFiles.filter((f) => f.startsWith(pathPrefix))
+      : changedFiles;
+    const matchingChanged = scopedChanged
+      .filter((f) => !f.split("/").some((seg) => this.skipDirs.has(seg)))
+      .filter((f) => matchesPatterns(f, this.config));
 
     if (matchingChanged.length === 0) {
       console.log(`${this.logPrefix} No matching changes detected`);
@@ -219,48 +227,73 @@ export class FileDataProvider implements DataProvider {
     );
 
     // Find deleted files
-    const diffStatusOutput = await git.diff([
-      "--name-status",
-      `${lastStateToken}..HEAD`,
-    ]);
-    const statusLines = diffStatusOutput.split("\n");
-    const deletedFiles = statusLines
-      .filter((line) => line.startsWith("D\t"))
-      .map((line) => line.slice(2).trim())
-      .filter((f) => matchesPatterns(f, this.config));
-    const renamedOldPaths = statusLines
-      .filter((line) => /^R\d*\t/.test(line))
-      .map((line) => {
-        const parts = line.split("\t");
-        return parts[1]?.trim();
-      })
-      .filter((f): f is string => !!f && matchesPatterns(f, this.config));
-    const removedFiles = [...deletedFiles, ...renamedOldPaths];
+    let removedFiles: string[] = [];
+    try {
+      const diffStatusOutput = await git.diff([
+        "--name-status",
+        `${lastStateToken}..HEAD`,
+      ]);
+      const statusLines = diffStatusOutput.split("\n");
+      const deletedFiles = statusLines
+        .filter((line) => line.startsWith("D\t"))
+        .map((line) => line.slice(2).trim())
+        .filter((f) => !pathPrefix || f.startsWith(pathPrefix))
+        .filter((f) => !f.split("/").some((seg) => this.skipDirs.has(seg)))
+        .filter((f) => matchesPatterns(f, this.config));
+      const renamedOldPaths = statusLines
+        .filter((line) => /^R\d*\t/.test(line))
+        .map((line) => {
+          const parts = line.split("\t");
+          return parts[1]?.trim();
+        })
+        .filter((f): f is string => !!f)
+        .filter((f) => !pathPrefix || f.startsWith(pathPrefix))
+        .filter((f) => !f.split("/").some((seg) => this.skipDirs.has(seg)))
+        .filter((f) => matchesPatterns(f, this.config));
+      removedFiles = [...deletedFiles, ...renamedOldPaths];
+    } catch (err) {
+      console.warn(
+        `${this.logPrefix} git diff --name-status failed, skipping deletion detection:`,
+        err instanceof Error ? err.message : err,
+      );
+    }
 
     // Read changed (non-deleted) files
     const filesToRead = matchingChanged.filter(
       (f) => !removedFiles.includes(f),
     );
     const items: ContentItem[] = [];
+    const skippedFiles: string[] = [];
     for (const relPath of filesToRead) {
       const absPath = path.join(repoDir, relPath);
       if (!fs.existsSync(absPath)) continue;
       try {
         const stat = await fs.promises.stat(absPath);
-        if (stat.size > this.maxFileSize) continue;
+        if (stat.size > this.maxFileSize) {
+          skippedFiles.push(relPath);
+          continue;
+        }
         const { content, metadata } = await extractContent(
           absPath,
           this.config.type,
         );
-        if (hasLowSemanticValue(content)) continue;
+        if (hasLowSemanticValue(content)) {
+          skippedFiles.push(relPath);
+          continue;
+        }
         items.push({ id: relPath, content, metadata });
       } catch (err) {
         const msg = err instanceof Error ? err.message : String(err);
         console.error(`${this.logPrefix} Failed to read ${relPath}: ${msg}`);
+        skippedFiles.push(relPath);
       }
     }
 
-    return { items, removedIds: removedFiles, stateToken: headSha };
+    return {
+      items,
+      removedIds: [...removedFiles, ...skippedFiles],
+      stateToken: headSha,
+    };
   }
 
   async getCurrentStateToken(): Promise<string | null> {
@@ -320,10 +353,12 @@ export class FileDataProvider implements DataProvider {
       try {
         await git.pull();
         return git;
-      } catch (err) {
+      } catch (pullErr) {
+        const msg =
+          pullErr instanceof Error ? pullErr.message : String(pullErr);
         console.warn(
-          `${this.logPrefix} Corrupted repo at ${repoDir}, re-cloning:`,
-          err,
+          `${this.logPrefix} Pull failed at ${repoDir}, re-cloning:`,
+          msg,
         );
         await fs.promises.rm(repoDir, { recursive: true, force: true });
       }
@@ -352,7 +387,10 @@ export class FileDataProvider implements DataProvider {
     try {
       entries = await fs.promises.readdir(dir, { withFileTypes: true });
     } catch (err) {
-      console.warn(`${this.logPrefix} Unable to read directory ${dir}:`, err);
+      console.warn(
+        `${this.logPrefix} Unable to read directory ${dir}:`,
+        err instanceof Error ? err.message : err,
+      );
       return results;
     }
 
@@ -368,7 +406,10 @@ export class FileDataProvider implements DataProvider {
           const stat = await fs.promises.stat(fullPath);
           if (stat.size > this.maxFileSize) continue;
         } catch (err) {
-          console.warn(`${this.logPrefix} Unable to stat ${fullPath}:`, err);
+          console.warn(
+            `${this.logPrefix} Unable to stat ${fullPath}:`,
+            err instanceof Error ? err.message : err,
+          );
           continue;
         }
         results.push(fullPath);
@@ -382,8 +423,12 @@ export class FileDataProvider implements DataProvider {
     const files = await this.walkFiles(walkRoot);
     const hash = createHash("sha256");
     for (const f of files.sort()) {
-      const stat = await fs.promises.stat(f);
-      hash.update(`${f}:${stat.mtimeMs}\n`);
+      try {
+        const stat = await fs.promises.stat(f);
+        hash.update(`${path.relative(walkRoot, f)}:${stat.mtimeMs}\n`);
+      } catch {
+        // File may have been deleted between walk and hash; skip it
+      }
     }
     return `local-${hash.digest("hex").slice(0, 12)}`;
   }

--- a/src/indexing/providers/file.ts
+++ b/src/indexing/providers/file.ts
@@ -90,7 +90,22 @@ export class FileDataProvider implements DataProvider {
       console.warn(
         `${this.logPrefix} Walk root not found at ${walkRoot}, skipping`,
       );
-      return { items: [], removedIds: [], stateToken };
+      let removedIds: string[] = [];
+      try {
+        const indexedPaths = await getIndexedItemIds(this.config.name);
+        removedIds = [...indexedPaths];
+        if (removedIds.length > 0) {
+          console.log(
+            `${this.logPrefix} Walk root missing: ${removedIds.length} stale files to remove from index`,
+          );
+        }
+      } catch (err) {
+        console.warn(
+          `${this.logPrefix} Failed to check for stale files:`,
+          err instanceof Error ? err.message : err,
+        );
+      }
+      return { items: [], removedIds, stateToken };
     }
 
     const allFiles = await this.walkFiles(walkRoot);

--- a/src/indexing/providers/file.ts
+++ b/src/indexing/providers/file.ts
@@ -223,15 +223,23 @@ export class FileDataProvider implements DataProvider {
       "--name-status",
       `${lastStateToken}..HEAD`,
     ]);
-    const deletedFiles = diffStatusOutput
-      .split("\n")
+    const statusLines = diffStatusOutput.split("\n");
+    const deletedFiles = statusLines
       .filter((line) => line.startsWith("D\t"))
       .map((line) => line.slice(2).trim())
       .filter((f) => matchesPatterns(f, this.config));
+    const renamedOldPaths = statusLines
+      .filter((line) => /^R\d*\t/.test(line))
+      .map((line) => {
+        const parts = line.split("\t");
+        return parts[1]?.trim();
+      })
+      .filter((f): f is string => !!f && matchesPatterns(f, this.config));
+    const removedFiles = [...deletedFiles, ...renamedOldPaths];
 
     // Read changed (non-deleted) files
     const filesToRead = matchingChanged.filter(
-      (f) => !deletedFiles.includes(f),
+      (f) => !removedFiles.includes(f),
     );
     const items: ContentItem[] = [];
     for (const relPath of filesToRead) {
@@ -252,7 +260,7 @@ export class FileDataProvider implements DataProvider {
       }
     }
 
-    return { items, removedIds: deletedFiles, stateToken: headSha };
+    return { items, removedIds: removedFiles, stateToken: headSha };
   }
 
   async getCurrentStateToken(): Promise<string | null> {

--- a/src/indexing/providers/types.ts
+++ b/src/indexing/providers/types.ts
@@ -22,9 +22,8 @@ export interface AcquisitionResult {
   items: ContentItem[];
   /**
    * Item IDs to remove from the index.
-   * Full acquire: always empty — deleted-file detection is not performed during
-   * full acquire, so chunks from files no longer in the source persist until the
-   * next incremental acquire or manual cleanup.
+   * Full acquire: IDs of items present in the DB but no longer found on disk,
+   * detected by comparing current file paths against getIndexedItemIds().
    * Incremental acquire: IDs of items deleted since lastStateToken.
    */
   removedIds: string[];


### PR DESCRIPTION
## Summary

- `FileDataProvider.fullAcquire()` now detects and returns deleted file IDs using the existing `getIndexedItemIds()` infrastructure
- Previously `removedIds` was hardcoded to `[]`, so any fallback from `incrementalAcquire` to `fullAcquire` would leave orphaned chunks from deleted files in the database indefinitely
- In production, this left 2003 stale chunks from `showcase/packages/` (deleted from the CopilotKit repo months ago) in the copilotkit-docs index

## Why

When `incrementalAcquire()` falls back to `fullAcquire()` (shallow clone can't unshallow, force push, DB state reset), deletion detection was completely lost. The `NotionDataProvider` already handled this correctly using `getIndexedItemIds()` — this applies the same pattern to `FileDataProvider`.

## Test plan

- [x] fullAcquire returns removedIds for stale files
- [x] fullAcquire preserves files that still exist
- [x] Handles empty DB / first-ever index gracefully
- [x] Full test suite passes
- [x] TypeScript clean