### PR TITLE
Centralize Slack notifications on org-level SLACK_WEBHOOK_OSS_ALERTS secret

### DIFF
--- a/.github/workflows/deploy-health-check.yml
+++ b/.github/workflows/deploy-health-check.yml
@@ -31,6 +31,6 @@ jobs:
               -d "$payload" || true
           fi
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_RUN_ID: ${{ github.run_id }}
         run: |

--- a/.github/workflows/index-health-monitor.yml
+++ b/.github/workflows/index-health-monitor.yml
@@ -448,7 +448,7 @@ jobs:
       - name: Send Slack notifications
         if: always() && inputs.dry_run != 'true'
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/notify-pr.yml
+++ b/.github/workflows/notify-pr.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Notify Slack
         if: github.actor != 'github-actions[bot]'
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           PR_NUMBER: ${{ github.event.pull_request.number }}

--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Notify Slack — success
         if: success()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           REF_NAME: ${{ github.ref_name }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
@@ -46,7 +46,7 @@ jobs:
       - name: Notify Slack — failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_RUN_ID: ${{ github.run_id }}
         run: |

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -109,7 +109,7 @@ jobs:
 
       - name: Notify Slack on success
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           RELEASE_VERSION: ${{ needs.build.outputs.version }}
           GH_REPOSITORY: ${{ github.repository }}
         run: |
@@ -125,7 +125,7 @@ jobs:
       - name: Notify Slack on failure
         if: failure()
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_RUN_ID: ${{ github.run_id }}
         run: |

--- a/.github/workflows/unreleased-check.yml
+++ b/.github/workflows/unreleased-check.yml
@@ -66,7 +66,7 @@ jobs:
               -d "$payload" || true
           fi
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           GH_REPOSITORY: ${{ github.repository }}
           UNRELEASED_COUNT: ${{ steps.unreleased.outputs.count }}
           UNRELEASED_TAG: ${{ steps.unreleased.outputs.tag }}

--- a/.github/workflows/update-competitive-matrix.yml
+++ b/.github/workflows/update-competitive-matrix.yml
@@ -55,7 +55,7 @@ jobs:
               -d "$payload" || true
           fi
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           PR_URL_OUTPUT: ${{ steps.pr.outputs.url }}
       - name: Notify Slack — failure
         if: failure()
@@ -68,6 +68,6 @@ jobs:
               -d "$payload" || true
           fi
         env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
           GH_REPOSITORY: ${{ github.repository }}
           GH_RUN_ID: ${{ github.run_id }}


### PR DESCRIPTION
## Summary

Standardize all workflow Slack notifications onto the CopilotKit **org-level** secret `SLACK_WEBHOOK_OSS_ALERTS` (visibility: all) instead of the repo-local `SLACK_WEBHOOK` secret.

This is a **pure secret-name swap** — both secrets point at the same **#oss-alerts** channel, so there is **no channel change and no behavior change**. Only the `${{ secrets.SLACK_WEBHOOK }}` reference token is renamed to `${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}`; the local `SLACK_WEBHOOK:` env-var alias names inside each step are left intact.

## Workflows touched (11 references across 8 files)

- `notify-pr.yml`
- `deploy-health-check.yml`
- `deploy-pages.yml`
- `index-health-monitor.yml`
- `publish-docker.yml` (x2)
- `publish-release.yml` (x2)
- `unreleased-check.yml`
- `update-competitive-matrix.yml` (x2)

## Validation

- `python3 yaml.safe_load` passes on all 8 changed workflows.
- `actionlint` clean for the change (only pre-existing, unrelated SC2086 info-level shellcheck warnings remain, none in the touched `env:` blocks).
- Diff confirmed to be the secret-name swap only.

## Follow-up

After this merges, the now-redundant repo-local `SLACK_WEBHOOK` secret will be deleted (handled separately — not part of this PR).