### PR TITLE
Add dedup to reindex audit Slack alerting

### DIFF
--- a/src/__tests__/reindex-audit.test.ts
+++ b/src/__tests__/reindex-audit.test.ts
@@ -39,6 +39,7 @@ vi.mock("../indexing/utils.js", () => ({
 
 import {
   runReindexAudit,
+  resetAuditCache,
   type AuditFinding,
 } from "../indexing/reindex-audit.js";
 
@@ -113,6 +114,7 @@ describe("runReindexAudit", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    resetAuditCache();
 
     // Default: single markdown source, DB and disk in sync
     const src = fileSource("docs");

--- a/src/indexing/reindex-audit.ts
+++ b/src/indexing/reindex-audit.ts
@@ -4,6 +4,14 @@ import { walkSourceFiles } from "./utils.js";
 import { isFileSourceConfig } from "../types.js";
 import type { FileSourceConfig } from "../types.js";
 
+// Dedup: only alert when findings change from the previous audit run.
+// Key = "source:check", value = count. If the counts match, skip the alert.
+const lastAuditFindings = new Map<string, number>();
+
+export function resetAuditCache(): void {
+  lastAuditFindings.clear();
+}
+
 export interface AuditFinding {
   source: string;
   check: "stale_files" | "scope_leak" | "count_divergence";
@@ -80,18 +88,36 @@ export async function runReindexAudit(
       }
     }
 
-    if (findings.length > 0) {
-      for (const f of findings) {
-        const detail = f.direction ? ` (${f.direction})` : "";
-        const samples =
-          f.samples.length > 0 ? `: ${f.samples.slice(0, 5).join(", ")}` : "";
-        console.warn(
-          `[reindex-audit] ${f.source} — ${f.check}: ${f.count} issues${detail}${samples}`,
-        );
+    // Always log findings to console
+    for (const f of findings) {
+      const detail = f.direction ? ` (${f.direction})` : "";
+      const samples =
+        f.samples.length > 0 ? `: ${f.samples.slice(0, 5).join(", ")}` : "";
+      console.warn(
+        `[reindex-audit] ${f.source} — ${f.check}: ${f.count} issues${detail}${samples}`,
+      );
+    }
+
+    // Only Slack-alert on NEW or CHANGED findings (dedup)
+    const newFindings = findings.filter((f) => {
+      const key = `${f.source}:${f.check}`;
+      const prev = lastAuditFindings.get(key);
+      return prev === undefined || prev !== f.count;
+    });
+
+    // Update the dedup cache with current findings
+    // Clear entries for sources we just audited (so resolved issues don't persist)
+    for (const name of sourceNames) {
+      for (const [key] of lastAuditFindings) {
+        if (key.startsWith(`${name}:`)) lastAuditFindings.delete(key);
       }
-      if (cfg.slackWebhookUrl) {
-        await sendSlackAlert(findings, cfg.slackWebhookUrl);
-      }
+    }
+    for (const f of findings) {
+      lastAuditFindings.set(`${f.source}:${f.check}`, f.count);
+    }
+
+    if (newFindings.length > 0 && cfg.slackWebhookUrl) {
+      await sendSlackAlert(newFindings, cfg.slackWebhookUrl);
     }
 
     return findings;


### PR DESCRIPTION
## Summary

- Audit findings are deduped against the previous run before sending Slack alerts
- Same findings = no alert. New or changed findings = alert.
- Console logging still fires every run for observability
- Prevents the alert spam we saw when first enabling the webhook (same stale data re-reported every reindex cycle)

## Test plan

- [x] 20 audit tests pass (including resetAuditCache in beforeEach)
- [x] Full test suite passes (4892 tests)
- [x] TypeScript clean