### PR TITLE
Harden real-time re-indexing pipeline

### DIFF
--- a/.github/workflows/index-health-monitor.yml
+++ b/.github/workflows/index-health-monitor.yml
@@ -51,10 +51,12 @@ jobs:
           declare -A INSTANCE_URLS
           INSTANCE_URLS[copilotkit-docs]="https://mcp.copilotkit.ai"
           INSTANCE_URLS[pathfinder-docs]="https://mcp.pathfinder.copilotkit.dev"
+          INSTANCE_URLS[aimock-docs]="https://mcp.aimock.copilotkit.dev" # TODO: verify domain
 
           declare -A CHUNK_FLOORS
           CHUNK_FLOORS[copilotkit-docs]=1000
           CHUNK_FLOORS[pathfinder-docs]=50
+          CHUNK_FLOORS[aimock-docs]=50
 
           # Source-to-repo mappings stored as "source:owner/repo:branch" entries
           COPILOTKIT_DOCS_SOURCES=(
@@ -65,6 +67,10 @@ jobs:
           )
           PATHFINDER_DOCS_SOURCES=(
             "pathfinder-docs:CopilotKit/pathfinder:main"
+          )
+          AIMOCK_DOCS_SOURCES=(
+            "docs:CopilotKit/aimock:main"
+            "code:CopilotKit/aimock:main"
           )
 
           # --- GitHub API: prefetch HEAD commits ---
@@ -212,7 +218,7 @@ jobs:
                     continue
                   fi
                   local age_hours=$(( (NOW - indexed_epoch) / 3600 ))
-                  if [ "$age_hours" -ge 6 ]; then
+                  if [ "$age_hours" -ge 25 ]; then
                     issues+=("commit drift: ${src_key} -- indexed ${indexed_commit}, HEAD is ${head_commit} (last indexed ${age_hours}h ago)")
                   fi
                 else
@@ -406,7 +412,7 @@ jobs:
 
           # --- Main ---
           # Prefetch HEAD commits for all unique repos (avoids subshell cache loss)
-          prefetch_head_commits "${COPILOTKIT_DOCS_SOURCES[@]}" "${PATHFINDER_DOCS_SOURCES[@]}"
+          prefetch_head_commits "${COPILOTKIT_DOCS_SOURCES[@]}" "${PATHFINDER_DOCS_SOURCES[@]}" "${AIMOCK_DOCS_SOURCES[@]}"
 
           process_instance "copilotkit-docs" \
             "${INSTANCE_URLS[copilotkit-docs]}" \
@@ -417,6 +423,11 @@ jobs:
             "${INSTANCE_URLS[pathfinder-docs]}" \
             "${CHUNK_FLOORS[pathfinder-docs]}" \
             "${PATHFINDER_DOCS_SOURCES[@]}"
+
+          process_instance "aimock-docs" \
+            "${INSTANCE_URLS[aimock-docs]}" \
+            "${CHUNK_FLOORS[aimock-docs]}" \
+            "${AIMOCK_DOCS_SOURCES[@]}"
 
           echo ""
           echo "=== Final state ==="

--- a/deploy/setup-webhooks.sh
+++ b/deploy/setup-webhooks.sh
@@ -16,42 +16,53 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 cd "$PROJECT_ROOT"
 
-echo ""
-echo "=== mcp-docs — GitHub Webhook Setup ==="
-echo ""
-
 # ── Parse arguments ───────────────────────────────────────────
 
 CLI_REPOS=()
 CLI_URL=""
+CONFIG_FILE=""
 for arg in "$@"; do
     case "$arg" in
-        --repo=*) CLI_REPOS+=("${arg#--repo=}") ;;
-        --url=*)  CLI_URL="${arg#--url=}" ;;
+        --repo=*)   CLI_REPOS+=("${arg#--repo=}") ;;
+        --url=*)    CLI_URL="${arg#--url=}" ;;
+        --config=*) CONFIG_FILE="${arg#--config=}" ;;
         --help|-h)
-            echo "Usage: $0 [--repo=owner/repo ...] [--url=https://...]"
+            echo "Usage: $0 [--config=<yaml-file>] [--repo=owner/repo ...] [--url=https://...]"
             echo ""
             echo "Options:"
+            echo "  --config=FILE      Deploy YAML to read (default: mcp-docs.yaml)"
             echo "  --repo=OWNER/REPO  Repository to configure (repeatable)"
             echo "  --url=URL          Webhook delivery URL"
             echo ""
             echo "If --repo is not provided, repos are read from webhook.repo_sources"
-            echo "in mcp-docs.yaml. If --url is not provided, you will be prompted."
+            echo "in the config YAML. If --url is not provided, you will be prompted."
             exit 0
             ;;
     esac
 done
 
+# Default config file if not specified
+if [ -z "$CONFIG_FILE" ]; then
+    CONFIG_FILE="mcp-docs.yaml"
+fi
+
+INSTANCE_NAME="${CONFIG_FILE%.yaml}"
+echo ""
+echo "=== ${INSTANCE_NAME} — GitHub Webhook Setup ==="
+echo ""
+
 # ── Repos to configure ─────────────────────────────────────────
+
+REPOS=()
 
 if [ ${#CLI_REPOS[@]} -gt 0 ]; then
     REPOS=("${CLI_REPOS[@]}")
 else
-    # Try to read repos from mcp-docs.yaml webhook.repo_sources keys
-    if [ -f mcp-docs.yaml ] && command -v python3 &>/dev/null; then
+    # Try to read repos from config YAML webhook.repo_sources keys
+    if [ -f "$CONFIG_FILE" ] && command -v python3 &>/dev/null; then
         mapfile -t REPOS < <(python3 -c "
 import yaml, sys
-with open('mcp-docs.yaml') as f:
+with open('$CONFIG_FILE') as f:
     cfg = yaml.safe_load(f)
 for repo in cfg.get('webhook', {}).get('repo_sources', {}):
     print(repo)
@@ -59,7 +70,7 @@ for repo in cfg.get('webhook', {}).get('repo_sources', {}):
     fi
 
     if [ ${#REPOS[@]} -eq 0 ]; then
-        error "No repos found. Provide --repo=owner/repo or configure webhook.repo_sources in mcp-docs.yaml"
+        error "No repos found. Provide --repo=owner/repo or configure webhook.repo_sources in ${CONFIG_FILE}"
         exit 1
     fi
 fi
@@ -135,6 +146,7 @@ for REPO in "${REPOS[@]}"; do
             -f "config[url]=${WEBHOOK_URL}" \
             -f "config[content_type]=json" \
             -f "config[secret]=${WEBHOOK_SECRET}" \
+            -F "events[]=push" \
             -F "active=true" &>/dev/null; then
             printf "${GREEN}updated${NC} (hook #%s)\n" "$EXISTING_HOOK_ID"
             UPDATED=$((UPDATED + 1))

--- a/src/__tests__/discord-webhook.test.ts
+++ b/src/__tests__/discord-webhook.test.ts
@@ -10,6 +10,13 @@ vi.mock("discord-interactions", () => ({
   verifyKey: vi.fn(),
 }));
 
+// Mock recordWebhookDelivery
+const mockRecordWebhookDelivery = vi.fn().mockResolvedValue(undefined);
+vi.mock("../db/queries.js", () => ({
+  recordWebhookDelivery: (...args: unknown[]) =>
+    mockRecordWebhookDelivery(...args),
+}));
+
 // Mock config
 vi.mock("../config.js", () => ({
   getConfig: vi.fn().mockReturnValue({
@@ -179,5 +186,86 @@ describe("createDiscordWebhookHandler", () => {
 
     await handler(req, res);
     expect(res.status).toHaveBeenCalledWith(400);
+  });
+
+  // -- Webhook delivery tracking ----------------------------------------
+
+  describe("webhook delivery tracking", () => {
+    it("records 'ignored' delivery for PING interaction", async () => {
+      const { req, res } = mockReqRes({ type: 1 });
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "discord",
+          event_type: "PING",
+          decision: "ignored",
+          reason: "PING interaction",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for unhandled interaction types", async () => {
+      const { req, res } = mockReqRes({ type: 2, data: { name: "test" } });
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "discord",
+          event_type: "interaction_type_2",
+          decision: "ignored",
+          reason: "unhandled interaction type: 2",
+        }),
+      );
+    });
+
+    it("records 'error' delivery for invalid signature", async () => {
+      (verifyKey as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+      const { req, res } = mockReqRes({ type: 1 });
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "discord",
+          decision: "error",
+          reason: "invalid signature",
+        }),
+      );
+    });
+
+    it("records 'error' delivery for malformed JSON", async () => {
+      (verifyKey as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+      const req = {
+        body: Buffer.from("not json"),
+        headers: {
+          "x-signature-ed25519": "sig",
+          "x-signature-timestamp": "12345",
+        },
+      } as any;
+      const res = { status: vi.fn().mockReturnThis(), json: vi.fn() } as any;
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "discord",
+          decision: "error",
+          reason: "malformed JSON",
+        }),
+      );
+    });
+
+    it("includes payload_size in delivery records", async () => {
+      const { req, res } = mockReqRes({ type: 1 });
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload_size: expect.any(Number),
+        }),
+      );
+    });
+
+    it("does not fail webhook processing when tracking throws", async () => {
+      mockRecordWebhookDelivery.mockRejectedValueOnce(new Error("DB down"));
+      const { req, res } = mockReqRes({ type: 1 });
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ type: 1 });
+    });
   });
 });

