### PR TITLE
Add Sentinel CI workflow for workflow security scanning

### DIFF
--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: jpr5/sentinel@2972cd7183264739e615939cba51988885920c36 # v1.3.3
+      - uses: jpr5/sentinel@3001b71ad3fc6998649be5a18e39585479a3ef5b # v1.3.4
         with:
           severity: high
           fail-on-findings: true

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -1,0 +1,19 @@
+name: Sentinel
+on:
+  pull_request:
+  push:
+    branches: [main]
+permissions:
+  contents: read
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+      - uses: jpr5/sentinel@ac7d8b6bae0bcc5aab0f28ba549eb6ee0ab7f8d9 # v1.3.0
+        with:
+          severity: high
+          fail-on-findings: true

--- a/.github/workflows/sentinel.yml
+++ b/.github/workflows/sentinel.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: jpr5/sentinel@ac7d8b6bae0bcc5aab0f28ba549eb6ee0ab7f8d9 # v1.3.0
+      - uses: jpr5/sentinel@2972cd7183264739e615939cba51988885920c36 # v1.3.3
         with:
           severity: high
           fail-on-findings: true


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/sentinel.yml` running [jpr5/sentinel](https://github.com/jpr5/sentinel) on PRs and pushes to main
- Configured in warn-only mode (`fail-on-findings: false`) with `severity: high`
- Part of org-wide Sentinel rollout for GitHub Actions workflow security scanning

## Details

Sentinel scans CI workflow files for security anti-patterns (credential exposure, injection risks, overly broad permissions, etc.). This initial rollout uses warn-only mode so findings appear as annotations without blocking merges.

Spec: https://www.notion.so/copilotkit/3683aa381852818bacd8e14eb7233c22

## Test plan

- [ ] Verify workflow triggers on this PR
- [ ] Confirm scan completes without errors
- [ ] Review any initial findings as annotations