### PR TITLE
fix(ci): bump upload-pages-artifact v3 to v5 with include-hidden-files

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,9 +22,10 @@ jobs:
         with:
           persist-credentials: false
       - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
-      - uses: actions/upload-pages-artifact@56afc609e74202658d3ffba0e8f6dda462b719fa # v3
+      - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs
+          include-hidden-files: true
       - id: deploy
         uses: actions/deploy-pages@d6db90164ac5ed86f2b6aed7e0febac5b3c0c03e # v4
 


### PR DESCRIPTION
Bumps upload-pages-artifact from v3 (56afc609) to v5 (fc324d35) and adds required `include-hidden-files: true` parameter.

v5 defaults to excluding hidden files (breaking change from v3). Without this flag, .nojekyll and other dotfiles would be silently dropped from the Pages deploy.

Supersedes Dependabot PR #68 which bumps the action but doesn't add the required parameter.