--- a/src/__tests__/faq-txt-endpoint.test.ts
+++ b/src/__tests__/faq-txt-endpoint.test.ts
@@ -12,6 +12,7 @@ vi.mock("../db/queries.js", () => ({
   getIndexStats: vi.fn(),
   getAllChunksForLlms: vi.fn(),
   insertCollectedData: vi.fn(),
+  getWebhookDeliveryStats: vi.fn().mockResolvedValue(null),
 }));
 
 // Mock config so getServerConfig returns a stable set of FAQ sources.

--- a/src/__tests__/github-webhook.test.ts
+++ b/src/__tests__/github-webhook.test.ts
@@ -14,6 +14,13 @@ vi.mock("../config.js", () => ({
   getServerConfig: (...args: unknown[]) => mockGetServerConfig(...args),
 }));
 
+// Mock recordWebhookDelivery
+const mockRecordWebhookDelivery = vi.fn().mockResolvedValue(undefined);
+vi.mock("../db/queries.js", () => ({
+  recordWebhookDelivery: (...args: unknown[]) =>
+    mockRecordWebhookDelivery(...args),
+}));
+
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
@@ -414,6 +421,120 @@ describe("GitHub webhook handler", () => {
       expect(orchestrator.queueIncrementalReindex).toHaveBeenCalledWith(
         "https://github.com/org/repo.git",
       );
+    });
+  });
+
+  // -- Webhook delivery tracking ----------------------------------------
+
+  describe("webhook delivery tracking", () => {
+    it("records 'queued' delivery on successful push", async () => {
+      const { req, res } = mockReqRes(makePushPayload());
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "github",
+          event_type: "push",
+          repo: "org/repo",
+          decision: "queued",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for non-push events", async () => {
+      const { req, res } = mockReqRes(makePushPayload(), {
+        "x-github-event": "ping",
+      });
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "github",
+          event_type: "ping",
+          decision: "ignored",
+          reason: "not a push event",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for non-default branch", async () => {
+      const payload = makePushPayload({ ref: "refs/heads/feature/my-branch" });
+      const { req, res } = mockReqRes(payload);
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "github",
+          decision: "ignored",
+          reason: "not the default branch",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for repo not in config", async () => {
+      const payload = makePushPayload({
+        repository: {
+          clone_url: "https://github.com/other/repo.git",
+          default_branch: "main",
+          full_name: "other/repo",
+        },
+      });
+      const { req, res } = mockReqRes(payload);
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "github",
+          decision: "ignored",
+          reason: "repo not in webhook config",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for no path triggers matched", async () => {
+      const payload = makePushPayload({
+        commits: [{ added: ["src/index.ts"], modified: [], removed: [] }],
+      });
+      const { req, res } = mockReqRes(payload);
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "github",
+          decision: "ignored",
+          reason: "no path triggers matched",
+        }),
+      );
+    });
+
+    it("records 'error' delivery for invalid signature", async () => {
+      const payload = makePushPayload();
+      const { req, res } = mockReqRes(payload, {
+        "x-hub-signature-256":
+          "sha256=0000000000000000000000000000000000000000000000000000000000000000",
+      });
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "github",
+          decision: "error",
+          reason: "invalid signature",
+        }),
+      );
+    });
+
+    it("includes payload_size in delivery records", async () => {
+      const { req, res } = mockReqRes(makePushPayload());
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload_size: expect.any(Number),
+        }),
+      );
+    });
+
+    it("does not fail webhook processing when tracking throws", async () => {
+      mockRecordWebhookDelivery.mockRejectedValueOnce(new Error("DB down"));
+      const { req, res } = mockReqRes(makePushPayload());
+      await handler(req, res);
+      // Handler should still succeed
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(res.json).toHaveBeenCalledWith({ queued: true });
     });
   });
 });

