### PR TITLE
Release @copilotkit/pathfinder 1.14.0 (atlas CLI)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @copilotkit/pathfinder
 
+## 1.14.0
+
+### Minor Changes
+
+- **`atlas` CLI**: New first-party command-line client shipped as `bin.atlas`. `atlas search` queries a Pathfinder knowledge server and `atlas feedback` submits feedback on results, with hardened `tools/call` response handling.
+- **`prepublishOnly` Build Guard**: Added a `prepublishOnly` script so the published tarball always ships a fresh `dist/` (including `dist/atlas-cli.js`), preventing stale or missing build output from being released.
+- **Atlas Foundation**: Off-by-default codebase-knowledge layer — additive schema, ratification endpoints, gardener, and webhook PR ingestion. Disabled unless explicitly enabled, so existing deployments are unaffected.
+
 ## 1.13.3
 
 ### Patch Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@copilotkit/pathfinder",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@copilotkit/pathfinder",
-      "version": "1.13.3",
+      "version": "1.14.0",
       "license": "Elastic-2.0",
       "dependencies": {
         "@discordjs/rest": "^2.6.1",
@@ -31,6 +31,7 @@
         "zod": "^3.23.8"
       },
       "bin": {
+        "atlas": "dist/atlas-cli.js",
         "pathfinder": "dist/cli.js"
       },
       "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/pathfinder",
-  "version": "1.13.3",
+  "version": "1.14.0",
   "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
   "type": "module",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("The knowledge server for AI agents")
-  .version("1.13.3");
+  .version("1.14.0");
 
 program
   .command("init")


### PR DESCRIPTION
## Summary

Version-only release cut. Bumps `@copilotkit/pathfinder` **1.13.3 → 1.14.0** so the version-gated `publish-release.yml` workflow fires on merge and publishes `@copilotkit/pathfinder@1.14.0` to npm — carrying the new `bin.atlas` CLI. The server/source code is **unchanged from #94** (commit `d43b88e`), which is already deployed to prod; this PR only changes the version (`package.json`, `package-lock.json`, `src/cli.ts`) and adds a CHANGELOG entry.

### Why
- The npm publish is version-gated: pushing to `main` publishes only when `package.json` version is unpublished. `1.14.0` is not yet on npm (verified `npm view @copilotkit/pathfinder@1.14.0` → 404), so merging this fires the publish.
- Unblocks internal-skills #121, which needs to pin `@copilotkit/pathfinder@1.14.0` for the `atlas` CLI.

### What 1.14.0 ships (all from #94, now released)
- **`atlas` CLI** — first-party client as `bin.atlas`: `atlas search` + `atlas feedback`, with hardened `tools/call` response handling.
- **`prepublishOnly` build guard** — the published tarball always ships a fresh `dist/` (incl. `dist/atlas-cli.js`).
- **Atlas foundation** — off-by-default codebase-knowledge layer: additive schema, ratification endpoints, gardener, webhook PR ingestion. Disabled unless explicitly enabled; existing deployments unaffected.

### Bump rationale
Minor bump (new additive `atlas` CLI feature, backward compatible). Repo uses a plain `package.json` version bump (no changesets/release-please). `src/cli.ts` `.version()` bumped in lockstep to satisfy the `version-sync` CI gate and the publish workflow's "Verify CLI version matches package version" check.

## Local gate results (node 25 / `/tmp/pf-release`)
- prettier `--check` (package.json, src/cli.ts, CHANGELOG.md): **clean**
- `scripts/check-version-sync.sh`: **✓ in sync (1.14.0)**
- `npx tsc --noEmit`: **0 errors**
- `npm run build`: **succeeds**, emits `dist/atlas-cli.js`, `dist/cli.js`, `dist/index.js`
- `npm test`: **3712 passed (254 files)** after build (CI test job builds before testing, matching this order)

## Merge note
Do **not** auto-merge. The orchestrator will merge after the prod deploy is confirmed healthy; merge fires the npm publish.