### PR TITLE
ci: harden CI/CD security

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,32 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    groups:
+      minor-and-patch:
+        patterns:
+          - "*"
+        update-types:
+          - "minor"
+          - "patch"
+      # Workaround for dependabot/dependabot-core#14202: without an explicit
+      # major group, major updates matching the minor-and-patch pattern are
+      # silently suppressed. Remove this group when #14202 is fixed to get
+      # individual (ungrouped) PRs per major bump instead.
+      major:
+        patterns:
+          - "*"
+        update-types:
+          - "major"
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    open-pull-requests-limit: 10
+    cooldown:
+      default-days: 1

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,32 @@
+name: Dependabot Auto-Merge (Minor/Patch)
+
+on:
+  pull_request_target:
+    types: [opened, synchronize]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve and merge minor/patch github-actions updates
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+          (steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+           steps.metadata.outputs.update-type == 'version-update:semver-patch')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          gh pr review "$PR_URL" --approve
+          gh pr merge "$PR_URL" --auto --merge

--- a/.github/workflows/dependabot-major-analysis.yml
+++ b/.github/workflows/dependabot-major-analysis.yml
@@ -1,0 +1,144 @@
+name: Dependabot Major Version Analysis
+
+on:
+  pull_request_target:
+    types: [opened]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  analyze-major:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@21025c705c08248db411dc16f3619e6b5f9ea21a # v2.5.0
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Analyze major version bump
+        if: >-
+          steps.metadata.outputs.package-ecosystem == 'github_actions' &&
+          steps.metadata.outputs.update-type == 'version-update:semver-major'
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7.1.0
+        env:
+          DEP_NAME: ${{ steps.metadata.outputs.dependency-names }}
+          PREV_VERSION: ${{ steps.metadata.outputs.previous-version }}
+          NEW_VERSION: ${{ steps.metadata.outputs.new-version }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const depName = process.env.DEP_NAME;
+            const prevVersion = process.env.PREV_VERSION;
+            const newVersion = process.env.NEW_VERSION;
+            const parts = depName.split('/');
+            const owner = parts[0];
+            const repo = parts[1];
+            const repoSlug = `${owner}/${repo}`;
+
+            let releases = [];
+            try {
+              const { data } = await github.rest.repos.listReleases({ owner, repo, per_page: 50 });
+              releases = data;
+            } catch (err) {
+              core.warning(`Could not fetch releases for ${repoSlug}: ${err.message}`);
+            }
+
+            const prevMajor = parseInt(prevVersion.replace(/^v/, ''), 10);
+            const newMajor = parseInt(newVersion.replace(/^v/, ''), 10);
+
+            const relevantReleases = releases.filter(r => {
+              const major = parseInt(r.tag_name.replace(/^v/, ''), 10);
+              return major > prevMajor && major <= newMajor;
+            });
+
+            let releaseNotesSummary = '';
+            let breakingChanges = '';
+
+            if (relevantReleases.length === 0) {
+              releaseNotesSummary = '_No releases found between these versions._';
+              breakingChanges = `_Unable to determine breaking changes automatically. Please review the [full changelog](https://github.com/${repoSlug}/releases)._`;
+            } else {
+              for (const release of relevantReleases.slice(0, 10)) {
+                const body = release.body || '_No release notes._';
+                releaseNotesSummary += `### ${release.tag_name}${release.name && release.name !== release.tag_name ? ' — ' + release.name : ''}\n\n`;
+                releaseNotesSummary += body.substring(0, 2000);
+                if (body.length > 2000) releaseNotesSummary += '\n\n_...truncated_';
+                releaseNotesSummary += '\n\n---\n\n';
+                const lines = body.split('\n');
+                for (const line of lines) {
+                  if (/breaking|BREAKING|removed|deprecated|incompatible|migration/i.test(line)) {
+                    breakingChanges += `- ${line.trim()}\n`;
+                  }
+                }
+              }
+            }
+
+            if (!breakingChanges) {
+              breakingChanges = '_No explicit breaking changes detected in release notes. Manual review recommended._';
+            }
+
+            let commentBody = `## :warning: Major Version Update — Manual Review Required
+
+            | Field | Value |
+            |-------|-------|
+            | **Action** | [\`${depName}\`](https://github.com/${repoSlug}) |
+            | **Previous** | \`v${prevVersion}\` |
+            | **New** | \`v${newVersion}\` |
+            | **Type** | Major (\`v${prevMajor}\` → \`v${newMajor}\`) |
+
+            ### Breaking Changes
+
+            ${breakingChanges}
+
+            ### Release Notes (v${prevMajor + 1} → v${newMajor})
+
+            ${releaseNotesSummary}
+
+            ### Next Steps
+
+            1. Review breaking changes above
+            2. Check if workflow inputs/outputs changed
+            3. Verify compatibility with your CI/CD configuration
+
+            > Full changelog: https://github.com/${repoSlug}/releases
+
+            ---
+            _Generated automatically for Dependabot major version PRs._`.replace(/^            /gm, '');
+
+            if (commentBody.length > 64000) {
+              commentBody = commentBody.substring(0, 63900) + '\n\n_...comment truncated due to size limit._';
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: commentBody,
+            });
+
+            try {
+              const labelsToAdd = ['major-update', 'needs-review'];
+              for (const label of labelsToAdd) {
+                try {
+                  await github.rest.issues.getLabel({ owner: context.repo.owner, repo: context.repo.repo, name: label });
+                } catch {
+                  const colors = { 'major-update': 'B60205', 'needs-review': 'FBCA04' };
+                  await github.rest.issues.createLabel({
+                    owner: context.repo.owner, repo: context.repo.repo,
+                    name: label, color: colors[label] || 'EDEDED',
+                  });
+                }
+              }
+              await github.rest.issues.addLabels({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.payload.pull_request.number,
+                labels: labelsToAdd,
+              });
+            } catch (err) {
+              core.warning(`Could not add labels: ${err.message}`);
+            }

