### PR TITLE
Quiet #oss-alerts: failure-only deploy notifications, daily unreleased check

### DIFF
--- a/.github/workflows/deploy-health-check.yml
+++ b/.github/workflows/deploy-health-check.yml
@@ -19,17 +19,7 @@ jobs:
           STATUS=$(curl -sf https://mcp.pathfinder.copilotkit.dev/health | jq -r '.status')
           echo "pathfinder-docs: $STATUS"
           [ "$STATUS" = "ok" ] || exit 1
-      - name: Notify Slack — success
-        if: success()
-        run: |
-          if [ -n "$SLACK_WEBHOOK" ]; then
-            curl -sf -X POST "$SLACK_WEBHOOK" \
-              -H 'Content-Type: application/json' \
-              -d '{"text":"Pathfinder production deploy healthy — both services OK"}' || true
-          fi
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-      - name: Notify Slack — failure
+      - name: Notify Slack — failure only
         if: failure()
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then

--- a/.github/workflows/unreleased-check.yml
+++ b/.github/workflows/unreleased-check.yml
@@ -1,7 +1,8 @@
 name: Unreleased Changes Check
 on:
-  push:
-    branches: [main, master]
+  schedule:
+    - cron: "0 16 * * *" # Daily at 9 AM Pacific
+  workflow_dispatch: {}
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

- **Deploy health check**: removed the success Slack notification. Only failures alert now. Success is the default — it doesn't need a message.
- **Unreleased check**: changed from `on: push` (fires every merge) to daily cron at 9 AM Pacific. One alert per day max, with the existing 24h grace period.

## Why

#oss-alerts was getting ~15 messages/day from these two workflows: a success notification on every deploy, and an unreleased-changes nag on every push. Real failures were buried in the noise.