--- a/src/__tests__/orchestrator-dedup-parallel.test.ts
+++ b/src/__tests__/orchestrator-dedup-parallel.test.ts
@@ -1,0 +1,401 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Track which jobs execute and their timing for concurrency assertions
+const executionLog: {
+  type: string;
+  key: string;
+  start: number;
+  end: number;
+}[] = [];
+let jobDelay = 50; // ms — controllable per-test
+
+// Mock all external dependencies before importing orchestrator
+vi.mock("../config.js", () => ({
+  getConfig: vi.fn().mockReturnValue({
+    databaseUrl: "postgresql://test",
+    openaiApiKey: "test-key",
+    githubToken: "",
+    githubWebhookSecret: "",
+    port: 3001,
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: "/tmp/test",
+    slackBotToken: "xoxb-test",
+    slackSigningSecret: "test-secret",
+  }),
+  getServerConfig: vi.fn().mockReturnValue({
+    server: { name: "test", version: "1.0" },
+    sources: [
+      {
+        name: "repo-a-docs",
+        type: "markdown",
+        path: "/docs",
+        repo: "https://github.com/org/repo-a",
+        file_patterns: ["**/*.md"],
+        chunk: {},
+      },
+      {
+        name: "repo-b-docs",
+        type: "markdown",
+        path: "/docs",
+        repo: "https://github.com/org/repo-b",
+        file_patterns: ["**/*.md"],
+        chunk: {},
+      },
+      {
+        name: "repo-a-code",
+        type: "markdown",
+        path: "/src",
+        repo: "https://github.com/org/repo-a",
+        file_patterns: ["**/*.ts"],
+        chunk: {},
+      },
+      {
+        name: "slack-support",
+        type: "slack",
+        channels: ["C001"],
+        confidence_threshold: 0.7,
+        trigger_emoji: "pathfinder",
+        min_thread_replies: 2,
+        chunk: {},
+      },
+    ],
+    tools: [
+      {
+        name: "search-a",
+        type: "search",
+        description: "Search repo A docs",
+        source: "repo-a-docs",
+        default_limit: 5,
+        max_limit: 20,
+        result_format: "docs",
+      },
+      {
+        name: "search-b",
+        type: "search",
+        description: "Search repo B docs",
+        source: "repo-b-docs",
+        default_limit: 5,
+        max_limit: 20,
+        result_format: "docs",
+      },
+      {
+        name: "search-slack",
+        type: "search",
+        description: "Search Slack",
+        source: "slack-support",
+        default_limit: 5,
+        max_limit: 20,
+        result_format: "docs",
+      },
+    ],
+    embedding: {
+      provider: "openai",
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+    },
+    indexing: {
+      auto_reindex: false,
+      reindex_hour_utc: 3,
+      stale_threshold_hours: 24,
+    },
+  }),
+  getIndexableSourceNames: vi
+    .fn()
+    .mockReturnValue(
+      new Set(["repo-a-docs", "repo-b-docs", "repo-a-code", "slack-support"]),
+    ),
+}));
+
+vi.mock("../db/queries.js", () => ({
+  getIndexState: vi.fn().mockResolvedValue(null),
+  upsertIndexState: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../indexing/embeddings.js", () => {
+  class MockEmbeddingProvider {
+    embed = vi.fn().mockResolvedValue([0.1, 0.2]);
+    embedBatch = vi.fn().mockResolvedValue([[0.1, 0.2]]);
+  }
+  return {
+    EmbeddingClient: MockEmbeddingProvider,
+    createEmbeddingProvider: () => new MockEmbeddingProvider(),
+  };
+});
+
+vi.mock("../indexing/pipeline.js", () => {
+  return {
+    IndexingPipeline: class MockIndexingPipeline {
+      indexItems = vi.fn().mockResolvedValue(undefined);
+      removeItems = vi.fn().mockResolvedValue(undefined);
+    },
+  };
+});
+
+vi.mock("../indexing/providers/index.js", () => ({
+  getProvider: vi.fn().mockReturnValue(() => ({
+    fullAcquire: vi.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, jobDelay));
+      return { items: [], removedIds: [], stateToken: "test-token" };
+    }),
+    incrementalAcquire: vi.fn().mockImplementation(async () => {
+      await new Promise((r) => setTimeout(r, jobDelay));
+      return { items: [], removedIds: [], stateToken: "test-token" };
+    }),
+    getCurrentStateToken: vi.fn().mockResolvedValue("test-token"),
+  })),
+}));
+
+import { IndexingOrchestrator } from "../indexing/orchestrator.js";
+
+// Helper: wait for all jobs to finish (poll onReindexComplete or activeJobCount)
+async function waitForDrain(
+  orchestrator: IndexingOrchestrator,
+  timeoutMs = 5000,
+): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    if (!orchestrator.isIndexing()) return;
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error("Timed out waiting for drain to complete");
+}
+
+describe("Queue-level deduplication", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executionLog.length = 0;
+    jobDelay = 50;
+  });
+
+  it("deduplicates incremental-reindex jobs for the same repo", async () => {
+    const orchestrator = new IndexingOrchestrator();
+    const completeSpy = vi.fn();
+    orchestrator.onReindexComplete = completeSpy;
+
+    // Make jobs slow so the second arrives while the first is still queued
+    jobDelay = 200;
+
+    // Queue same repo twice rapidly
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-a");
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-a");
+
+    await waitForDrain(orchestrator);
+
+    // Should only get one completion callback — the second was deduped
+    expect(completeSpy.mock.calls.length).toBe(1);
+  });
+
+  it("does NOT deduplicate incremental-reindex jobs for different repos", async () => {
+    const orchestrator = new IndexingOrchestrator();
+    const completeSpy = vi.fn();
+    orchestrator.onReindexComplete = completeSpy;
+
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-a");
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-b");
+
+    await waitForDrain(orchestrator);
+
+    // Both should execute
+    expect(completeSpy.mock.calls.length).toBe(2);
+  });
+
+  it("deduplicates source-reindex jobs for the same source", async () => {
+    const orchestrator = new IndexingOrchestrator();
+    const logSpy = vi.spyOn(console, "log");
+
+    // Make jobs slow so the second arrives while the first is still queued
+    jobDelay = 200;
+
+    orchestrator.queueSourceReindex("slack-support");
+    orchestrator.queueSourceReindex("slack-support");
+
+    // Verify dedup log was emitted
+    expect(
+      logSpy.mock.calls.some(
+        (args) =>
+          typeof args[0] === "string" &&
+          args[0].includes("Source re-index for slack-support already queued"),
+      ),
+    ).toBe(true);
+
+    await waitForDrain(orchestrator);
+    logSpy.mockRestore();
+  });
+
+  it("deduplicates full-reindex jobs", async () => {
+    const orchestrator = new IndexingOrchestrator();
+    const logSpy = vi.spyOn(console, "log");
+
+    jobDelay = 200;
+
+    orchestrator.queueFullReindex();
+    orchestrator.queueFullReindex();
+
+    expect(
+      logSpy.mock.calls.some(
+        (args) =>
+          typeof args[0] === "string" &&
+          args[0].includes("Full re-index already queued, skipping"),
+      ),
+    ).toBe(true);
+
+    await waitForDrain(orchestrator);
+    logSpy.mockRestore();
+  });
+
+  it("allows re-queuing after a job has been consumed from the queue", async () => {
+    const orchestrator = new IndexingOrchestrator();
+    const completeSpy = vi.fn();
+    orchestrator.onReindexComplete = completeSpy;
+    jobDelay = 10;
+
+    orchestrator.queueSourceReindex("slack-support");
+    await waitForDrain(orchestrator);
+
+    // Now queue the same source again — should be allowed since first was consumed
+    orchestrator.queueSourceReindex("slack-support");
+    await waitForDrain(orchestrator);
+
+    expect(completeSpy.mock.calls.length).toBe(2);
+  });
+});
+
+describe("Concurrent drain with per-repo coordination", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    executionLog.length = 0;
+    jobDelay = 50;
+  });
+
+  it("processes jobs for different repos in parallel", async () => {
+    jobDelay = 100;
+    const orchestrator = new IndexingOrchestrator({ maxConcurrent: 3 });
+    const callTimes: number[] = [];
+    const completeSpy = vi.fn().mockImplementation(() => {
+      callTimes.push(Date.now());
+    });
+    orchestrator.onReindexComplete = completeSpy;
+
+    const start = Date.now();
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-a");
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-b");
+
+    await waitForDrain(orchestrator);
+
+    // Both should complete
+    expect(completeSpy.mock.calls.length).toBe(2);
+
+    // If they ran in parallel, total time should be roughly 1x jobDelay, not 2x.
+    // Allow generous margin for test execution overhead.
+    const elapsed = Date.now() - start;
+    // Serial would take ~200ms+ (2 * 100ms). Parallel should be ~100ms + overhead.
+    // Use a generous upper bound — mainly checking they're not strictly serial.
+    expect(elapsed).toBeLessThan(350);
+  });
+
+  it("serializes jobs for the same repo", async () => {
+    jobDelay = 80;
+    // Use maxConcurrent=3 but queue two jobs for the same repo
+    const orchestrator = new IndexingOrchestrator({ maxConcurrent: 3 });
+    const completeSpy = vi.fn();
+    orchestrator.onReindexComplete = completeSpy;
+
+    // Queue two incremental-reindex for the same repo — second will be deduped!
+    // Instead, queue an incremental-reindex and a source-reindex for same repo.
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-a");
+    orchestrator.queueSourceReindex("repo-a-docs"); // This source is in repo-a
+
+    const start = Date.now();
+    await waitForDrain(orchestrator);
+
+    // Both should complete
+    expect(completeSpy.mock.calls.length).toBe(2);
+
+    // If they were serialized (same repo), total time should be >= 2x jobDelay
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(140); // 2 * 80ms - small margin
+  });
+
+  it("respects maxConcurrent limit", async () => {
+    jobDelay = 100;
+    const orchestrator = new IndexingOrchestrator({ maxConcurrent: 1 });
+    const completeSpy = vi.fn();
+    orchestrator.onReindexComplete = completeSpy;
+
+    const start = Date.now();
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-a");
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-b");
+
+    await waitForDrain(orchestrator);
+
+    // With maxConcurrent=1, even different repos should be serial
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeGreaterThanOrEqual(180); // 2 * 100ms - small margin
+    expect(completeSpy.mock.calls.length).toBe(2);
+  });
+
+  it("defaults maxConcurrent to 3", () => {
+    const orchestrator = new IndexingOrchestrator();
+    // Access private field via type assertion for testing
+    expect(
+      (orchestrator as unknown as { maxConcurrent: number }).maxConcurrent,
+    ).toBe(3);
+  });
+
+  it("full-reindex gets exclusive access (blocks other jobs)", async () => {
+    jobDelay = 80;
+    const orchestrator = new IndexingOrchestrator({ maxConcurrent: 3 });
+    const completeSpy = vi.fn();
+    orchestrator.onReindexComplete = completeSpy;
+
+    // Queue a full-reindex followed by an incremental
+    orchestrator.queueFullReindex();
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-b");
+
+    const start = Date.now();
+    await waitForDrain(orchestrator);
+
+    // Full reindex should block the incremental — they run serially
+    const elapsed = Date.now() - start;
+    // Full reindex indexes all sources (repo-a-docs, repo-b-docs, repo-a-code, slack-support)
+    // That's 4 source calls * 80ms each = 320ms, plus the incremental for repo-b = 1 more * 80ms
+    // Total serial: ~400ms minimum
+    expect(elapsed).toBeGreaterThanOrEqual(300);
+    expect(completeSpy.mock.calls.length).toBe(2);
+  });
+
+  it("isIndexing returns true while jobs are running", async () => {
+    jobDelay = 200;
+    const orchestrator = new IndexingOrchestrator();
+
+    expect(orchestrator.isIndexing()).toBe(false);
+
+    orchestrator.queueSourceReindex("slack-support");
+
+    // Give drain a tick to start
+    await new Promise((r) => setTimeout(r, 20));
+    expect(orchestrator.isIndexing()).toBe(true);
+
+    await waitForDrain(orchestrator);
+    expect(orchestrator.isIndexing()).toBe(false);
+  });
+
+  it("non-repo source jobs (slack) can run in parallel with repo jobs", async () => {
+    jobDelay = 100;
+    const orchestrator = new IndexingOrchestrator({ maxConcurrent: 3 });
+    const completeSpy = vi.fn();
+    orchestrator.onReindexComplete = completeSpy;
+
+    const start = Date.now();
+    orchestrator.queueSourceReindex("slack-support"); // no repo
+    orchestrator.queueIncrementalReindex("https://github.com/org/repo-a");
+
+    await waitForDrain(orchestrator);
+
+    // Should run in parallel (different repos / no repo conflict)
+    const elapsed = Date.now() - start;
+    expect(elapsed).toBeLessThan(350);
+    expect(completeSpy.mock.calls.length).toBe(2);
+  });
+});

