### PR TITLE
ci: bump deploy-pages.yml actions to Node 24 (pre-Sep 2026 deprecation)

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
           persist-credentials: false
-      - uses: actions/configure-pages@1f0c5cde4bc74cd7e1254d0cb4de8d49e9068c7d # v4
+      - uses: actions/configure-pages@45bfe0192ca1faeb007ade9deae92b16b8254a0d # v6.0.0
       - uses: actions/upload-pages-artifact@fc324d3547104276b827a68afc52ff2a11cc49c9 # v5
         with:
           path: docs


### PR DESCRIPTION
GitHub Actions deprecates Node 20 actions on 2026-09-16. Bumps the Node-20 action in `.github/workflows/deploy-pages.yml` (`actions/configure-pages` v4 → v6.0.0) to its current Node 24 SHA. The other actions in the file (`checkout` v6.0.2, `upload-pages-artifact` v5, `deploy-pages` v5.0.0) are already on Node 24 or composite and remain unchanged. No behavioral change; Pages deploy still triggers on push to main + serves `docs/`.