### PR TITLE
Release v1.15.1 — RFC 9728 resource_metadata + RFC 6750 conformance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @copilotkit/pathfinder
 
+## 1.15.1
+
+### Patch Changes
+
+- **OAuth Bearer 401s emit RFC 9728 `resource_metadata` discovery hint on `WWW-Authenticate`** — wires the previously-dead `unauthorizedWithDiscovery` helper into all three `bearerMiddleware` failure paths. Discovery endpoint (`/.well-known/oauth-protected-resource`) was already live. Adds `[oauth] bearer_failure reason={empty_token|invalid_signature|expired|aud_mismatch|malformed_token} ip=<ip>` observability logs at every Bearer-401 path. Additive header change, backward compatible — spec-compliant clients ignore unknown attributes.
+- **RFC 6750 §3.1 conformance**: the `WWW-Authenticate` header now retains `error="invalid_token"` alongside `resource_metadata=` and `scope="mcp"`. Per RFC 6750 §3.1 the `error=` attribute MUST be in the header when a Bearer token is presented and invalid; the helper previously dropped it (kept only in the JSON body). Strengthened `assertDiscoveryHeader` test helper now pins this invariant on all four RFC 9728 paths (empty Bearer, invalid signature, expired, aud mismatch).
+
 ## 1.15.0
 
 ### Minor Changes

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@copilotkit/pathfinder",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@copilotkit/pathfinder",
-      "version": "1.15.0",
+      "version": "1.15.1",
       "license": "Elastic-2.0",
       "dependencies": {
         "@discordjs/rest": "^2.6.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/pathfinder",
-  "version": "1.15.0",
+  "version": "1.15.1",
   "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
   "type": "module",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("The knowledge server for AI agents")
-  .version("1.15.0");
+  .version("1.15.1");
 
 program
   .command("init")


### PR DESCRIPTION
Patch for PR #107 (https://github.com/CopilotKit/pathfinder/pull/107). Publishes @copilotkit/pathfinder@1.15.1 → tags v1.15.1 → Publish Docker → Railway redeploy.