### PR TITLE
Harden CI: npm auth, git scope, JSON injection, timeouts

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   auto-merge:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/dependabot-major-analysis.yml
+++ b/.github/workflows/dependabot-major-analysis.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   analyze-major:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/deploy-health-check.yml
+++ b/.github/workflows/deploy-health-check.yml
@@ -6,6 +6,7 @@ permissions: {}
 jobs:
   health-check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Wait for deploy
         run: sleep 120
@@ -23,9 +24,11 @@ jobs:
         if: failure()
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg repo "$GH_REPOSITORY" --arg run "$GH_RUN_ID" \
+              '{text: "Pathfinder production health check FAILED after deploy\n<https://github.com/\($repo)/actions/runs/\($run)|View run>"}')
             curl -s -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Pathfinder production health check FAILED after deploy\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
+              -d "$payload" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -14,6 +14,7 @@ concurrency:
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment:
       name: github-pages
       url: ${{ steps.deploy.outputs.page_url }}
@@ -37,7 +38,9 @@ jobs:
           GH_RUN_ID: ${{ github.run_id }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg repo "$GH_REPOSITORY" --arg run "$GH_RUN_ID" \
+              '{text: "❌ *Pathfinder GitHub Pages deploy failed*\n<https://github.com/\($repo)/actions/runs/\($run)|View run>"}')
             curl -s -X POST "$SLACK_WEBHOOK" \
               -H "Content-Type: application/json" \
-              -d "{\"text\":\"❌ *Pathfinder GitHub Pages deploy failed*\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
+              -d "$payload" || true
           fi

--- a/.github/workflows/index-health-monitor.yml
+++ b/.github/workflows/index-health-monitor.yml
@@ -18,6 +18,7 @@ permissions:
 jobs:
   monitor:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Restore state from cache
         uses: actions/cache/restore@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -6,6 +6,7 @@ permissions: {}
 jobs:
   notify:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - name: Notify Slack
         if: github.actor != 'github-actions[bot]'
@@ -17,7 +18,10 @@ jobs:
           PR_AUTHOR: ${{ github.actor }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg title "$PR_TITLE" --arg author "$PR_AUTHOR" \
+              --arg url "$PR_URL" --arg num "$PR_NUMBER" \
+              '{text: "New PR on pathfinder: *\($title)* by \($author)\n<\($url)|View PR #\($num)>"}')
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"New PR on pathfinder: *${PR_TITLE}* by ${PR_AUTHOR}\n<${PR_URL}|View PR #${PR_NUMBER}>\"}" || true
+              -d "$payload" || true
           fi

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -6,6 +6,7 @@ permissions: {}
 jobs:
   docker:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -36,9 +37,11 @@ jobs:
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg ref "$REF_NAME" \
+              '{text: "Docker image published: ghcr.io/copilotkit/pathfinder:\($ref)"}')
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Docker image published: ghcr.io/copilotkit/pathfinder:${REF_NAME}\"}" || true
+              -d "$payload" || true
           fi
       - name: Notify Slack — failure
         if: failure()
@@ -48,7 +51,9 @@ jobs:
           GH_RUN_ID: ${{ github.run_id }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg repo "$GH_REPOSITORY" --arg run "$GH_RUN_ID" \
+              '{text: "Docker publish failed\n<https://github.com/\($repo)/actions/runs/\($run)|View run>"}')
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Docker publish failed\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
+              -d "$payload" || true
           fi

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -7,6 +7,7 @@ permissions: {}
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
     steps:
@@ -63,6 +64,7 @@ jobs:
     needs: build
     if: needs.build.outputs.published == 'false'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     environment: npm
     permissions:
       contents: write
@@ -79,6 +81,8 @@ jobs:
 
       - name: Publish to npm
         run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Configure git credentials
         env:
@@ -112,9 +116,11 @@ jobs:
         run: |
           VERSION="v${RELEASE_VERSION}"
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg ver "$VERSION" --arg rel "$RELEASE_VERSION" --arg repo "$GH_REPOSITORY" \
+              '{text: "📦 *@copilotkit/pathfinder \($ver) published*\nnpm: https://www.npmjs.com/package/@copilotkit/pathfinder/v/\($rel)\nRelease: https://github.com/\($repo)/releases/tag/\($ver)"}')
             curl -s -X POST "$SLACK_WEBHOOK" \
               -H "Content-Type: application/json" \
-              -d "{\"text\":\"📦 *@copilotkit/pathfinder ${VERSION} published*\nnpm: https://www.npmjs.com/package/@copilotkit/pathfinder/v/${RELEASE_VERSION}\nRelease: https://github.com/${GH_REPOSITORY}/releases/tag/${VERSION}\"}" || true
+              -d "$payload" || true
           fi
 
       - name: Notify Slack on failure