--- a/src/__tests__/slack-webhook.test.ts
+++ b/src/__tests__/slack-webhook.test.ts
@@ -6,6 +6,19 @@ import {
   type SlackReindexOrchestrator,
 } from "../webhooks/slack.js";
 
+// Mock types (to avoid zod dependency)
+vi.mock("../types.js", () => ({
+  isSlackSourceConfig: (s: Record<string, unknown>) => s.type === "slack",
+  isDiscordSourceConfig: (s: Record<string, unknown>) => s.type === "discord",
+}));
+
+// Mock recordWebhookDelivery
+const mockRecordWebhookDelivery = vi.fn().mockResolvedValue(undefined);
+vi.mock("../db/queries.js", () => ({
+  recordWebhookDelivery: (...args: unknown[]) =>
+    mockRecordWebhookDelivery(...args),
+}));
+
 // Mock config
 vi.mock("../config.js", () => ({
   getConfig: vi.fn().mockReturnValue({
@@ -236,5 +249,119 @@ describe("createSlackWebhookHandler", () => {
     expect(res.json).toHaveBeenCalledWith(
       expect.objectContaining({ ignored: true }),
     );
+  });
+
+  // -- Webhook delivery tracking ----------------------------------------
+
+  describe("webhook delivery tracking", () => {
+    it("records 'queued' delivery on matching reaction", async () => {
+      const { req, res } = mockReqRes({
+        type: "event_callback",
+        event: {
+          type: "reaction_added",
+          reaction: "pathfinder",
+          item: { type: "message", channel: "C001", ts: "1234.5678" },
+        },
+      });
+
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "slack",
+          event_type: "reaction_added",
+          decision: "queued",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for non-matching reaction", async () => {
+      const { req, res } = mockReqRes({
+        type: "event_callback",
+        event: {
+          type: "reaction_added",
+          reaction: "thumbsup",
+          item: { type: "message", channel: "C001", ts: "1234.5678" },
+        },
+      });
+
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "slack",
+          event_type: "reaction_added",
+          decision: "ignored",
+          reason: "no matching Slack source configured",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for url_verification", async () => {
+      const { req, res } = mockReqRes({
+        type: "url_verification",
+        challenge: "abc123",
+      });
+      req.body = Buffer.from(
+        JSON.stringify({ type: "url_verification", challenge: "abc123" }),
+      );
+
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "slack",
+          event_type: "url_verification",
+          decision: "ignored",
+          reason: "url verification challenge",
+        }),
+      );
+    });
+
+    it("records 'ignored' delivery for unknown event types", async () => {
+      const { req, res } = mockReqRes({
+        type: "event_callback",
+        event: { type: "message" },
+      });
+
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          source: "slack",
+          event_type: "message",
+          decision: "ignored",
+        }),
+      );
+    });
+
+    it("includes payload_size in delivery records", async () => {
+      const { req, res } = mockReqRes({
+        type: "event_callback",
+        event: {
+          type: "reaction_added",
+          reaction: "pathfinder",
+          item: { type: "message", channel: "C001", ts: "1234.5678" },
+        },
+      });
+
+      await handler(req, res);
+      expect(mockRecordWebhookDelivery).toHaveBeenCalledWith(
+        expect.objectContaining({
+          payload_size: expect.any(Number),
+        }),
+      );
+    });
+
+    it("does not fail webhook processing when tracking throws", async () => {
+      mockRecordWebhookDelivery.mockRejectedValueOnce(new Error("DB down"));
+      const { req, res } = mockReqRes({
+        type: "event_callback",
+        event: {
+          type: "reaction_added",
+          reaction: "pathfinder",
+          item: { type: "message", channel: "C001", ts: "1234.5678" },
+        },
+      });
+
+      await handler(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+    });
   });
 });

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -435,6 +435,176 @@ export async function insertCollectedData(
 }
 
 // ---------------------------------------------------------------------------
