### PR TITLE
Fix atlas state-token precision stranding approved seeds

### DIFF
--- a/src/__tests__/atlas-db.test.ts
+++ b/src/__tests__/atlas-db.test.ts
@@ -371,6 +371,38 @@ describe("Atlas DB helpers", () => {
     expect(items.map((item) => item.key)).toEqual(["included"]);
   });
 
+  it("does not strand rows whose updated_at has sub-millisecond precision", async () => {
+    // State tokens round-trip through JS Dates (millisecond precision) while
+    // updated_at is a Postgres timestamptz (microsecond precision). A row
+    // updated at ...28.786830 produces the token ...28.786Z; the incremental
+    // bound `updated_at <= token` must still include that row, and the next
+    // run's `updated_at > token` must not re-strand it forever.
+    await upsertAtlasSeedCandidate({
+      canonicalKey: "micro",
+      sourceName: "atlas",
+      title: "Micro",
+      content: "Micro content",
+      provenance: {},
+      evidence: [],
+    });
+    await approveAtlasSeedEntry("micro", "reviewer");
+    await db.query(
+      "UPDATE atlas_seed_entries SET updated_at = '2026-06-11T01:46:28.786830+00'::timestamptz WHERE canonical_key = $1",
+      ["micro"],
+    );
+
+    const token = await getAtlasStateToken("atlas");
+    expect(token).toBe("2026-06-11T01:46:28.786Z");
+
+    // Mirror of the incremental acquire bounds: previous token < new token.
+    const items = await listIndexableAtlasContent("atlas", {
+      changedAfter: new Date("2026-06-11T01:00:00.000Z"),
+      changedOnOrBefore: new Date(token!),
+    });
+
+    expect(items.map((item) => item.key)).toEqual(["micro"]);
+  });
+
   it("surfaces stale cache pages as removals and includes them in state tokens", async () => {
     await upsertAtlasCachePage({
       pageKey: "fresh",

--- a/src/__tests__/atlas-db.test.ts
+++ b/src/__tests__/atlas-db.test.ts
@@ -573,6 +573,14 @@ describe("Atlas row-mapper robustness", () => {
     );
   });
 
+  it("resolveAtlasStateToken throws on a mixed null-plus-unparseable shape (one empty table, one corrupt MAX)", () => {
+    expect(() =>
+      __testing.resolveAtlasStateToken([null, "garbage"]),
+    ).toThrowError(
+      /getAtlasStateToken: unparseable MAX\(updated_at\): "garbage"/,
+    );
+  });
+
   it("resolveAtlasStateToken returns null when every table MAX is null (empty tables)", () => {
     expect(__testing.resolveAtlasStateToken([null, null])).toBeNull();
     expect(__testing.resolveAtlasStateToken([])).toBeNull();

--- a/src/__tests__/atlas-db.test.ts
+++ b/src/__tests__/atlas-db.test.ts
@@ -376,7 +376,8 @@ describe("Atlas DB helpers", () => {
     // updated_at is a Postgres timestamptz (microsecond precision). A row
     // updated at ...28.786830 produces the token ...28.786Z; the incremental
     // bound `updated_at <= token` must still include that row, and the next
-    // run's `updated_at > token` must not re-strand it forever.
+    // run's `updated_at > token` must not re-emit it forever (endless
+    // re-embedding).
     await upsertAtlasSeedCandidate({
       canonicalKey: "micro",
       sourceName: "atlas",
@@ -401,6 +402,23 @@ describe("Atlas DB helpers", () => {
     });
 
     expect(items.map((item) => item.key)).toEqual(["micro"]);
+
+    // Second incremental cycle: bounds collapse to (token, token]. The row is
+    // already indexed and must NOT re-emit — an un-truncated lower bound
+    // (updated_at > token) would re-embed it on every incremental run forever.
+    const second = await listIndexableAtlasContent("atlas", {
+      changedAfter: new Date(token!),
+      changedOnOrBefore: new Date(token!),
+    });
+    expect(second).toEqual([]);
+
+    // Recovery for already-stranded prod rows: clearing last_commit_sha forces
+    // fullAcquire, which bounds ONLY with changedOnOrBefore — must include the
+    // row.
+    const recovered = await listIndexableAtlasContent("atlas", {
+      changedOnOrBefore: new Date(token!),
+    });
+    expect(recovered.map((item) => item.key)).toEqual(["micro"]);
   });
 
   it("surfaces stale cache pages as removals and includes them in state tokens", async () => {
@@ -547,5 +565,25 @@ describe("Atlas row-mapper robustness", () => {
     const result = __testing.toDate(iso);
     expect(result).toBeInstanceOf(Date);
     expect(result?.toISOString()).toBe(iso);
+  });
+
+  it("resolveAtlasStateToken throws on an unparseable non-null MAX instead of silently shrinking the window", () => {
+    expect(() => __testing.resolveAtlasStateToken(["garbage"])).toThrowError(
+      /getAtlasStateToken: unparseable MAX\(updated_at\): "garbage"/,
+    );
+  });
+
+  it("resolveAtlasStateToken returns null when every table MAX is null (empty tables)", () => {
+    expect(__testing.resolveAtlasStateToken([null, null])).toBeNull();
+    expect(__testing.resolveAtlasStateToken([])).toBeNull();
+  });
+
+  it("resolveAtlasStateToken returns the max of the per-table MAXes as a ms-precision ISO string", () => {
+    expect(
+      __testing.resolveAtlasStateToken([
+        new Date("2026-01-01T00:00:00.123Z"),
+        "2026-01-02T00:00:00.456Z",
+      ]),
+    ).toBe("2026-01-02T00:00:00.456Z");
   });
 });

--- a/src/db/atlas.ts
+++ b/src/db/atlas.ts
@@ -243,7 +243,8 @@ function addUpdatedAtClauses(
   // produced the token (e.g. ...28.786830 → token ...28.786Z) falls in the
   // sub-millisecond gap: it fails `updated_at <= token` in the run that
   // generated the token, and every later run bounds with the same token
-  // (`> token AND <= token`), stranding the row forever un-indexed.
+  // (`> token AND <= token`), stranding the row forever un-indexed (until
+  // its updated_at next changes).
   // Truncating the LOWER bound matters independently: an un-truncated
   // `updated_at > token` would match the boundary row (...28.786830 > ...28.786)
   // on every incremental run, re-indexing (and re-embedding) it forever.
@@ -846,10 +847,12 @@ export async function getAtlasStateToken(
   ]);
 }
 
-// Test-only exports of the otherwise-private row mappers and timestamp parser.
-// These are pure functions; exporting them lets us unit-test the robustness
-// paths (malformed JSON → context-bearing error, invalid timestamp → null)
-// directly without contriving a backing store that can hold malformed columns.
+// Test-only exports of the otherwise-private row mappers, timestamp parser,
+// and state-token resolver. These are pure functions; exporting them lets us
+// unit-test the robustness paths (malformed JSON → context-bearing error,
+// invalid timestamp → null in toDate, unparseable non-null MAX → throw with
+// context and all-null/empty input → null in resolveAtlasStateToken) directly
+// without contriving a backing store that can hold malformed columns.
 export const __testing = {
   mapSeedRow,
   mapCacheRow,

--- a/src/db/atlas.ts
+++ b/src/db/atlas.ts
@@ -240,10 +240,16 @@ function addUpdatedAtClauses(
   // State tokens travel through JS Dates (millisecond precision) while
   // updated_at is a Postgres timestamptz (microsecond precision). Compare at
   // millisecond precision on BOTH bounds, otherwise the row whose updated_at
-  // produced the token (e.g. ...28.78683 → token ...28.786Z) falls in the
+  // produced the token (e.g. ...28.786830 → token ...28.786Z) falls in the
   // sub-millisecond gap: it fails `updated_at <= token` in the run that
   // generated the token, and every later run bounds with the same token
   // (`> token AND <= token`), stranding the row forever un-indexed.
+  // Truncating the LOWER bound matters independently: an un-truncated
+  // `updated_at > token` would match the boundary row (...28.786830 > ...28.786)
+  // on every incremental run, re-indexing (and re-embedding) it forever.
+  // Residual: a write landing in the token's millisecond after the items query
+  // is not picked up by the strict lower bound — accepted sliver, see the
+  // µs-faithful-token follow-up.
   if (query.changedAfter) {
     params.push(query.changedAfter);
     clauses.push(
@@ -763,6 +769,33 @@ export async function listRemovedAtlasContentIds(
   ];
 }
 
+// Resolves the raw MAX(updated_at) values from the per-table state-token
+// queries into a single token. Nulls (empty tables) are skipped; an
+// unparseable non-null MAX is a hard error — silently dropping it would
+// shrink the incremental window and no-op the run while reporting success,
+// the same silent-stranding failure class addUpdatedAtClauses guards against.
+function resolveAtlasStateToken(raw: unknown[]): string | null {
+  const values: Date[] = [];
+  for (const value of raw) {
+    if (value == null) continue;
+    const date = value instanceof Date ? value : new Date(value as string);
+    if (isNaN(date.getTime())) {
+      throw new Error(
+        `getAtlasStateToken: unparseable MAX(updated_at): ${JSON.stringify(value)}`,
+      );
+    }
+    values.push(date);
+  }
+  if (values.length === 0) return null;
+  return new Date(
+    Math.max(...values.map((value) => value.getTime())),
+  ).toISOString();
+}
+
+// Note: the returned token is implicitly ms-truncated by the Date round-trip
+// in resolveAtlasStateToken (updated_at carries microseconds, JS Dates keep
+// milliseconds); the query bounds compare ms-truncated updated_at to match
+// (see addUpdatedAtClauses).
 export async function getAtlasStateToken(
   sourceName: string,
   query: Pick<AtlasContentQuery, "repositories"> = {},
@@ -807,16 +840,10 @@ export async function getAtlasStateToken(
     ),
   ]);
 
-  const values = [
+  return resolveAtlasStateToken([
     seedResult.rows[0]?.state_token,
     cacheResult.rows[0]?.state_token,
-  ]
-    .map((value) => toDate(value, "atlas state token"))
-    .filter((value): value is Date => value !== null);
-  if (values.length === 0) return null;
-  return new Date(
-    Math.max(...values.map((value) => value.getTime())),
-  ).toISOString();
+  ]);
 }
 
 // Test-only exports of the otherwise-private row mappers and timestamp parser.
@@ -827,4 +854,5 @@ export const __testing = {
   mapSeedRow,
   mapCacheRow,
   toDate,
+  resolveAtlasStateToken,
 };

--- a/src/db/atlas.ts
+++ b/src/db/atlas.ts
@@ -237,13 +237,24 @@ function addUpdatedAtClauses(
   params: unknown[],
 ): string[] {
   const clauses: string[] = [];
+  // State tokens travel through JS Dates (millisecond precision) while
+  // updated_at is a Postgres timestamptz (microsecond precision). Compare at
+  // millisecond precision on BOTH bounds, otherwise the row whose updated_at
+  // produced the token (e.g. ...28.78683 → token ...28.786Z) falls in the
+  // sub-millisecond gap: it fails `updated_at <= token` in the run that
+  // generated the token, and every later run bounds with the same token
+  // (`> token AND <= token`), stranding the row forever un-indexed.
   if (query.changedAfter) {
     params.push(query.changedAfter);
-    clauses.push(`${alias}.updated_at > $${params.length}`);
+    clauses.push(
+      `date_trunc('milliseconds', ${alias}.updated_at) > $${params.length}`,
+    );
   }
   if (query.changedOnOrBefore) {
     params.push(query.changedOnOrBefore);
-    clauses.push(`${alias}.updated_at <= $${params.length}`);
+    clauses.push(
+      `date_trunc('milliseconds', ${alias}.updated_at) <= $${params.length}`,
+    );
   }
   return clauses;
 }


### PR DESCRIPTION
## Summary

`getAtlasStateToken` returns `MAX(updated_at)` from the atlas tables, but the value round-trips through a JS `Date`, truncating PostgreSQL's microsecond precision to milliseconds (e.g. `…28.78683` → `…28.786Z`). The incremental acquire path then bounds with `updated_at > $lastToken AND updated_at <= $newToken` at full microsecond precision, so the row that produced the token falls in the sub-millisecond gap: it fails `updated_at <= token` in the run that generated the token, and every later run bounds `> token AND <= token` — the row is permanently stranded. Symptom: approved seeds never get indexed by incremental reindex, silently ("Indexing complete" with 0 items).

**Fix:** compare with `date_trunc('milliseconds', updated_at)` on BOTH bound clauses in `addUpdatedAtClauses`, so comparison precision matches token precision. This is the minimal correct surface: truncating inside `MAX()` in `getAtlasStateToken` would be redundant (the JS `Date` round-trip already truncates the token) and would not by itself close the comparison gap — the mismatch only matters where the bounds are evaluated.

Found by the atlas sandbox live run; hot-patch validated there end-to-end before this PR (seed approved at `01:46:28.78683`, token `2026-06-11T01:46:28.786Z`, 0 chunks indexed before the patch; seed indexed with 1 chunk and a real search hit after).

## Test plan

- [x] New red-green regression test in `src/__tests__/atlas-db.test.ts`: approved seed with `updated_at = '2026-06-11T01:46:28.786830+00'`, token captured, incremental bounds applied. Red against unfixed code: `AssertionError: expected [] to deeply equal [ 'micro' ]`. Green after the fix.
- [x] Second-cycle assertion pins the LOWER bound: querying `(token, token]` must return `[]`. Red-verified against an un-truncated `updated_at > token` (boundary row re-emits forever) before restoring the fix.
- [x] Recovery-path assertion: a fullAcquire-shaped query (`changedOnOrBefore` only) includes the previously-stranded row — pins the deploy-step recovery mechanism in code.
- [x] `resolveAtlasStateToken` unit tests: throws on an unparseable non-null `MAX(updated_at)` (fail loud instead of silently shrinking the window), `null` on empty tables, max-of-maxes as ms ISO string.
- [x] Full suite: 324 files, 5933/5933 passing
- [x] `tsc --noEmit` on both tsconfigs (`tsconfig.json`, `tsconfig.scripts.json`)
- [x] `npm run build` clean

## Deploy step (one-time, REQUIRED)

The bound fix is forward-only: a prod row stranded by the pre-fix bug has `date_trunc('milliseconds', updated_at)` exactly equal to the persisted token, and the fixed lower bound is strict (`> token`), so the already-stranded row stays excluded forever with all signals green — deploying the code alone does not heal it. Clearing the persisted state token forces one full re-acquire (idempotent re-index), which bounds only with `changedOnOrBefore` and picks the stranded rows back up.

Note the wall-clock time, then run (idle-gated: a run in flight reads state before and writes the token after this UPDATE, which would silently cancel the clear):

```sql
UPDATE index_state
SET last_commit_sha = NULL
WHERE source_type = 'atlas'
  AND status <> 'indexing'
RETURNING source_key, status;
```

Every atlas row must come back in RETURNING. If any row was skipped (a run was in flight), wait for it to finish and re-run the UPDATE until all atlas rows are returned.

Confirm the clear took effect before the next orchestrator run:

```sql
SELECT source_key, last_commit_sha, status
FROM index_state WHERE source_type = 'atlas';
-- expect: last_commit_sha IS NULL on every row
```

After the next orchestrator run, verify recovery actually ran:

```sql
SELECT source_key, last_commit_sha, status, last_indexed_at
FROM index_state WHERE source_type = 'atlas';
-- expect: repopulated last_commit_sha, status = 'idle', AND
-- last_indexed_at LATER than the time you ran the UPDATE above
-- (proves the full re-acquire ran after the clear, not pre-deploy
-- state surviving a clobber).
```

This step is part of this PR's definition of done — whoever merges deploys and runs it in the same motion.
