### PR TITLE
fix(ci): strip @mentions from dependabot major version analysis comments

### DIFF
--- a/.github/workflows/dependabot-major-analysis.yml
+++ b/.github/workflows/dependabot-major-analysis.yml
@@ -63,7 +63,7 @@ jobs:
               breakingChanges = `_Unable to determine breaking changes automatically. Please review the [full changelog](https://github.com/${repoSlug}/releases)._`;
             } else {
               for (const release of relevantReleases.slice(0, 10)) {
-                const body = release.body || '_No release notes._';
+                const body = (release.body || '_No release notes._').replace(/(?<=^|\s)@(?=[a-zA-Z0-9])(?![a-zA-Z0-9-]*\/)/gm, '');
                 releaseNotesSummary += `### ${release.tag_name}${release.name && release.name !== release.tag_name ? ' — ' + release.name : ''}\n\n`;
                 releaseNotesSummary += body.substring(0, 2000);
                 if (body.length > 2000) releaseNotesSummary += '\n\n_...truncated_';


### PR DESCRIPTION
## Summary

- Strip `@username` mentions from upstream release notes before posting as PR comments
- Prevents notification spam to external open-source contributors
- Preserves `@scope/pkg`, `email@domain`, and `action@version` patterns

Closes CopilotKit/aimock#216

## Test plan

- [x] Regex tested against real spam comment from aimock PR #214 (44 mentions stripped, 0 collateral damage)
- [x] YAML code refs (`checkout@v5`) preserved
- [x] npm scopes (`@actions/cache`) preserved
- [x] Email patterns preserved