+// Webhook delivery tracking
+// ---------------------------------------------------------------------------
+
+export interface WebhookDelivery {
+  id: number;
+  source: string;
+  event_type: string | null;
+  repo: string | null;
+  decision: string;
+  reason: string | null;
+  payload_size: number | null;
+  delivered_at: Date;
+}
+
+/**
+ * Record a webhook delivery. Fire-and-forget: catches all errors and logs
+ * them so webhook processing is never blocked by tracking failures.
+ */
+export async function recordWebhookDelivery(delivery: {
+  source: string;
+  event_type?: string;
+  repo?: string;
+  decision: string;
+  reason?: string;
+  payload_size?: number;
+}): Promise<void> {
+  try {
+    const pool = getPool();
+    await pool.query(
+      `INSERT INTO webhook_deliveries (source, event_type, repo, decision, reason, payload_size)
+       VALUES ($1, $2, $3, $4, $5, $6)`,
+      [
+        delivery.source,
+        delivery.event_type ?? null,
+        delivery.repo ?? null,
+        delivery.decision,
+        delivery.reason ?? null,
+        delivery.payload_size ?? null,
+      ],
+    );
+  } catch (err) {
+    console.error("[webhook-tracking] Failed to record delivery:", err);
+  }
+}
+
+/**
+ * Fetch recent webhook deliveries, ordered by most recent first.
+ */
+export async function getRecentWebhookDeliveries(
+  limit: number = 50,
+): Promise<WebhookDelivery[]> {
+  const pool = getPool();
+  const { rows } = await pool.query(
+    `SELECT id, source, event_type, repo, decision, reason, payload_size, delivered_at
+     FROM webhook_deliveries
+     ORDER BY delivered_at DESC
+     LIMIT $1`,
+    [limit],
+  );
+  return rows.map((r: Record<string, unknown>) => ({
+    id: r.id as number,
+    source: r.source as string,
+    event_type: (r.event_type as string) ?? null,
+    repo: (r.repo as string) ?? null,
+    decision: r.decision as string,
+    reason: (r.reason as string) ?? null,
+    payload_size: (r.payload_size as number) ?? null,
+    delivered_at: r.delivered_at as Date,
+  }));
+}
+
+/**
+ * Get webhook delivery stats for the last 24 hours, for the health endpoint.
+ */
+export async function getWebhookDeliveryStats(): Promise<{
+  total_24h: number;
+  by_decision: Record<string, number>;
+  last_delivery_at: string | null;
+  errors_24h: Array<{
+    source: string;
+    reason: string | null;
+    delivered_at: Date;
+  }>;
+}> {
+  const pool = getPool();
+
+  const [countsResult, lastResult, errorsResult] = await Promise.all([
+    pool.query(
+      `SELECT decision, count(*)::int AS count
+       FROM webhook_deliveries
+       WHERE delivered_at > NOW() - INTERVAL '24 hours'
+       GROUP BY decision`,
+    ),
+    pool.query(
+      `SELECT delivered_at FROM webhook_deliveries ORDER BY delivered_at DESC LIMIT 1`,
+    ),
+    pool.query(
+      `SELECT source, reason, delivered_at
+       FROM webhook_deliveries
+       WHERE decision = 'error' AND delivered_at > NOW() - INTERVAL '24 hours'
+       ORDER BY delivered_at DESC`,
+    ),
+  ]);
+
+  const byDecision: Record<string, number> = {};
+  let total = 0;
+  for (const row of countsResult.rows) {
+    byDecision[row.decision as string] = row.count as number;
+    total += row.count as number;
+  }
+
+  const lastRow = lastResult.rows[0];
+  const lastDeliveryAt = lastRow
+    ? (lastRow.delivered_at as Date).toISOString()
+    : null;
+
+  const errors = errorsResult.rows.map((r: Record<string, unknown>) => ({
+    source: r.source as string,
+    reason: (r.reason as string) ?? null,
+    delivered_at: r.delivered_at as Date,
+  }));
+
+  return {
+    total_24h: total,
+    by_decision: byDecision,
+    last_delivery_at: lastDeliveryAt,
+    errors_24h: errors,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Webhook delivery cleanup
+// ---------------------------------------------------------------------------
+
+/**
+ * Delete webhook_deliveries rows older than the specified number of days.
+ * Mirrors cleanupOldQueryLogs in analytics.ts — rolling retention window
+ * anchored to NOW().
+ *
+ * Returns the number of rows deleted.
+ */
+export async function cleanupOldWebhookDeliveries(
+  retentionDays: number,
+): Promise<number> {
+  if (!Number.isFinite(retentionDays) || retentionDays <= 0) {
+    throw new Error(
+      `[webhook-tracking] cleanupOldWebhookDeliveries: invalid retentionDays=${retentionDays} (must be a positive finite number)`,
+    );
+  }
+  const pool = getPool();
+  try {
+    const result = await pool.query(
+      `DELETE FROM webhook_deliveries WHERE delivered_at <= NOW() - INTERVAL '1 day' * $1`,
+      [retentionDays],
+    );
+    const rowCount = result.rowCount ?? 0;
+    console.log(
+      `[webhook-tracking] cleanupOldWebhookDeliveries: deleted ${rowCount} rows older than ${retentionDays} days`,
+    );
+    return rowCount;
+  } catch (err) {
+    console.error(
+      `[webhook-tracking] cleanupOldWebhookDeliveries failed (retentionDays=${retentionDays})`,
+      err,
+    );
+    throw err;
+  }
+}
+
+// ---------------------------------------------------------------------------
 // Statistics
 // ---------------------------------------------------------------------------
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -102,6 +102,20 @@ CREATE TABLE IF NOT EXISTS query_log (
 
 CREATE INDEX IF NOT EXISTS idx_query_log_created_at ON query_log (created_at);
 CREATE INDEX IF NOT EXISTS idx_query_log_tool_name ON query_log (tool_name);
+
+-- Webhook delivery tracking
+CREATE TABLE IF NOT EXISTS webhook_deliveries (
+    id              SERIAL PRIMARY KEY,
+    source          TEXT NOT NULL,
+    event_type      TEXT,
+    repo            TEXT,
+    decision        TEXT NOT NULL,
+    reason          TEXT,
+    payload_size    INTEGER,
+    delivered_at    TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_source ON webhook_deliveries (source);
+CREATE INDEX IF NOT EXISTS idx_webhook_deliveries_delivered_at ON webhook_deliveries (delivered_at);
 `;
 
   return coreSql;

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -14,7 +14,11 @@ import { createEmbeddingProvider } from "./embeddings.js";
 import type { EmbeddingProvider } from "./embeddings.js";
 import { getProvider } from "./providers/index.js";
 import { IndexingPipeline } from "./pipeline.js";
-import { getIndexState, upsertIndexState } from "../db/queries.js";
+import {
+  getIndexState,
+  upsertIndexState,
+  cleanupOldWebhookDeliveries,
+} from "../db/queries.js";
 import { cleanupOldQueryLogs } from "../db/analytics.js";
 import { isFileSourceConfig } from "../types.js";
 import type { IndexState, IndexStatus, SourceConfig } from "../types.js";
@@ -48,10 +52,22 @@ interface Job {
 export class IndexingOrchestrator {
   private queue: Job[] = [];
   private running = false;
-  private processing = false;
+  private draining = false;
 
   // Per-source mutex: prevents concurrent indexing of the same source
   private activeSources = new Set<string>();
+
+  // Per-repo mutex: prevents concurrent indexing of the same repo across jobs
+  private activeRepos = new Set<string>();
+
+  // Dedup keys for jobs currently being executed (not in queue but running)
+  private executingJobKeys = new Set<string>();
+
+  // Number of jobs currently executing
+  private activeJobCount = 0;
+
+  // Maximum number of concurrent indexing jobs
+  private maxConcurrent: number;
 
   // Track last nightly reindex date to prevent drift-based duplicate triggers
   private lastReindexDate: string | null = null;
@@ -59,8 +75,8 @@ export class IndexingOrchestrator {
   // Callback fired after each reindex job completes with affected source names
   onReindexComplete?: (sourceNames: string[]) => void;
 
-  constructor() {
-    // No-op — all setup happens lazily via getConfig()
+  constructor(options?: { maxConcurrent?: number }) {
+    this.maxConcurrent = options?.maxConcurrent ?? 3;
   }
 
   /**
@@ -238,10 +254,51 @@ export class IndexingOrchestrator {
   }
 
   /**
+   * Derive a dedup key for a job. Jobs with the same key are considered duplicates.
+   */
+  private jobDedupKey(job: Job): string {
+    if (job.type === "incremental-reindex") return `incremental:${job.repoUrl}`;
+    if (job.type === "source-reindex") return `source:${job.sourceName}`;
+    if (job.type === "full-reindex") return "full-reindex";
+    // full-reindex-local jobs are not deduped (they carry specific source lists)
+    return `local:${job.sources?.map((s) => s.name).join(",") ?? ""}`;
+  }
+
+  /**
+   * Check if a job is a duplicate of one already queued or currently executing.
+   */
+  private isDuplicateJob(job: Job): boolean {
+    const key = this.jobDedupKey(job);
+    if (this.executingJobKeys.has(key)) return true;
+    if (job.type === "full-reindex") {
+      return this.queue.some((j) => j.type === "full-reindex");
+    }
+    if (job.type === "incremental-reindex") {
+      return this.queue.some(
+        (j) => j.type === "incremental-reindex" && j.repoUrl === job.repoUrl,
+      );
+    }
+    if (job.type === "source-reindex") {
+      return this.queue.some(
+        (j) => j.type === "source-reindex" && j.sourceName === job.sourceName,
+      );
+    }
+    return false;
+  }
+
+  /**
    * Queue a full re-index of all sources. Returns immediately.
+   * Deduplicates: only one full-reindex can be queued or running at a time.
    */
   queueFullReindex(): void {
-    this.queue.push({ type: "full-reindex" });
+    const job: Job = { type: "full-reindex" };
+    if (this.isDuplicateJob(job)) {
+      console.log(
+        "[orchestrator] Full re-index already queued, skipping duplicate",
+      );
+      return;
+    }
+    this.queue.push(job);
     console.log("[orchestrator] Full re-index queued");
     this.drain().catch((err) => {
       console.error("[orchestrator] drain() failed:", err);
@@ -250,9 +307,17 @@ export class IndexingOrchestrator {
 
   /**
    * Queue an incremental re-index for a specific repo. Returns immediately.
+   * Deduplicates on (type, repoUrl): skips if the same repo is already queued or running.
    */
   queueIncrementalReindex(repoUrl: string): void {
-    this.queue.push({ type: "incremental-reindex", repoUrl });
+    const job: Job = { type: "incremental-reindex", repoUrl };
+    if (this.isDuplicateJob(job)) {
+      console.log(
+        `[orchestrator] Incremental re-index for ${repoUrl} already queued, skipping`,
+      );
+      return;
+    }
+    this.queue.push(job);
     console.log(`[orchestrator] Incremental re-index queued for ${repoUrl}`);
     this.drain().catch((err) => {
       console.error("[orchestrator] drain() failed:", err);
@@ -262,9 +327,17 @@ export class IndexingOrchestrator {
   /**
    * Queue a reindex for a single named source. Returns immediately.
    * Used by webhook handlers to trigger reindexing of specific sources.
+   * Deduplicates on (type, sourceName): skips if the same source is already queued or running.
    */
   queueSourceReindex(sourceName: string): void {
-    this.queue.push({ type: "source-reindex", sourceName });
+    const job: Job = { type: "source-reindex", sourceName };
+    if (this.isDuplicateJob(job)) {
+      console.log(
+        `[orchestrator] Source re-index for ${sourceName} already queued, skipping`,
+      );
+      return;
+    }
+    this.queue.push(job);
     console.log(`[orchestrator] Source re-index queued for ${sourceName}`);
     this.drain().catch((err) => {
       console.error("[orchestrator] drain() failed:", err);
@@ -315,6 +388,19 @@ export class IndexingOrchestrator {
             .catch((err) => {
               console.error("[analytics] Cleanup failed:", err);
             });
+
+          // Webhook delivery cleanup — 30-day retention
+          cleanupOldWebhookDeliveries(30)
+            .then((deleted) => {
+              if (deleted > 0) {
+                console.log(
+                  `[webhook-tracking] Cleaned up ${deleted} webhook_deliveries rows older than 30 days`,
+                );
+              }
+            })
+            .catch((err) => {
+              console.error("[webhook-tracking] Cleanup failed:", err);
+            });
         }
       }
     }, 60_000);
@@ -337,26 +423,132 @@ export class IndexingOrchestrator {
   }
 
   /**
-   * Process the job queue (max 1 concurrent job).
+   * Derive the repo URL(s) a job will touch, for concurrency coordination.
+   * Returns null for full-reindex (touches all repos — needs exclusive access)
+   * or for local/non-repo sources that don't have a repo URL.
+   */
+  private getJobRepoKey(job: Job): string | null {
+    if (job.type === "incremental-reindex") {
+      return job.repoUrl ?? null;
+    }
+    if (job.type === "source-reindex" && job.sourceName) {
+      const serverCfg = getServerConfig();
+      const source = serverCfg.sources.find((s) => s.name === job.sourceName);
+      if (source && isFileSourceConfig(source) && source.repo) {
+        return source.repo;
+      }
+      return null; // Non-repo source — no repo-level conflict
+    }
+    if (job.type === "full-reindex-local") {
+      return null; // Local sources only — no repo conflict
+    }
+    // full-reindex: return a sentinel meaning "all repos"
+    return "__all__";
+  }
+
+  /**
+   * Check if a job can run right now given active repo constraints.
+   */
+  private canRunJob(job: Job): boolean {
+    // If a full-reindex is active (sentinel "__all__" in activeRepos), block everything
+    if (this.activeRepos.has("__all__")) return false;
+
+    const repoKey = this.getJobRepoKey(job);
+
+    // full-reindex needs exclusive access — can only run when nothing else is active
+    if (repoKey === "__all__") {
+      return this.activeJobCount === 0;
+    }
+
+    // Jobs with a repo key can't run if that repo is already active
+    if (repoKey && this.activeRepos.has(repoKey)) return false;
+
+    return true;
+  }
+
+  /**
+   * Process the job queue with up to maxConcurrent parallel jobs.
+   * Jobs for the same repo are serialized; different repos run in parallel.
    */
   private async drain(): Promise<void> {
-    if (this.processing) return; // Already draining
-    this.processing = true;
+    if (this.draining) return; // Already draining
+    this.draining = true;
 
     try {
-      while (this.queue.length > 0) {
-        const job = this.queue.shift()!;
-        this.running = true;
+      do {
+        while (this.queue.length > 0) {
+          // Find runnable jobs (respecting concurrency + repo constraints)
+          const launched: Promise<void>[] = [];
 
-        try {
-          await this.executeJob(job);
-        } catch (err) {
-          console.error("[orchestrator] Job failed:", err);
+          for (
+            let i = 0;
+            i < this.queue.length && this.activeJobCount < this.maxConcurrent;
+          ) {
+            const job = this.queue[i];
+            if (this.canRunJob(job)) {
+              // Remove from queue
+              this.queue.splice(i, 1);
+
+              const repoKey = this.getJobRepoKey(job);
+              const dedupKey = this.jobDedupKey(job);
+              if (repoKey) this.activeRepos.add(repoKey);
+              this.executingJobKeys.add(dedupKey);
+              this.activeJobCount++;
+              this.running = true;
+
+              // Launch job concurrently
+              const jobPromise = this.executeJob(job)
+                .catch((err) => {
+                  console.error("[orchestrator] Job failed:", err);
+                })
+                .finally(() => {
+                  if (repoKey) this.activeRepos.delete(repoKey);
+                  this.executingJobKeys.delete(dedupKey);
+                  this.activeJobCount--;
+                  if (this.activeJobCount === 0) this.running = false;
+                });
+              launched.push(jobPromise);
+            } else {
+              i++; // Skip this job, try next
+            }
+          }
+
+          if (launched.length === 0) {
+            // No jobs could be launched — all remaining are blocked on repo conflicts.
+            // Wait for at least one active job to finish before retrying.
+            if (this.activeJobCount > 0) {
+              await new Promise<void>((resolve) => {
+                const check = setInterval(() => {
+                  if (this.activeJobCount < this.maxConcurrent) {
+                    clearInterval(check);
+                    resolve();
+                  }
+                }, 50);
+              });
+              continue; // Re-evaluate the queue
+            }
+            break; // Nothing active and nothing runnable — shouldn't happen, but bail safely
+          }
+
+          // Wait for at least one launched job to complete before scanning queue again
+          await Promise.race(launched);
         }
-      }
+
+        // Wait for all remaining active jobs to finish
+        if (this.activeJobCount > 0) {
+          await new Promise<void>((resolve) => {
+            const check = setInterval(() => {
+              if (this.activeJobCount === 0) {
+                clearInterval(check);
+                resolve();
+              }
+            }, 50);
+          });
+        }
+      } while (this.queue.length > 0); // Re-check: jobs may have been queued during final-wait
     } finally {
       this.running = false;
-      this.processing = false;
+      this.draining = false;
     }
   }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -19,6 +19,7 @@ import {
   getIndexStats,
   getAllChunksForLlms,
   getFaqChunks,
+  getWebhookDeliveryStats,
 } from "./db/queries.js";
 import {
   getConfig,
@@ -421,7 +422,7 @@ export function classifyWebhookUnavailable(opts: {
 
 app.post(
   "/webhooks/github",
-  express.raw({ type: "application/json" }),
+  express.raw({ type: "application/json", limit: "25mb" }),
   // Runtime guard: assert req.body is a Buffer. If a future refactor moves
   // express.json() above this route, the guard fires a loud 500 instead of
   // silently 401-ing every webhook delivery.
@@ -468,7 +469,7 @@ app.post(
 // Slack webhook endpoint — also before express.json() for raw body signature verification
 app.post(
   "/webhooks/slack",
-  express.raw({ type: "application/json" }),
+  express.raw({ type: "application/json", limit: "25mb" }),
   assertWebhookRawBodyOrder("slack-webhook"),
   async (req: Request, res: Response) => {
     const handler = slackWebhookHandler;
@@ -491,7 +492,7 @@ app.post(
 // Discord webhook endpoint — also before express.json() for raw body signature verification
 app.post(
   "/webhooks/discord",
-  express.raw({ type: "application/json" }),
+  express.raw({ type: "application/json", limit: "25mb" }),
   assertWebhookRawBodyOrder("discord-webhook"),
   async (req: Request, res: Response) => {
     const handler = discordWebhookHandler;
@@ -2012,6 +2013,7 @@ app.post("/messages", ...sseHandlers.postHandler);
 
 export interface HealthRouteDeps {
   getIndexStats?: typeof getIndexStats;
+  getWebhookDeliveryStats?: typeof getWebhookDeliveryStats;
 }
 
 export function registerHealthRoute(
@@ -2019,6 +2021,8 @@ export function registerHealthRoute(
   deps: HealthRouteDeps = {},
 ): void {
   const _getIndexStats = deps.getIndexStats ?? getIndexStats;
+  const _getWebhookDeliveryStats =
+    deps.getWebhookDeliveryStats ?? getWebhookDeliveryStats;
 
   app.get("/health", async (_req: Request, res: Response) => {
     const uptime = Math.floor((Date.now() - startedAt.getTime()) / 1000);
@@ -2041,7 +2045,16 @@ export function registerHealthRoute(
     }
 
     try {
-      const stats = await _getIndexStats();
+      const [stats, deliveryStats] = await Promise.all([
+        _getIndexStats(),
+        _getWebhookDeliveryStats().catch((err) => {
+          console.error(
+            "[health] Failed to fetch webhook delivery stats:",
+            err,
+          );
+          return null;
+        }),
+      ]);
       res.json({
         status: "ok",
         server: getServerConfig().server.name,
@@ -2063,6 +2076,7 @@ export function registerHealthRoute(
             error: s.error_message ?? null,
           })),
         },
+        ...(deliveryStats ? { webhook_deliveries: deliveryStats } : {}),
       });
     } catch (err) {
       // Log the full error server-side for operators, but never surface

--- a/src/webhooks/discord.ts
+++ b/src/webhooks/discord.ts
@@ -5,6 +5,7 @@
 import { verifyKey } from "discord-interactions";
 import type { Request, Response } from "express";
 import { getConfig } from "../config.js";
+import { recordWebhookDelivery } from "../db/queries.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -53,10 +54,17 @@ export function createDiscordWebhookHandler(
 
     // -- Raw body check ------------------------------------------------
     const rawBody = Buffer.isBuffer(req.body) ? req.body : null;
+    const payloadSize = rawBody?.length;
     if (!rawBody) {
       console.error(
         "[discord-webhook] req.body is not a Buffer — ensure the route uses express.raw()",
       );
+      recordWebhookDelivery({
+        source: "discord",
+        decision: "error",
+        reason: "req.body not a Buffer",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res
         .status(500)
         .json({ error: "Server misconfiguration: raw body not available" });
@@ -73,6 +81,12 @@ export function createDiscordWebhookHandler(
     if (
       !(await verifyDiscordSignature(rawBody, signature, timestamp, publicKey))
     ) {
+      recordWebhookDelivery({
+        source: "discord",
+        decision: "error",
+        reason: "invalid signature",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(401).json({ error: "Invalid or missing Discord signature" });
       return;
     }
@@ -82,17 +96,37 @@ export function createDiscordWebhookHandler(
     try {
       interaction = JSON.parse(rawBody.toString("utf-8")) as DiscordInteraction;
     } catch {
+      recordWebhookDelivery({
+        source: "discord",
+        decision: "error",
+        reason: "malformed JSON",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(400).json({ error: "Malformed JSON payload" });
       return;
     }
 
     // -- PING handling (type: 1) — required by Discord for URL verification
     if (interaction.type === 1) {
+      recordWebhookDelivery({
+        source: "discord",
+        event_type: "PING",
+        decision: "ignored",
+        reason: "PING interaction",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(200).json({ type: 1 });
       return;
     }
 
     // -- All other interaction types: acknowledge
+    recordWebhookDelivery({
+      source: "discord",
+      event_type: `interaction_type_${interaction.type}`,
+      decision: "ignored",
+      reason: `unhandled interaction type: ${interaction.type}`,
+      payload_size: payloadSize,
+    }).catch(() => {});
     res.status(200).json({
       ok: true,
       ignored: true,

--- a/src/webhooks/github.ts
+++ b/src/webhooks/github.ts
@@ -5,6 +5,7 @@
 import crypto from "node:crypto";
 import type { Request, Response } from "express";
 import { getConfig, getServerConfig } from "../config.js";
+import { recordWebhookDelivery } from "../db/queries.js";
 
 // ---------------------------------------------------------------------------
 // Types
@@ -102,10 +103,17 @@ export function createWebhookHandler(orchestrator: ReindexOrchestrator) {
     // The route MUST be configured with express.raw() so req.body is a
     // Buffer.  If it isn't, bail out — we cannot safely verify the HMAC.
     const rawBody = Buffer.isBuffer(req.body) ? req.body : null;
+    const payloadSize = rawBody?.length;
     if (!rawBody) {
       console.error(
         "[webhook] req.body is not a Buffer — ensure the route uses express.raw()",
       );
+      recordWebhookDelivery({
+        source: "github",
+        decision: "error",
+        reason: "req.body not a Buffer",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res
         .status(500)
         .json({ error: "Server misconfiguration: raw body not available" });
@@ -116,12 +124,24 @@ export function createWebhookHandler(orchestrator: ReindexOrchestrator) {
       console.log(
         "[webhook] Rejecting request — webhook secret not configured",
       );
+      recordWebhookDelivery({
+        source: "github",
+        decision: "error",
+        reason: "webhook secret not configured",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(403).json({ error: "Forbidden" });
       return;
     }
 
     const signature = req.headers["x-hub-signature-256"] as string | undefined;
     if (!verifySignature(rawBody, signature, cfg.githubWebhookSecret)) {
+      recordWebhookDelivery({
+        source: "github",
+        decision: "error",
+        reason: "invalid signature",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(401).json({ error: "Invalid or missing webhook signature" });
       return;
     }
@@ -129,6 +149,13 @@ export function createWebhookHandler(orchestrator: ReindexOrchestrator) {
     // -- Event routing -------------------------------------------------
     const event = req.headers["x-github-event"] as string | undefined;
     if (event !== "push") {
+      recordWebhookDelivery({
+        source: "github",
+        event_type: event ?? "unknown",
+        decision: "ignored",
+        reason: "not a push event",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(200).json({ ignored: true, reason: "not a push event" });
       return;
     }
@@ -138,11 +165,26 @@ export function createWebhookHandler(orchestrator: ReindexOrchestrator) {
     try {
       payload = JSON.parse(rawBody.toString("utf-8")) as PushPayload;
     } catch {
+      recordWebhookDelivery({
+        source: "github",
+        event_type: "push",
+        decision: "error",
+        reason: "malformed JSON",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(400).json({ error: "Malformed JSON payload" });
       return;
     }
 
     if (!isDefaultBranchPush(payload)) {
+      recordWebhookDelivery({
+        source: "github",
+        event_type: "push",
+        repo: payload.repository.full_name,
+        decision: "ignored",
+        reason: "not the default branch",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(200).json({ ignored: true, reason: "not the default branch" });
       return;
     }
@@ -159,6 +201,14 @@ export function createWebhookHandler(orchestrator: ReindexOrchestrator) {
       console.log(
         `[webhook] Push to ${repoFullName} at ${sha.slice(0, 8)} — repo not in webhook config, ignoring`,
       );
+      recordWebhookDelivery({
+        source: "github",
+        event_type: "push",
+        repo: repoFullName,
+        decision: "ignored",
+        reason: "repo not in webhook config",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res
         .status(200)
         .json({ ignored: true, reason: "repo not in webhook config" });
@@ -181,6 +231,14 @@ export function createWebhookHandler(orchestrator: ReindexOrchestrator) {
         `[webhook] Push to ${repoFullName} at ${sha.slice(0, 8)} — ` +
           `no path triggers matched, ignoring`,
       );
+      recordWebhookDelivery({
+        source: "github",
+        event_type: "push",
+        repo: repoFullName,
+        decision: "ignored",
+        reason: "no path triggers matched",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res
         .status(200)
         .json({ ignored: true, reason: "no path triggers matched" });
@@ -192,6 +250,13 @@ export function createWebhookHandler(orchestrator: ReindexOrchestrator) {
         `(${payload.repository.default_branch}) at ${sha.slice(0, 8)} — queuing reindex`,
     );
 
+    recordWebhookDelivery({
+      source: "github",
+      event_type: "push",
+      repo: repoFullName,
+      decision: "queued",
+      payload_size: payloadSize,
+    }).catch(() => {});
     orchestrator.queueIncrementalReindex(repoUrl);
     res.status(200).json({ queued: true });
   };

--- a/src/webhooks/slack.ts
+++ b/src/webhooks/slack.ts
@@ -5,6 +5,7 @@ import crypto from "node:crypto";
 import type { Request, Response } from "express";
 import { getConfig, getServerConfig } from "../config.js";
 import { isSlackSourceConfig } from "../types.js";
+import { recordWebhookDelivery } from "../db/queries.js";
 
 // ── Types ────────────────────────────────────────────────────────────────────
 
@@ -83,10 +84,17 @@ export function createSlackWebhookHandler(
 
     // -- Raw body check ------------------------------------------------
     const rawBody = Buffer.isBuffer(req.body) ? req.body : null;
+    const payloadSize = rawBody?.length;
     if (!rawBody) {
       console.error(
         "[slack-webhook] req.body is not a Buffer — ensure the route uses express.raw()",
       );
+      recordWebhookDelivery({
+        source: "slack",
+        decision: "error",
+        reason: "req.body not a Buffer",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res
         .status(500)
         .json({ error: "Server misconfiguration: raw body not available" });
@@ -98,6 +106,12 @@ export function createSlackWebhookHandler(
     try {
       payload = JSON.parse(rawBody.toString("utf-8")) as SlackEventPayload;
     } catch {
+      recordWebhookDelivery({
+        source: "slack",
+        decision: "error",
+        reason: "malformed JSON",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(400).json({ error: "Malformed JSON payload" });
       return;
     }
@@ -105,6 +119,13 @@ export function createSlackWebhookHandler(
     // -- URL verification challenge ------------------------------------
     // Slack sends this during app setup; no signature verification needed
     if (payload.type === "url_verification") {
+      recordWebhookDelivery({
+        source: "slack",
+        event_type: "url_verification",
+        decision: "ignored",
+        reason: "url verification challenge",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(200).json({ challenge: payload.challenge });
       return;
     }
@@ -114,6 +135,12 @@ export function createSlackWebhookHandler(
       console.log(
         "[slack-webhook] Rejecting request — signing secret not configured",
       );
+      recordWebhookDelivery({
+        source: "slack",
+        decision: "error",
+        reason: "signing secret not configured",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(403).json({ error: "Forbidden" });
       return;
     }
@@ -131,12 +158,25 @@ export function createSlackWebhookHandler(
         cfg.slackSigningSecret,
       )
     ) {
+      recordWebhookDelivery({
+        source: "slack",
+        decision: "error",
+        reason: "invalid signature",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res.status(401).json({ error: "Invalid or missing Slack signature" });
       return;
     }
 
     // -- Event routing -------------------------------------------------
     if (payload.type !== "event_callback" || !payload.event) {
+      recordWebhookDelivery({
+        source: "slack",
+        event_type: payload.type,
+        decision: "ignored",
+        reason: "not an event_callback",
+        payload_size: payloadSize,
+      }).catch(() => {});
       res
         .status(200)
         .json({ ok: true, ignored: true, reason: "not an event_callback" });
@@ -147,13 +187,20 @@ export function createSlackWebhookHandler(
 
     if (event.type === "reaction_added") {
       const reactionEvent = event as ReactionAddedEvent;
-      handleReactionAdded(reactionEvent, orchestrator);
+      handleReactionAdded(reactionEvent, orchestrator, payloadSize);
       // Respond immediately (Slack requires <3s)
       res.status(200).json({ ok: true });
       return;
     }
 
     // Unknown event type — acknowledge but ignore
+    recordWebhookDelivery({
+      source: "slack",
+      event_type: event.type,
+      decision: "ignored",
+      reason: `unhandled event type: ${event.type}`,
+      payload_size: payloadSize,
+    }).catch(() => {});
     res.status(200).json({
       ok: true,
       ignored: true,
@@ -167,6 +214,7 @@ export function createSlackWebhookHandler(
 function handleReactionAdded(
   event: ReactionAddedEvent,
   orchestrator: SlackReindexOrchestrator,
+  payloadSize?: number,
 ): void {
   const serverCfg = getServerConfig();
 
@@ -184,6 +232,14 @@ function handleReactionAdded(
       `[slack-webhook] Reaction :${event.reaction}: on ${event.item.channel} ` +
         `— no matching Slack source configured, ignoring`,
     );
+    recordWebhookDelivery({
+      source: "slack",
+      event_type: "reaction_added",
+      repo: event.item.channel,
+      decision: "ignored",
+      reason: "no matching Slack source configured",
+      payload_size: payloadSize,
+    }).catch(() => {});
     return;
   }
 
@@ -192,6 +248,13 @@ function handleReactionAdded(
       `[slack-webhook] Reaction :${event.reaction}: on ${event.item.channel} ` +
         `— queuing reindex for source "${source.name}"`,
     );
+    recordWebhookDelivery({
+      source: "slack",
+      event_type: "reaction_added",
+      repo: event.item.channel,
+      decision: "queued",
+      payload_size: payloadSize,
+    }).catch(() => {});
     orchestrator.queueSourceReindex(source.name);
   }
 }


### PR DESCRIPTION
## Summary

- **Fixed silent 413 rejections** on large GitHub webhook payloads — `express.raw()` defaulted to 100KB, now 25mb
- **Raised health monitor threshold** from 6h to 25h to match daily reindex cadence
- **Added queue-level job dedup** — prevents redundant reindex jobs for the same repo/source
- **Added concurrent drain** — independent repos now reindex in parallel (max 3 concurrent, per-repo serialization)
- **Added persistent webhook delivery tracking** — new `webhook_deliveries` DB table logs every webhook receipt with decision/reason; stats exposed on `/health`
- **Extended monitoring to aimock-docs** — third Pathfinder instance now in health monitor workflow
- **Hardened setup-webhooks.sh** — `--config` flag for multi-instance use, PATCH includes `events[]=push`, REPOS array initialized

## Why

The root cause of spurious "commit drift" health alerts was `express.raw()` silently dropping GitHub push payloads larger than 100KB with a 413 — no logs on the Pathfinder side. Webhook-triggered re-indexing was already built but not firing for large pushes. The delivery tracking table ensures this class of silent failure is visible going forward.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 1739 tests pass (4 pre-existing failures in cli.test.ts/faq-txt-endpoint.test.ts)
- [x] 12 new orchestrator dedup/parallel tests
- [x] 18 new webhook delivery tracking tests
- [x] CR converged: Round 1 (5 bucket-a findings fixed) → Confirmation round (0 bucket-a)