@@ -125,7 +131,9 @@ jobs:
           GH_RUN_ID: ${{ github.run_id }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg repo "$GH_REPOSITORY" --arg run "$GH_RUN_ID" \
+              '{text: "❌ *Pathfinder release failed*\n<https://github.com/\($repo)/actions/runs/\($run)|View run>"}')
             curl -s -X POST "$SLACK_WEBHOOK" \
               -H "Content-Type: application/json" \
-              -d "{\"text\":\"❌ *Pathfinder release failed*\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
+              -d "$payload" || true
           fi

--- a/.github/workflows/static-quality.yml
+++ b/.github/workflows/static-quality.yml
@@ -11,6 +11,7 @@ permissions:
 jobs:
   prettier:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -22,6 +23,7 @@ jobs:
 
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -33,6 +35,7 @@ jobs:
 
   version-sync:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -43,6 +46,7 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:

--- a/.github/workflows/unreleased-check.yml
+++ b/.github/workflows/unreleased-check.yml
@@ -10,6 +10,7 @@ permissions:
 jobs:
   check:
     runs-on: ubuntu-latest
+    timeout-minutes: 5
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -58,9 +59,11 @@ jobs:
         if: steps.unreleased.outputs.count
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg count "$UNRELEASED_COUNT" --arg tag "$UNRELEASED_TAG" --arg repo "$GH_REPOSITORY" \
+              '{text: "Unreleased changes on main — \($count) commits since \($tag)\n<https://github.com/\($repo)/compare/\($tag)...main|View compare>"}')
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Unreleased changes on main — ${UNRELEASED_COUNT} commits since ${UNRELEASED_TAG}\n<https://github.com/${GH_REPOSITORY}/compare/${UNRELEASED_TAG}...main|View compare>\"}" || true
+              -d "$payload" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -9,6 +9,7 @@ permissions: {}
 jobs:
   update:
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
       pull-requests: write
@@ -30,7 +31,7 @@ jobs:
       - name: Configure git credentials for push
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
+        run: git config --local url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
       - name: Create PR
         if: steps.changes.outputs.changed == 'true'
         id: pr
@@ -47,9 +48,11 @@ jobs:
         if: steps.changes.outputs.changed == 'true'
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg url "$PR_URL_OUTPUT" \
+              '{text: "Competitive matrix updated — PR created\n<\($url)|View PR>"}')
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Competitive matrix updated — PR created\n<${PR_URL_OUTPUT}|View PR>\"}" || true
+              -d "$payload" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
@@ -58,9 +61,11 @@ jobs:
         if: failure()
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
+            payload=$(jq -nc --arg repo "$GH_REPOSITORY" --arg run "$GH_RUN_ID" \
+              '{text: "Competitive matrix scan failed\n<https://github.com/\($repo)/actions/runs/\($run)|View run>"}')
             curl -sf -X POST "$SLACK_WEBHOOK" \
               -H 'Content-Type: application/json' \
-              -d "{\"text\":\"Competitive matrix scan failed\n<https://github.com/${GH_REPOSITORY}/actions/runs/${GH_RUN_ID}|View run>\"}" || true
+              -d "$payload" || true
           fi
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}


### PR DESCRIPTION
## Summary

- **publish-release.yml**: Add missing `NODE_AUTH_TOKEN` env var to the `npm publish` step (was silently failing auth with `registry-url` set but no token)
- **update-competitive-matrix.yml**: Change `git config --global` to `--local` so credentials are scoped to the checkout, not the runner
- **Slack notification JSON injection**: All 7 workflow files that pass shell variables into double-quoted JSON strings via curl now use `jq -nc --arg` for safe payload construction. Prevents breakage/injection from PR titles or other untrusted inputs.
- **timeout-minutes**: Added to every job across all 12 workflows (only `zizmor` already had one). Values: 5m for lightweight jobs, 10m for build/test, 15m for competitive matrix, 30m for Docker multi-arch.

## Files changed (11 workflows)

- `dependabot-auto-merge.yml` — timeout
- `dependabot-major-analysis.yml` — timeout
- `deploy-health-check.yml` — timeout + jq
- `deploy-pages.yml` — timeout + jq
- `index-health-monitor.yml` — timeout (Slack already used jq)
- `notify-pr.yml` — timeout + jq
- `publish-docker.yml` — timeout + jq
- `publish-release.yml` — timeout + NODE_AUTH_TOKEN + jq
- `static-quality.yml` — timeout (4 jobs)
- `unreleased-check.yml` — timeout + jq
- `update-competitive-matrix.yml` — timeout + git --local + jq

## Test plan

- [x] All YAML is syntactically valid (no parse errors)
- [x] jq string interpolation syntax verified for all payloads
- [x] No functional changes to workflow triggers or job logic