--- a/.github/workflows/deploy-health-check.yml
+++ b/.github/workflows/deploy-health-check.yml
@@ -2,6 +2,7 @@ name: Production Health Check
 on:
   push:
     branches: [main]
+permissions: {}
 jobs:
   health-check:
     runs-on: ubuntu-latest
@@ -34,7 +35,9 @@ jobs:
           if [ -n "$SLACK_WEBHOOK" ]; then
             curl -s -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Pathfinder production health check FAILED after deploy\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+              -d "{\"text\":\"Pathfinder production health check FAILED after deploy\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -18,19 +18,25 @@ jobs:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/configure-pages@v4
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
+      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
         with:
           path: docs
       - id: deploy
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 
       - name: Notify Slack on failure
         if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
-          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
-            curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -s -X POST "$SLACK_WEBHOOK" \
               -H "Content-Type: application/json" \
-              -d "{\"text\":\"❌ *Pathfinder GitHub Pages deploy failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+              -d "{\"text\":\"❌ *Pathfinder GitHub Pages deploy failed*\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
           fi

--- a/.github/workflows/index-health-monitor.yml
+++ b/.github/workflows/index-health-monitor.yml
@@ -12,12 +12,15 @@ on:
         description: "Run checks but do not notify or update state"
         type: boolean
         default: false
+permissions:
+  contents: read
+
 jobs:
   monitor:
     runs-on: ubuntu-latest
     steps:
       - name: Restore state from cache
-        uses: actions/cache/restore@v4
+        uses: actions/cache/restore@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         with:
           path: /tmp/health-monitor-state.json
           key: index-health-state-
@@ -480,7 +483,7 @@ jobs:
           done < "$NOTIFY_FILE"
 
       - name: Save state to cache
-        uses: actions/cache/save@v4
+        uses: actions/cache/save@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
         if: always() && inputs.dry_run != 'true'
         with:
           path: /tmp/health-monitor-state.json

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -2,17 +2,22 @@ name: PR Notification
 on:
   pull_request_target:
     types: [opened]
+permissions: {}
 jobs:
   notify:
     runs-on: ubuntu-latest
     steps:
       - name: Notify Slack
         if: github.actor != 'github-actions[bot]'
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_AUTHOR: ${{ github.actor }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"New PR on pathfinder: *${{ github.event.pull_request.title }}* by ${{ github.actor }}\n<${{ github.event.pull_request.html_url }}|View PR #${{ github.event.pull_request.number }}>\"}" || true
+              -d "{\"text\":\"New PR on pathfinder: *${PR_TITLE}* by ${PR_AUTHOR}\n<${PR_URL}|View PR #${PR_NUMBER}>\"}" || true
           fi
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -2,6 +2,7 @@ name: Publish Docker
 on:
   push:
     tags: ['v*']
+permissions: {}
 jobs:
   docker:
     runs-on: ubuntu-latest
@@ -9,15 +10,17 @@ jobs:
       contents: read
       packages: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: docker/setup-qemu-action@v3
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130 # v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
+      - uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - uses: docker/build-push-action@v5
+      - uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25 # v5
         with:
           push: true
           tags: |
@@ -28,21 +31,24 @@ jobs:
           cache-to: type=gha,mode=max
       - name: Notify Slack — success
         if: success()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          REF_NAME: ${{ github.ref_name }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Docker image published: ghcr.io/copilotkit/pathfinder:${{ github.ref_name }}\"}" || true
+              -d "{\"text\":\"Docker image published: ghcr.io/copilotkit/pathfinder:${REF_NAME}\"}" || true
           fi
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
       - name: Notify Slack — failure
         if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Docker publish failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+              -d "{\"text\":\"Docker publish failed\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
           fi
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -3,15 +3,18 @@ on:
   push:
     branches: [main]
   workflow_dispatch:
+permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         # No cache — release builds must be hermetic
         with:
           node-version: 24
@@ -45,7 +48,7 @@ jobs:
 
       - name: Upload build artifacts
         if: steps.check.outputs.published == 'false'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
           name: build-output
           path: .
@@ -65,11 +68,11 @@ jobs:
       contents: write
     steps:
       - name: Download build artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
         with:
           name: build-output
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           registry-url: "https://registry.npmjs.org"
@@ -78,38 +81,51 @@ jobs:
         run: npm publish --access public
 
       - name: Configure git credentials
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git config --local url."https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/".insteadOf "https://github.com/"
+          git config --local url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
 
       - name: Ensure git tag exists
+        env:
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
         run: |
-          TAG="v${{ needs.build.outputs.version }}"
+          TAG="v${RELEASE_VERSION}"
           if ! git rev-parse "${TAG}" >/dev/null 2>&1; then
             git tag "${TAG}"
             git push origin "${TAG}"
           fi
 
       - name: Create GitHub Release
-        run: |
-          TAG="v${{ needs.build.outputs.version }}"
-          gh release create "${TAG}" --generate-notes --title "${TAG}" --verify-tag
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
+        run: |
+          TAG="v${RELEASE_VERSION}"
+          gh release create "${TAG}" --generate-notes --title "${TAG}" --verify-tag
 
       - name: Notify Slack on success
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          RELEASE_VERSION: ${{ needs.build.outputs.version }}
+          GH_REPOSITORY: ${{ github.repository }}
         run: |
-          VERSION="v${{ needs.build.outputs.version }}"
-          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
-            curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          VERSION="v${RELEASE_VERSION}"
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -s -X POST "$SLACK_WEBHOOK" \
               -H "Content-Type: application/json" \
-              -d "{\"text\":\"📦 *@copilotkit/pathfinder ${VERSION} published*\nnpm: https://www.npmjs.com/package/@copilotkit/pathfinder/v/${{ needs.build.outputs.version }}\nRelease: https://github.com/${{ github.repository }}/releases/tag/${VERSION}\"}" || true
+              -d "{\"text\":\"📦 *@copilotkit/pathfinder ${VERSION} published*\nnpm: https://www.npmjs.com/package/@copilotkit/pathfinder/v/${RELEASE_VERSION}\nRelease: https://github.com/${GH_REPOSITORY}/releases/tag/${VERSION}\"}" || true
           fi
 
       - name: Notify Slack on failure
         if: failure()
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}
         run: |
-          if [ -n "${{ secrets.SLACK_WEBHOOK }}" ]; then
-            curl -s -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+          if [ -n "$SLACK_WEBHOOK" ]; then
+            curl -s -X POST "$SLACK_WEBHOOK" \
               -H "Content-Type: application/json" \
-              -d "{\"text\":\"❌ *Pathfinder release failed*\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+              -d "{\"text\":\"❌ *Pathfinder release failed*\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
           fi

--- a/.github/workflows/security_zizmor.yml
+++ b/.github/workflows/security_zizmor.yml
@@ -1,0 +1,47 @@
+name: security / zizmor
+
+on:
+  push:
+    branches: [main, master]
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/zizmor.yml"
+      - ".github/dependabot.yml"
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+      - ".github/zizmor.yml"
+      - ".github/dependabot.yml"
+  schedule:
+    - cron: "0 9 * * 1"
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event_name == 'schedule' && github.run_id || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' }}
+
+permissions:
+  contents: read
+
+jobs:
+  zizmor:
+    name: Static analysis (zizmor)
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3
+        with:
+          min-severity: medium
+          advanced-security: false
+          annotations: true
+          config: .github/zizmor.yml

--- a/.github/workflows/static-quality.yml
+++ b/.github/workflows/static-quality.yml
@@ -4,12 +4,18 @@ on:
     branches: [main, master]
   push:
     branches: [main, master]
+
+permissions:
+  contents: read
+
 jobs:
   prettier:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with: { node-version: 22 }
       - run: npm ci
       - run: npx prettier --check "src/**/*.ts"
@@ -17,8 +23,10 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with: { node-version: 22 }
       - run: npm ci
       - run: npm run build
@@ -26,16 +34,20 @@ jobs:
   version-sync:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with: { node-version: 22 }
       - run: ./scripts/check-version-sync.sh
 
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with: { node-version: 22 }
       - run: npm ci
       - run: npm run build

--- a/.github/workflows/unreleased-check.yml
+++ b/.github/workflows/unreleased-check.yml
@@ -3,12 +3,17 @@ on:
   push:
     branches: [main, master]
 
+permissions:
+  contents: read
+
 jobs:
   check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with: { fetch-depth: 0 }
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
 
       - name: Check for unreleased source changes
         id: unreleased
@@ -54,7 +59,10 @@ jobs:
           if [ -n "$SLACK_WEBHOOK" ]; then
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Unreleased changes on main — ${{ steps.unreleased.outputs.count }} commits since ${{ steps.unreleased.outputs.tag }}\n<https://github.com/${{ github.repository }}/compare/${{ steps.unreleased.outputs.tag }}...main|View compare>\"}" || true
+              -d "{\"text\":\"Unreleased changes on main — ${UNRELEASED_COUNT} commits since ${UNRELEASED_TAG}\n<https://github.com/${GH_REPOSITORY}/compare/${UNRELEASED_TAG}...main|View compare>\"}" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_REPOSITORY: ${{ github.repository }}
+          UNRELEASED_COUNT: ${{ steps.unreleased.outputs.count }}
+          UNRELEASED_TAG: ${{ steps.unreleased.outputs.tag }}

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -4,12 +4,19 @@ on:
     - cron: '0 9 * * 1'  # Monday 9am UTC
   workflow_dispatch:
 
+permissions: {}
+
 jobs:
   update:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: '22'
       - run: npm ci
@@ -20,6 +27,10 @@ jobs:
           if [ -n "$(git diff --name-only)" ]; then
             echo "changed=true" >> $GITHUB_OUTPUT
           fi
+      - name: Configure git credentials for push
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Create PR
         if: steps.changes.outputs.changed == 'true'
         id: pr
@@ -38,17 +49,20 @@ jobs:
           if [ -n "$SLACK_WEBHOOK" ]; then
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Competitive matrix updated — PR created\n<${{ steps.pr.outputs.url }}|View PR>\"}" || true
+              -d "{\"text\":\"Competitive matrix updated — PR created\n<${PR_URL_OUTPUT}|View PR>\"}" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          PR_URL_OUTPUT: ${{ steps.pr.outputs.url }}
       - name: Notify Slack — failure
         if: failure()
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Competitive matrix scan failed\n<https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}|View run>\"}" || true
+              -d "{\"text\":\"Competitive matrix scan failed\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          GH_REPOSITORY: ${{ github.repository }}
+          GH_RUN_ID: ${{ github.run_id }}

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -1,0 +1,12 @@
+rules:
+  dangerous-triggers:
+    ignore:
+      # Dependabot auto-merge: uses pull_request_target for write token.
+      # Does NOT checkout PR code. Actor-gated to dependabot[bot].
+      - dependabot-auto-merge.yml
+      # Dependabot major analysis: uses pull_request_target for PR comments.
+      # Does NOT checkout PR code. Actor-gated to dependabot[bot].
+      - dependabot-major-analysis.yml
+      # notify-pr.yml uses pull_request_target but only curls a Slack webhook.
+      # It has permissions: {} so no token is exposed.
+      - notify-pr.yml

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,2 @@
+minimum-release-age=1440
+block-exotic-subdeps=true


### PR DESCRIPTION
## Summary
- SHA-pin all GitHub Actions with version comments
- Add least-privilege permissions blocks to all workflows
- Fix shell injection (route attacker-controllable values through env)
- Add persist-credentials: false on read-only checkouts
- Add zizmor static analysis for workflow security
- Add Dependabot daily for github-actions (auto-merge minor/patch)
- Add pnpm 10 supply chain hardening

Part of Phase 2 CI/CD supply chain hardening.