### PR TITLE
Fix git credentials in publish job for tag push

### DIFF
--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -77,6 +77,10 @@ jobs:
       - name: Publish to npm
         run: npm publish --access public
 
+      - name: Configure git credentials
+        run: |
+          git config --local url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+
       - name: Ensure git tag exists
         run: |
           TAG="v${{ needs.build.outputs.version }}"


### PR DESCRIPTION
Same fix as CopilotKit/aimock#188 and CopilotKit/CopilotKit#4801 — the build/publish split passes the workspace via artifact but the credential helper doesn't survive. Adds url.insteadOf to inject GITHUB_TOKEN for git push without collapsing the security boundary.