### PR TITLE
Sweep NUL-byte sanitization across non-chunk writers and chunk read paths

### DIFF
--- a/src/__tests__/strip-nul-bytes-sweep.test.ts
+++ b/src/__tests__/strip-nul-bytes-sweep.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Follow-up coverage to strip-nul-bytes.test.ts (PR #114, chunk write path).
+// PR #114 sanitized the chunks INSERT/DELETE paths; this file pins the same
+// invariant on every OTHER text-typed bind on Postgres TEXT/JSONB columns that
+// is fed by caller input. Mirrors the existing test's mocking pattern: a
+// pooled client capture for transactional code and a pool.query capture for
+// direct queries.
+
+const clientQuery = vi.fn();
+const clientRelease = vi.fn();
+const connect = vi.fn(async () => ({
+  query: clientQuery,
+  release: clientRelease,
+}));
+const poolQuery = vi.fn();
+
+vi.mock("../db/client.js", () => ({
+  getPool: () => ({ connect, query: poolQuery }),
+}));
+
+vi.mock("pgvector", () => ({
+  default: { toSql: (v: unknown) => v },
+}));
+
+// Import AFTER mocking so queries.ts binds to the mocked getPool.
+import {
+  insertCollectedData,
+  recordWebhookDelivery,
+  upsertIndexState,
+  textSearchChunks,
+  getIndexedItemIds,
+  getIndexState,
+  searchChunks,
+  getFaqChunks,
+} from "../db/queries.js";
+
+const NUL = "\x00";
+
+beforeEach(() => {
+  poolQuery.mockReset();
+  poolQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+  clientQuery.mockReset();
+  clientRelease.mockReset();
+  connect.mockClear();
+  clientQuery.mockResolvedValue({ rows: [], rowCount: 0 });
+});
+
+// ---------------------------------------------------------------------------
+// Writers
+// ---------------------------------------------------------------------------
+
+describe("insertCollectedData NUL sanitization", () => {
+  it("strips NUL from tool_name AND from every string in the JSONB data blob (keys + values, nested)", async () => {
+    // collected_data is fed by user MCP input (collect.ts) and raw shell
+    // command strings (bash-telemetry.ts). A NUL anywhere in the JSONB blob
+    // (including object keys) errors the cast with `invalid byte sequence
+    // for encoding "UTF8": 0x00` and fails the INSERT. The deep sanitizer
+    // must walk the entire structure.
+    await insertCollectedData(`bash${NUL}-telemetry`, {
+      cmd: `printf '${NUL}' | xxd`,
+      nested: { [`key${NUL}A`]: `v${NUL}` },
+      arr: [`a${NUL}b`, "ok"],
+    });
+
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    expect(String(sql)).toContain("INSERT INTO collected_data");
+
+    const [toolName, dataJson] = params as [string, string];
+    expect(toolName).toBe("bash-telemetry");
+    expect(toolName).not.toContain(NUL);
+
+    // JSON.stringify escapes a literal NUL to the 6-char sequence \\u0000.
+    // The meaningful assertion is on the escape, not on the literal byte
+    // (the escape would still fail the jsonb cast on the wire). Same lesson
+    // as PR #114's metadata jsonb assertion.
+    expect(dataJson).not.toContain(NUL);
+    expect(dataJson).not.toContain("\\u0000");
+    const parsed = JSON.parse(dataJson);
+    expect(parsed).toEqual({
+      cmd: "printf '' | xxd",
+      nested: { keyA: "v" },
+      arr: ["ab", "ok"],
+    });
+  });
+});
+
+describe("recordWebhookDelivery NUL sanitization", () => {
+  it("strips NUL from every text bind (source, event_type, repo, decision, reason)", async () => {
+    // Webhook payloads are partly attacker-influenced — event_type/repo/reason
+    // come from incoming HTTP bodies. The function is fire-and-forget (the
+    // outer try/catch swallows errors), so an unsanitized NUL would surface
+    // as a silently dropped tracking row, not a visible failure. Pin the
+    // sanitization at the bind site so we never write — or attempt to write —
+    // a NUL into webhook_deliveries.
+    await recordWebhookDelivery({
+      source: `git${NUL}hub`,
+      event_type: `pull${NUL}_request`,
+      repo: `CopilotKit/${NUL}pathfinder`,
+      decision: `acce${NUL}pted`,
+      reason: `ok ${NUL} done`,
+      payload_size: 42,
+    });
+
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    expect(String(sql)).toContain("INSERT INTO webhook_deliveries");
+    const [source, eventType, repo, decision, reason, size] =
+      params as unknown[];
+
+    expect(source).toBe("github");
+    expect(eventType).toBe("pull_request");
+    expect(repo).toBe("CopilotKit/pathfinder");
+    expect(decision).toBe("accepted");
+    expect(reason).toBe("ok  done");
+    expect(size).toBe(42);
+
+    for (const v of [source, eventType, repo, decision, reason]) {
+      expect(String(v)).not.toContain(NUL);
+    }
+  });
+
+  it("preserves null optional fields (does not stringify null through the sanitizer)", async () => {
+    await recordWebhookDelivery({
+      source: "github",
+      decision: "rejected",
+      // event_type / repo / reason / payload_size omitted
+    });
+
+    const [, params] = poolQuery.mock.calls[0];
+    const [, eventType, repo, , reason, size] = params as unknown[];
+    expect(eventType).toBeNull();
+    expect(repo).toBeNull();
+    expect(reason).toBeNull();
+    expect(size).toBeNull();
+  });
+});
+
+describe("upsertIndexState NUL sanitization", () => {
+  it("strips NUL from every text bind, including the poison-pill error_message path", async () => {
+    // The highest-risk column is error_message: it's populated with raw
+    // upstream errors. If a chunks-INSERT fails with `invalid byte sequence
+    // for encoding "UTF8": 0x00`, the orchestrator persists the error string
+    // — which literally contains the offending 0x00 byte — into index_state.
+    // Without sanitization, the index_state UPDATE itself re-trips the same
+    // encoding rejection, turning a transient failure into a poison-pill
+    // loop. Sanitize all binds; pin error_message explicitly.
+    await upsertIndexState({
+      source_type: `git${NUL}hub`,
+      source_key: `repo${NUL}-key`,
+      last_commit_sha: `sha${NUL}123`,
+      last_indexed_at: new Date(0),
+      status: "error",
+      error_message: `invalid byte sequence for encoding "UTF8": 0x${NUL}00`,
+    });
+
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    expect(String(sql)).toContain("INSERT INTO index_state");
+    const [sourceType, sourceKey, sha, , status, errMsg] = params as unknown[];
+    expect(sourceType).toBe("github");
+    expect(sourceKey).toBe("repo-key");
+    expect(sha).toBe("sha123");
+    expect(status).toBe("error");
+    expect(String(errMsg)).not.toContain(NUL);
+    expect(String(errMsg)).toBe(
+      'invalid byte sequence for encoding "UTF8": 0x00',
+    );
+
+    for (const v of [sourceType, sourceKey, sha, status, errMsg]) {
+      expect(String(v)).not.toContain(NUL);
+    }
+  });
+
+  it("preserves null optional fields", async () => {
+    await upsertIndexState({
+      source_type: "github",
+      source_key: "k",
+      last_commit_sha: null,
+      last_indexed_at: null,
+      status: "idle",
+      error_message: null,
+    });
+
+    const [, params] = poolQuery.mock.calls[0];
+    const [, , sha, lastAt, , err] = params as unknown[];
+    expect(sha).toBeNull();
+    expect(lastAt).toBeNull();
+    expect(err).toBeNull();
+  });
+
+  it("defaults status to 'idle' (sanitizer must not perturb the default-substitution)", async () => {
+    // The implementation uses `state.status ?? "idle"`; the sanitizer wraps
+    // that expression. Pin the default still flows through cleanly.
+    await upsertIndexState({
+      source_type: "github",
+      source_key: "k",
+      last_commit_sha: null,
+      last_indexed_at: null,
+      // status omitted intentionally — exercises the `?? "idle"` default path
+      error_message: null,
+    });
+    const [, params] = poolQuery.mock.calls[0];
+    expect((params as unknown[])[4]).toBe("idle");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Readers
+// ---------------------------------------------------------------------------
+//
+// Readers matter because the chunks table is WRITTEN with stripNulBytes
+// applied (PR #114), so the stored values are sanitized. An unsanitized reader
+// bind has two failure modes:
+//   (a) crash the SELECT with `invalid byte sequence for encoding "UTF8":
+//       0x00` (Postgres rejects 0x00 in TEXT binds identically to INSERT/UPDATE
+//       — `plainto_tsquery`'s input is a TEXT bind on the wire);
+//   (b) return zero rows because the WHERE comparand carries a NUL while the
+//       stored value does not — silent inconsistency that's far worse than a
+//       loud encoding error.
+
+describe("textSearchChunks NUL sanitization", () => {
+  it("strips NUL from pattern, sourceName, and version binds", async () => {
+    await textSearchChunks(`query${NUL}text`, 5, `src${NUL}name`, `v${NUL}1`);
+
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [, params] = poolQuery.mock.calls[0];
+    const [pattern, source, version, limit] = params as unknown[];
+    expect(pattern).toBe("querytext");
+    expect(source).toBe("srcname");
+    expect(version).toBe("v1");
+    expect(limit).toBe(5);
+    for (const v of [pattern, source, version]) {
+      expect(String(v)).not.toContain(NUL);
+    }
+  });
+
+  it("early-returns on empty pattern without binding (no query issued)", async () => {
+    // Guards the existing pattern.trim() short-circuit — the sanitizer must
+    // not change that behavior.
+    const out = await textSearchChunks("   ", 5);
+    expect(out).toEqual([]);
+    expect(poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("early-returns on NUL-only pattern without binding (no query issued)", async () => {
+    // A NUL-only pattern survives `pattern.trim()` (NUL is not whitespace),
+    // then sanitizes to "" — issuing a useless plainto_tsquery DB roundtrip
+    // against an empty string. Sanitize FIRST, then check empty/whitespace.
+    const out = await textSearchChunks(`${NUL}${NUL}${NUL}`, 5);
+    expect(out).toEqual([]);
+    expect(poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("omits the source_name filter when sourceName is NUL-only (sanitize-then-truthy)", async () => {
+    // Truthy check on the RAW sourceName lets `"\x00"` through; sanitization
+    // then produces `""`, and the WHERE filter becomes `source_name = ''` —
+    // which matches zero rows because the writer stores NUL-stripped
+    // (non-empty) values. The keyword half of hybridSearchChunks's RRF merge
+    // is silently zeroed out on NUL-bearing source filters. Eager-sanitize
+    // at function entry and skip the filter when the sanitized result is
+    // empty — same discipline as searchChunks.
+    await textSearchChunks("query", 5, `${NUL}${NUL}`);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    expect(String(sql)).not.toMatch(/source_name\s*=\s*\$/);
+    // Only the tsquery pattern bind and the limit bind survive.
+    const paramArr = params as unknown[];
+    expect(paramArr.length).toBe(2);
+    for (const v of paramArr) {
+      expect(String(v)).not.toBe("");
+    }
+  });
+
+  it("omits the version filter when version is NUL-only (sanitize-then-truthy)", async () => {
+    await textSearchChunks("query", 5, undefined, `${NUL}${NUL}`);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    expect(String(sql)).not.toMatch(/version\s*=\s*\$/);
+    const paramArr = params as unknown[];
+    expect(paramArr.length).toBe(2);
+    for (const v of paramArr) {
+      expect(String(v)).not.toBe("");
+    }
+  });
+});
+
+describe("getIndexedItemIds NUL sanitization", () => {
+  it("strips NUL from the source_name bind", async () => {
+    await getIndexedItemIds(`ag-ui${NUL}code`);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [, params] = poolQuery.mock.calls[0];
+    expect((params as unknown[])[0]).toBe("ag-uicode");
+    expect(String((params as unknown[])[0])).not.toContain(NUL);
+  });
+});
+
+describe("getIndexState NUL sanitization", () => {
+  it("strips NUL from sourceType and sourceKey binds", async () => {
+    await getIndexState(`git${NUL}hub`, `repo${NUL}-key`);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [, params] = poolQuery.mock.calls[0];
+    const [t, k] = params as unknown[];
+    expect(t).toBe("github");
+    expect(k).toBe("repo-key");
+    for (const v of [t, k]) expect(String(v)).not.toContain(NUL);
+  });
+});
+
+describe("searchChunks NUL sanitization", () => {
+  it("strips NUL from sourceName and version binds (vector embedding param untouched)", async () => {
+    await searchChunks([0.1, 0.2], 10, `src${NUL}name`, `v${NUL}1`);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [, params] = poolQuery.mock.calls[0];
+    // params[0] = embedding (pgvector.toSql passthrough), $2 = sourceName,
+    // $3 = version, $4 = limit
+    const [, source, version, limit] = params as unknown[];
+    expect(source).toBe("srcname");
+    expect(version).toBe("v1");
+    expect(limit).toBe(10);
+    for (const v of [source, version]) {
+      expect(String(v)).not.toContain(NUL);
+    }
+  });
+
+  it("does not bind a sanitized sourceName when the caller passes undefined (filter skipped)", async () => {
+    // Sanitization must not synthesize a bind where there wasn't one — the
+    // sourceName / version filters are conditional. A NUL-stripping helper
+    // applied before the conditional check would have inadvertently added an
+    // empty-string source filter; the fix's `if (sourceName)` guard runs first.
+    await searchChunks([0.1], 10);
+    const [, params] = poolQuery.mock.calls[0];
+    // Only the embedding and the limit bind ($2) — no source/version.
+    expect((params as unknown[]).length).toBe(2);
+  });
+
+  it("omits the source_name filter when sourceName is NUL-only (sanitize-then-truthy)", async () => {
+    // Truthy check on the RAW input lets `"\x00"` through; sanitization then
+    // produces `""`, and the WHERE filter becomes `source_name = ''` — which
+    // matches zero rows because the writer stores NUL-stripped (non-empty)
+    // values. Mirror the textSearchChunks discipline: sanitize FIRST, then
+    // skip the filter when empty.
+    await searchChunks([0.1, 0.2], 10, `${NUL}${NUL}`);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    expect(String(sql)).not.toMatch(/source_name\s*=\s*\$/);
+    // No empty-string source_name bind smuggled in: only embedding + limit.
+    expect((params as unknown[]).length).toBe(2);
+  });
+
+  it("omits the version filter when version is NUL-only (sanitize-then-truthy)", async () => {
+    await searchChunks([0.1, 0.2], 10, undefined, `${NUL}${NUL}`);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    expect(String(sql)).not.toMatch(/version\s*=\s*\$/);
+    expect((params as unknown[]).length).toBe(2);
+  });
+});
+
+describe("getFaqChunks NUL sanitization", () => {
+  it("strips NUL from every source_name in the array bind", async () => {
+    await getFaqChunks([`docs${NUL}-a`, "docs-b", `docs${NUL}-c`], 0.5, 20);
+
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [, params] = poolQuery.mock.calls[0];
+    const [a, b, c, minConf, limit] = params as unknown[];
+    expect(a).toBe("docs-a");
+    expect(b).toBe("docs-b");
+    expect(c).toBe("docs-c");
+    expect(minConf).toBe(0.5);
+    expect(limit).toBe(20);
+    for (const v of [a, b, c]) {
+      expect(String(v)).not.toContain(NUL);
+    }
+  });
+
+  it("empty sourceNames input returns early (no query issued)", async () => {
+    const out = await getFaqChunks([], 0.0);
+    expect(out).toEqual([]);
+    expect(poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("returns [] without issuing a query when every sourceName is NUL-only (sanitize-then-filter)", async () => {
+    // sourceNames.map(stripNulBytes) on `["\x00", "\x00\x00"]` would yield
+    // `["", ""]`, then bind those to `WHERE source_name IN ('', '')` — which
+    // matches zero rows because the writer never stores empty source_name.
+    // Filter empty entries AFTER sanitization; if nothing remains, skip the
+    // query entirely (same semantic as the existing `length === 0` guard).
+    const out = await getFaqChunks([`${NUL}`, `${NUL}${NUL}`], 0.5, 20);
+    expect(out).toEqual([]);
+    expect(poolQuery).not.toHaveBeenCalled();
+  });
+
+  it("drops NUL-only entries from the IN bind list while keeping real source names", async () => {
+    // Mixed-list case: one real source, one NUL-only. The NUL-only entry must
+    // not survive as `""` in the params, or it pollutes the IN clause with a
+    // never-matching empty-string comparand. Real entries flow through
+    // sanitized as before.
+    await getFaqChunks([`docs-a`, `${NUL}`, `docs-b`], 0.5, 20);
+    expect(poolQuery).toHaveBeenCalledTimes(1);
+    const [sql, params] = poolQuery.mock.calls[0];
+    // Two placeholders only — the NUL-only entry was dropped.
+    expect(String(sql)).toMatch(/source_name IN \(\$1, \$2\)/);
+    const [a, b, minConf, limit] = params as unknown[];
+    expect(a).toBe("docs-a");
+    expect(b).toBe("docs-b");
+    expect(minConf).toBe(0.5);
+    expect(limit).toBe(20);
+    for (const v of params as unknown[]) {
+      expect(String(v)).not.toContain(NUL);
+    }
+    // Pin no empty-string entry slipped through.
+    for (const v of [a, b]) expect(v).not.toBe("");
+  });
+});

--- a/src/__tests__/strip-nul-bytes.test.ts
+++ b/src/__tests__/strip-nul-bytes.test.ts
@@ -277,6 +277,78 @@ describe("stripNulBytesDeep (identity-preservation contract)", () => {
   });
 });
 
+describe("stripNulBytesDeep safety under adversarial input (cycles + deep nesting)", () => {
+  // The only consumer of stripNulBytesDeep that doesn't control its input is
+  // insertCollectedData (queries.ts:651): MCP tool-call payloads land here as
+  // arbitrary JSON-shaped JS values produced by external clients. A recursive
+  // tree walk on such input is a stack-overflow waiting to happen — either
+  // the client constructs a self-referential structure (cycle) or simply
+  // feeds a deeply-nested object. Pre-fix the recursive impl in queries.ts
+  // would throw `RangeError: Maximum call stack size exceeded` on both
+  // shapes, bricking the INSERT in exactly the way the JSON.stringify ->
+  // stripNulBytesDeep swap was supposed to prevent. Iterative walk closes
+  // the regression by construction.
+  it("does not throw on a self-referential object (cycle root)", () => {
+    const a: Record<string, unknown> = { x: "ok\x00cyc" };
+    a.self = a;
+    // Must not stack-overflow. The visible NUL on `x` is stripped.
+    const out = stripNulBytesDeep(a) as Record<string, unknown>;
+    expect(out).not.toBe(a);
+    expect(out.x).toBe("okcyc");
+    // The output preserves the cycle structurally — `self` points back at
+    // the cloned root (NOT at the input). This matches the docstring: the
+    // function's contract is "do not stack-overflow", not "flatten cycles".
+    expect(out.self).toBe(out);
+  });
+
+  it("does not throw on a cycle that requires no sanitization (identity NOT preserved on cycle)", () => {
+    // A clean cycle would, in the no-cycle case, return the input
+    // referentially. With cycles present and a NUL elsewhere in the tree,
+    // the detect pass still trips needsClean and we clone — verify that the
+    // walk terminates regardless of whether the dirty string is reached
+    // before or after the back-edge.
+    const a: Record<string, unknown> = { dirty: "x\x00y" };
+    const b: Record<string, unknown> = { ref: a };
+    a.back = b;
+    const out = stripNulBytesDeep(a) as Record<string, unknown>;
+    expect(out).not.toBe(a);
+    expect(out.dirty).toBe("xy");
+    const outBack = out.back as Record<string, unknown>;
+    expect(outBack).not.toBe(b);
+    expect(outBack.ref).toBe(out); // back-edge rewritten onto the clone
+  });
+
+  it("does not throw on a 10,000-level deeply nested linear object", () => {
+    // Construct a 10k-deep linear chain. Pre-fix this stack-overflows on
+    // V8's default ~10k call-stack budget the moment the walker descends
+    // through every level. Iterative walk pays only heap, not stack.
+    let cur: Record<string, unknown> = { leaf: "deep\x00leaf" };
+    for (let i = 0; i < 10000; i++) cur = { a: cur };
+    // Must not throw.
+    const out = stripNulBytesDeep(cur);
+    // Descend the output non-recursively to verify both that we got a clean
+    // mirror back AND that the deepest string was sanitized.
+    let node: unknown = out;
+    for (let i = 0; i < 10000; i++) {
+      node = (node as Record<string, unknown>).a;
+    }
+    expect((node as Record<string, unknown>).leaf).toBe("deepleaf");
+  });
+
+  it("does not throw on a deeply nested array (mirror shape via Array.isArray branch)", () => {
+    // Same idea as the deep-object test, but exercising the array branch of
+    // the iterative walker — a deeply nested `[[[ ... ]]]` chain.
+    let curArr: unknown[] = ["deep\x00leaf"];
+    for (let i = 0; i < 10000; i++) curArr = [curArr];
+    const out = stripNulBytesDeep(curArr) as unknown[];
+    let node: unknown = out;
+    for (let i = 0; i < 10000; i++) {
+      node = (node as unknown[])[0];
+    }
+    expect((node as unknown[])[0]).toBe("deepleaf");
+  });
+});
+
 describe("stripNulBytesDeep prototype-setter trap (the __proto__ key drop)", () => {
   // A NUL-bearing key like "__proto__\x00" sanitizes to "__proto__". Assigning
   // through bracket notation on a plain {} invokes the __proto__ setter — when
@@ -328,6 +400,96 @@ describe("stripNulBytesDeep prototype-setter trap (the __proto__ key drop)", () 
     expect(Object.prototype.hasOwnProperty.call(out, "constructor")).toBe(true);
     expect(out["constructor"]).toBe("evil");
     expect(out["normal"]).toBe("ok");
+  });
+});
+
+describe("stripNulBytesDeep non-plain-object leaf semantics (Date/Buffer/RegExp)", () => {
+  // J1 (recurring CR finding): the walker reallocates every container it
+  // visits as `Object.create(null)` or a fresh array, enumerating via
+  // `Object.entries`. For a Date/Buffer/RegExp nested INSIDE a dirty subtree,
+  // `Object.entries(date)` returns `[]` (no own enumerable props) and the
+  // value gets silently replaced with an empty null-prototype object — its
+  // `toJSON()` semantics are lost. This is path-dependent corruption: a Date
+  // next to a NUL-bearing sibling is destroyed; a Date in a clean subtree is
+  // preserved by the identity-hot-path early-return.
+  //
+  // The fix: treat non-plain objects (prototype is neither Object.prototype
+  // nor null) as opaque leaves — pass them through by reference, do NOT
+  // walk, do NOT reallocate. This restores `JSON.stringify`'s delegation to
+  // the value's `toJSON()` for Dates and to its native serializer for Buffer
+  // / class instances.
+
+  it("preserves a Date when a sibling string carries a NUL (dirty-path)", () => {
+    const ts = new Date("2024-01-01T00:00:00Z");
+    const input = { ts, bad: "n\x00ul" };
+    const out = stripNulBytesDeep(input) as { ts: unknown; bad: string };
+    // Sanitization of the dirty sibling still happens.
+    expect(out.bad).toBe("nul");
+    // The Date survives intact: same reference AND same ISO serialization
+    // through JSON.stringify (which is the realistic consumer path via
+    // chunkInsertParams). Pre-fix, the walker would reallocate `ts` as an
+    // empty `Object.create(null)` and JSON.stringify would emit `"{}"`.
+    expect(out.ts).toBeInstanceOf(Date);
+    expect(out.ts).toBe(ts);
+    expect((out.ts as Date).toISOString()).toBe("2024-01-01T00:00:00.000Z");
+    expect(JSON.stringify(out)).toContain('"ts":"2024-01-01T00:00:00.000Z"');
+  });
+
+  it("preserves a Buffer when a sibling string carries a NUL (dirty-path)", () => {
+    const buf = Buffer.from("hello");
+    const input = { buf, bad: "n\x00ul" };
+    const out = stripNulBytesDeep(input) as { buf: unknown; bad: string };
+    expect(out.bad).toBe("nul");
+    // Pre-fix: `out.buf` would be `{}` (Object.entries(Buffer) returns [];
+    // Buffer's own enumerable props are the numeric indices, but the walker
+    // would still reallocate as `Object.create(null)` and not preserve
+    // Buffer semantics). Post-fix: same reference, IS-A Buffer.
+    expect(Buffer.isBuffer(out.buf)).toBe(true);
+    expect(out.buf).toBe(buf);
+    expect((out.buf as Buffer).toString("utf8")).toBe("hello");
+  });
+
+  it("preserves a RegExp when a sibling string carries a NUL (dirty-path)", () => {
+    const re = /abc/g;
+    const input = { re, bad: "n\x00ul" };
+    const out = stripNulBytesDeep(input) as { re: unknown; bad: string };
+    expect(out.bad).toBe("nul");
+    // Pre-fix: `out.re` would be `{}`. Post-fix: same reference, IS-A RegExp.
+    expect(out.re).toBeInstanceOf(RegExp);
+    expect(out.re).toBe(re);
+    expect((out.re as RegExp).source).toBe("abc");
+    expect((out.re as RegExp).flags).toBe("g");
+  });
+
+  it("preserves a non-plain leaf nested under multiple dirty containers", () => {
+    // Depth check: the walker must treat the non-plain object as a leaf at
+    // ANY depth, not just at the root level. A Date deep under two dirty
+    // wrapping objects must survive the same way.
+    const ts = new Date("2025-06-01T12:34:56Z");
+    const input = {
+      outer: { dirty: "x\x00y", inner: { ts, alsoDirty: "p\x00q" } },
+    };
+    const out = stripNulBytesDeep(input) as {
+      outer: {
+        dirty: string;
+        inner: { ts: unknown; alsoDirty: string };
+      };
+    };
+    expect(out.outer.dirty).toBe("xy");
+    expect(out.outer.inner.alsoDirty).toBe("pq");
+    expect(out.outer.inner.ts).toBeInstanceOf(Date);
+    expect(out.outer.inner.ts).toBe(ts);
+  });
+
+  it("preserves a non-plain leaf inside a dirty array element", () => {
+    // Array branch coverage — symmetric to the object branch above.
+    const ts = new Date("2026-01-01T00:00:00Z");
+    const input = ["clean", "n\x00ul", ts];
+    const out = stripNulBytesDeep(input) as unknown[];
+    expect(out[0]).toBe("clean");
+    expect(out[1]).toBe("nul");
+    expect(out[2]).toBeInstanceOf(Date);
+    expect(out[2]).toBe(ts);
   });
 });
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -57,59 +57,203 @@ export function stripNulBytes(s: string): string {
  * NUL-bearing key would otherwise survive `JSON.stringify` as the 6-char
  * escape ` ` and still error the jsonb cast at the wire.
  *
- * Returns the input unchanged (referentially `===`) when nothing needed
- * sanitizing — defers allocating a new array/object until the first mutation
- * is observed, so the common no-NUL path makes zero intermediate allocations.
+ * Safe under cyclic inputs and arbitrary nesting depth — does not recurse on
+ * the JS call stack. Implemented as a two-pass iterative walk over an
+ * explicit work-stack with a `WeakSet` for cycle tracking on the detect pass
+ * and a `WeakMap<input,output>` on the transform pass. Untrusted callers (the
+ * MCP-driven `insertCollectedData` accepts arbitrary tool-supplied JSON) can
+ * therefore feed cyclic OR arbitrarily-deep payloads without risking a
+ * `RangeError: Maximum call stack size exceeded` mid-INSERT.
+ *
+ * Identity preservation: returns the input unchanged (referentially `===`)
+ * when no string anywhere in the tree carried a NUL — the detect pass
+ * short-circuits and skips the transform allocation entirely. This is the
+ * common case for indexed content. NOTE: under the iterative scheme the
+ * identity guarantee is now whole-tree — if ANY descendant required cleaning,
+ * EVERY container on the path from root to that descendant is freshly
+ * allocated (the prior recursive impl had the same property in practice,
+ * since a dirty descendant forced cloning at every wrapping container).
+ *
+ * Object containers are allocated via `Object.create(null)` so that bracket
+ * assignment of a sanitized key like `"__proto__"` (from input
+ * `"__proto__\x00"`) creates an own data property instead of invoking the
+ * `Object.prototype` setter — which would silently discard a non-object/null
+ * value, dropping a metadata entry on the floor. `JSON.stringify` walks own
+ * enumerable properties on a null-prototype object identically to a plain
+ * object, so the only downstream consumer (`chunkInsertParams`, via
+ * `insertCollectedData`'s `JSON.stringify`) is transparent to the swap.
  *
  * If two pre-sanitization keys collide post-strip (e.g. both `"a\x00"` and
  * `"a"` map to `"a"`), the later entry from `Object.entries` order wins.
  * This is acceptable because a NUL-bearing key is by definition malformed
  * input — losing one of the colliding entries is preferable to failing the
  * whole INSERT and bricking the source's index pipeline.
+ *
+ * Cyclic inputs: the cycle is preserved in the OUTPUT (the same back-edge
+ * structure, rewritten onto cloned containers). The downstream
+ * `JSON.stringify` will of course throw `TypeError: cyclic` on such an output
+ * — but it would have thrown identically on the input had we returned it
+ * unchanged. This function's contract is "do not stack-overflow"; it does
+ * not promise to flatten cycles into a JSON-serializable shape.
+ *
+ * Non-plain objects (Date, Buffer, RegExp, Map, Set, class instances —
+ * anything whose prototype is neither `Object.prototype` nor `null`) are
+ * treated as opaque LEAVES: they are passed through untouched, NOT walked or
+ * reallocated. Walking such values would be doubly wrong: (a)
+ * `Object.entries(new Date(...))` returns `[]` (no own enumerable props), so
+ * the reallocation would silently flatten the value to `{}` and destroy its
+ * `toJSON()` behavior on the downstream `JSON.stringify`; (b) Map/Set hold
+ * their content in internal slots, not enumerable own properties, so the
+ * walker can't see the payload anyway. The cost of this contract is that any
+ * NUL bytes embedded in strings INSIDE such non-plain leaves are NOT
+ * sanitized — acceptable because every realistic consumer (jsonb metadata,
+ * MCP-tool JSON input) is already plain-shape; the rare Date/Buffer in a
+ * caller-hydrated payload survives intact rather than being silently lost.
+ * Arrays are still walked (they're plain-shape).
  */
+function isPlainContainer(o: object): boolean {
+  // Arrays are plain-shape and handled by Array.isArray branches.
+  if (Array.isArray(o)) return true;
+  const proto = Object.getPrototypeOf(o);
+  return proto === Object.prototype || proto === null;
+}
+
 export function stripNulBytesDeep(value: unknown): unknown {
+  // Fast path: scalars and the no-container case bypass both passes.
   if (typeof value === "string") return stripNulBytes(value);
-  if (Array.isArray(value)) {
-    let out: unknown[] | null = null;
-    for (let i = 0; i < value.length; i++) {
-      const v = value[i];
-      const cleaned = stripNulBytesDeep(v);
-      if (cleaned !== v && out === null) {
-        out = value.slice(0, i);
+  if (value === null || typeof value !== "object") return value;
+  // Non-plain objects (Date/Buffer/RegExp/Map/Set/class instances) are
+  // treated as leaves — see JSDoc above. Returning unchanged preserves the
+  // value's identity and its `toJSON()` semantics for the downstream
+  // `JSON.stringify` consumer.
+  if (!isPlainContainer(value)) return value;
+
+  // ---- Pass 1: detect whether any string (key or value) carries a NUL. ----
+  // Iterative DFS over an explicit work-stack. WeakSet guards against cycles;
+  // a cycle alone does NOT mean "needs cleaning" — we keep walking the rest
+  // of the tree.
+  const seen = new WeakSet<object>();
+  const detectStack: unknown[] = [value];
+  let needsClean = false;
+  while (detectStack.length > 0) {
+    const node = detectStack.pop();
+    if (typeof node === "string") {
+      if (node.includes("\x00")) {
+        needsClean = true;
+        break;
       }
-      if (out !== null) out.push(cleaned);
+      continue;
     }
-    return out ?? value;
+    if (node === null || typeof node !== "object") continue;
+    // Non-plain objects (Date/Buffer/RegExp/Map/Set/class instances) are
+    // opaque leaves — do not walk their internals. Skips both the cycle
+    // record (irrelevant for leaves) and any false-positive NUL hits inside
+    // opaque payloads we wouldn't be able to safely rewrite anyway.
+    if (!isPlainContainer(node)) continue;
+    if (seen.has(node)) continue;
+    seen.add(node);
+    if (Array.isArray(node)) {
+      for (let i = node.length - 1; i >= 0; i--) detectStack.push(node[i]);
+    } else {
+      // Object.entries semantics: own enumerable string-keyed properties.
+      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+        if (k.includes("\x00")) {
+          needsClean = true;
+          break;
+        }
+        detectStack.push(v);
+      }
+      if (needsClean) break;
+    }
   }
-  if (value !== null && typeof value === "object") {
-    // Output container is a null-prototype object so that bracket assignment
-    // of a sanitized key like "__proto__" (from input "__proto__\x00") creates
-    // an own data property instead of invoking the Object.prototype setter
-    // — which would silently discard a non-object/null value (typical case:
-    // string), dropping the entry on the floor and losing the source's
-    // metadata. JSON.stringify walks own enumerable properties on a
-    // null-prototype object identically to a plain object, so the only
-    // downstream consumer (chunkInsertParams, which JSON.stringify's the
-    // result) is transparent to the prototype swap.
-    let out: Record<string, unknown> | null = null;
-    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-      const cleanedKey = stripNulBytes(k);
-      const cleanedVal = stripNulBytesDeep(v);
-      if ((cleanedKey !== k || cleanedVal !== v) && out === null) {
-        out = Object.create(null) as Record<string, unknown>;
-        // Backfill prior (already-clean) entries we walked past.
-        for (const [pk, pv] of Object.entries(
-          value as Record<string, unknown>,
-        )) {
-          if (pk === k) break;
-          out[pk] = pv;
+  if (!needsClean) return value;
+
+  // ---- Pass 2: build cleaned mirror iteratively. -------------------------
+  // WeakMap input→output preserves cycles (a back-edge in the input becomes
+  // a back-edge in the output pointing at the already-allocated clone).
+  // Strategy: pre-allocate the output container for every reachable container
+  // on a first sweep (so back-edges can resolve), then a second sweep wires
+  // up children.
+  const mirror = new WeakMap<object, unknown[] | Record<string, unknown>>();
+  const allocStack: object[] = [value as object];
+  // Allocate skeletons. Non-plain children (Date/Buffer/RegExp/Map/Set/class
+  // instances) are NOT allocated a mirror — they're treated as leaves in the
+  // fill pass and the input reference is wired through unchanged.
+  while (allocStack.length > 0) {
+    const node = allocStack.pop()!;
+    if (mirror.has(node)) continue;
+    if (Array.isArray(node)) {
+      mirror.set(node, new Array(node.length));
+      for (let i = 0; i < node.length; i++) {
+        const child = node[i];
+        if (
+          child !== null &&
+          typeof child === "object" &&
+          isPlainContainer(child as object)
+        )
+          allocStack.push(child as object);
+      }
+    } else {
+      mirror.set(node, Object.create(null) as Record<string, unknown>);
+      for (const v of Object.values(node as Record<string, unknown>)) {
+        if (
+          v !== null &&
+          typeof v === "object" &&
+          isPlainContainer(v as object)
+        )
+          allocStack.push(v as object);
+      }
+    }
+  }
+  // Fill skeletons.
+  const fillStack: object[] = [value as object];
+  const filled = new WeakSet<object>();
+  while (fillStack.length > 0) {
+    const node = fillStack.pop()!;
+    if (filled.has(node)) continue;
+    filled.add(node);
+    const out = mirror.get(node)!;
+    if (Array.isArray(node)) {
+      const outArr = out as unknown[];
+      for (let i = 0; i < node.length; i++) {
+        const child = node[i];
+        if (typeof child === "string") {
+          outArr[i] = stripNulBytes(child);
+        } else if (child !== null && typeof child === "object") {
+          // Non-plain children are passed through by reference (leaf
+          // semantics — see JSDoc). Plain children resolve to their
+          // pre-allocated mirror and get filled on a later iteration.
+          if (!isPlainContainer(child as object)) {
+            outArr[i] = child;
+          } else {
+            outArr[i] = mirror.get(child as object)!;
+            fillStack.push(child as object);
+          }
+        } else {
+          outArr[i] = child;
         }
       }
-      if (out !== null) out[cleanedKey] = cleanedVal;
+    } else {
+      const outObj = out as Record<string, unknown>;
+      for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+        const cleanedKey = k.includes("\x00") ? stripNulBytes(k) : k;
+        if (typeof v === "string") {
+          outObj[cleanedKey] = stripNulBytes(v);
+        } else if (v !== null && typeof v === "object") {
+          // See array branch above — non-plain values are leaves.
+          if (!isPlainContainer(v as object)) {
+            outObj[cleanedKey] = v;
+          } else {
+            outObj[cleanedKey] = mirror.get(v as object)!;
+            fillStack.push(v as object);
+          }
+        } else {
+          outObj[cleanedKey] = v;
+        }
+      }
     }
-    return out ?? value;
   }
-  return value;
+  return mirror.get(value as object)!;
 }
 
 // ---------------------------------------------------------------------------
@@ -133,13 +277,29 @@ export async function searchChunks(
   const params: unknown[] = [pgvector.toSql(embedding)];
   let paramIdx = 2;
 
-  if (sourceName) {
+  // Sanitize text-typed binds: chunks rows are written with stripNulBytes
+  // applied to source_name/version, so a NUL-bearing reader bind would either
+  // (a) crash the SELECT with `invalid byte sequence for encoding "UTF8":
+  // 0x00`, or (b) silently miss rows because the stored values are sanitized
+  // while the WHERE comparand is not. Mirror the writer-side discipline.
+  //
+  // Eager-sanitize every optional text filter ONCE, then test truthy on the
+  // sanitized local: a raw `"\x00"` is truthy under the truthy check, but
+  // sanitizes to `""`. Without this ordering the WHERE filter would become
+  // `source_name = ''` / `version = ''` — matching zero rows because the
+  // writer stores non-empty NUL-stripped values. textSearchChunks applies
+  // the same discipline for its sourceName/version filters and keyword
+  // pattern (which feeds plainto_tsquery's TEXT bind on the wire).
+  const sanitizedSourceName =
+    sourceName != null ? stripNulBytes(sourceName) : undefined;
+  const sanitizedVersion = version != null ? stripNulBytes(version) : undefined;
+  if (sanitizedSourceName) {
     conditions.push(`source_name = $${paramIdx++}`);
-    params.push(sourceName);
+    params.push(sanitizedSourceName);
   }
-  if (version) {
+  if (sanitizedVersion) {
     conditions.push(`version = $${paramIdx++}`);
-    params.push(version);
+    params.push(sanitizedVersion);
   }
 
   const whereClause =
@@ -194,7 +354,31 @@ export async function textSearchChunks(
   sourceName?: string,
   version?: string,
 ): Promise<ChunkResult[]> {
-  if (!pattern.trim()) return [];
+  // Eager-sanitize EVERY caller-supplied text input ONCE at function entry,
+  // then use the sanitized locals throughout. This makes the
+  // sanitize-then-truthy ordering bug impossible by construction: a raw input
+  // never reaches a truthy gate or a bind site. Mirrors searchChunks; the
+  // value of doing it at the top (rather than per-binding) is that adding a
+  // new conditional filter later cannot reintroduce the raw-truthy bug.
+  //
+  // For each optional filter: a `null`/`undefined`/missing value preserves
+  // "no filter" semantics (the caller omitted it). A NUL-only input
+  // (`"\x00"`) is truthy on the raw value but sanitizes to `""`; treating
+  // empty-after-sanitize as "no filter" prevents `WHERE source_name = ''`,
+  // which would match zero rows because the writer stores NUL-stripped
+  // non-empty values. Downstream, hybridSearchChunks uses textSearchChunks
+  // for the keyword half of the RRF merge, so a NUL in the source filter
+  // would silently zero out the keyword contribution on NUL-bearing inputs.
+  const sanitizedPattern = stripNulBytes(pattern);
+  // Sanitize BEFORE the empty/whitespace early-return: NUL bytes are not
+  // whitespace, so a NUL-only input (`"\x00\x00\x00"`) would otherwise
+  // survive `pattern.trim()` and issue a useless plainto_tsquery DB
+  // roundtrip against an empty string.
+  if (!sanitizedPattern.trim()) return [];
+
+  const sanitizedSourceName =
+    sourceName != null ? stripNulBytes(sourceName) : undefined;
+  const sanitizedVersion = version != null ? stripNulBytes(version) : undefined;
 
   const pool = getPool();
 
@@ -202,20 +386,26 @@ export async function textSearchChunks(
   const params: unknown[] = [];
   let paramIdx = 1;
 
-  // tsquery from user input — plainto_tsquery handles special chars safely
+  // tsquery from user input — plainto_tsquery handles special chars safely.
+  // The pattern bind is the sanitized local: a NUL in the tsquery text bind
+  // raises the same `invalid byte sequence for encoding "UTF8": 0x00` error
+  // as the chunks text columns (plainto_tsquery's input is a TEXT bind on
+  // the wire).
   conditions.push(`tsv @@ plainto_tsquery('english', $${paramIdx})`);
-  params.push(pattern);
+  params.push(sanitizedPattern);
   paramIdx++;
 
-  if (sourceName) {
-    conditions.push(`source_name = $${paramIdx}`);
-    params.push(sourceName);
-    paramIdx++;
+  // The truthy check runs on the SANITIZED locals — a NUL-only input
+  // sanitizes to `""` and is correctly treated as "no filter" rather than
+  // "match empty string".
+  if (sanitizedSourceName) {
+    conditions.push(`source_name = $${paramIdx++}`);
+    params.push(sanitizedSourceName);
   }
 
-  if (version) {
+  if (sanitizedVersion) {
     conditions.push(`version = $${paramIdx++}`);
-    params.push(version);
+    params.push(sanitizedVersion);
   }
 
   const whereClause = conditions.join(" AND ");
@@ -539,9 +729,12 @@ export async function getIndexedItemIds(
   sourceName: string,
 ): Promise<Set<string>> {
   const pool = getPool();
+  // Sanitize sourceName: chunks.source_name is stored NUL-stripped on write,
+  // so a NUL-bearing bind here would either crash the SELECT or silently miss
+  // rows. Matches the chunks-table writer-side discipline.
   const { rows } = await pool.query(
     "SELECT DISTINCT file_path FROM chunks WHERE source_name = $1",
-    [sourceName],
+    [stripNulBytes(sourceName)],
   );
   return new Set(
     rows.map((r: Record<string, unknown>) => r.file_path as string),
@@ -565,7 +758,14 @@ export async function getIndexState(
         FROM index_state
         WHERE source_type = $1 AND source_key = $2
     `;
-  const { rows } = await pool.query(sql, [sourceType, sourceKey]);
+  // Sanitize text identifiers: index_state.source_type / source_key are
+  // written through upsertIndexState with NUL-stripped binds, so a
+  // NUL-bearing lookup would either crash with `invalid byte sequence` or
+  // miss the row entirely against the sanitized stored value.
+  const { rows } = await pool.query(sql, [
+    stripNulBytes(sourceType),
+    stripNulBytes(sourceKey),
+  ]);
   if (rows.length === 0) return null;
 
   const row = rows[0];
@@ -595,13 +795,22 @@ export async function upsertIndexState(state: IndexState): Promise<void> {
             status          = EXCLUDED.status,
             error_message   = EXCLUDED.error_message
     `;
+  // Sanitize every text-typed bind. The highest-risk column here is
+  // error_message: it's populated with raw upstream errors, which in the
+  // chunks-INSERT failure mode is literally a stringified Postgres error
+  // containing the offending 0x00 byte. Persisting that raw would re-trip
+  // `invalid byte sequence for encoding "UTF8": 0x00` on the index_state
+  // UPDATE itself — turning the original transient failure into a poison-pill
+  // loop the orchestrator can never advance past. Sanitizing all binds here
+  // (not just error_message) also keeps the ON CONFLICT EXCLUDED.* targets
+  // symmetric with their INSERT VALUES counterparts.
   await pool.query(sql, [
-    state.source_type,
-    state.source_key,
-    state.last_commit_sha ?? null,
+    stripNulBytes(state.source_type),
+    stripNulBytes(state.source_key),
+    state.last_commit_sha == null ? null : stripNulBytes(state.last_commit_sha),
     state.last_indexed_at ?? null,
-    state.status ?? "idle",
-    state.error_message ?? null,
+    stripNulBytes(state.status ?? "idle"),
+    state.error_message == null ? null : stripNulBytes(state.error_message),
   ]);
 }
 
@@ -617,9 +826,18 @@ export async function insertCollectedData(
   data: Record<string, unknown>,
 ): Promise<void> {
   const pool = getPool();
+  // Sanitize the tool_name TEXT bind and walk the data JSONB blob with
+  // stripNulBytesDeep before JSON.stringify. collected_data is fed from
+  // arbitrary caller payloads: collect.ts forwards user MCP input, and
+  // bash-telemetry.ts records raw shell-command strings (which legitimately
+  // contain NUL — e.g. `printf '\0' | xxd`). An unsanitized NUL anywhere in
+  // the JSONB string members fails the cast with `invalid byte sequence for
+  // encoding "UTF8": 0x00` and rejects the INSERT. Walking with the deep
+  // sanitizer also covers object KEYS, which jsonb rejects identically to
+  // values.
   await pool.query(
     "INSERT INTO collected_data (tool_name, data) VALUES ($1, $2)",
-    [toolName, JSON.stringify(data)],
+    [stripNulBytes(toolName), JSON.stringify(stripNulBytesDeep(data))],
   );
 }
 
@@ -655,12 +873,18 @@ export async function recordWebhookDelivery(delivery: {
     await pool.query(
       `INSERT INTO webhook_deliveries (source, event_type, repo, decision, reason, payload_size)
        VALUES ($1, $2, $3, $4, $5, $6)`,
+      // Webhook payloads are partly attacker-influenced (event_type/repo/
+      // reason come from incoming webhook bodies). A NUL in any of those text
+      // binds would error the INSERT with `invalid byte sequence for encoding
+      // "UTF8": 0x00`; since recordWebhookDelivery is fire-and-forget, the
+      // failure would only surface as a logged tracking miss, but the cleanup
+      // is identical to the chunks-table side: strip the byte at the bind.
       [
-        delivery.source,
-        delivery.event_type ?? null,
-        delivery.repo ?? null,
-        delivery.decision,
-        delivery.reason ?? null,
+        stripNulBytes(delivery.source),
+        delivery.event_type == null ? null : stripNulBytes(delivery.event_type),
+        delivery.repo == null ? null : stripNulBytes(delivery.repo),
+        stripNulBytes(delivery.decision),
+        delivery.reason == null ? null : stripNulBytes(delivery.reason),
         delivery.payload_size ?? null,
       ],
     );
@@ -850,9 +1074,23 @@ export async function getFaqChunks(
 
   if (sourceNames.length === 0) return [];
 
+  // Sanitize each source_name text bind FIRST, then drop empty-after-sanitize
+  // entries: chunks.source_name is stored NUL-stripped by the writer side, so
+  // a NUL-only caller input would sanitize to `""` and pollute the IN clause
+  // with a never-matching empty-string comparand (silent zero-rows for any
+  // legitimate companion entries in the list). If every entry sanitizes away,
+  // there is nothing to filter on — return [] (same semantic as the
+  // `length === 0` guard above). Mirrors searchChunks / textSearchChunks.
+  const sanitizedSourceNames = sourceNames
+    .map((s) => stripNulBytes(s))
+    .filter((s) => s !== "");
+  if (sanitizedSourceNames.length === 0) return [];
+
   // Build parameterized source_name IN clause
-  const placeholders = sourceNames.map((_, i) => `$${i + 1}`).join(", ");
-  const confidenceParam = sourceNames.length + 1;
+  const placeholders = sanitizedSourceNames
+    .map((_, i) => `$${i + 1}`)
+    .join(", ");
+  const confidenceParam = sanitizedSourceNames.length + 1;
 
   // Guard BOTH confidence casts with jsonb_typeof so a row whose `confidence`
   // KEY exists but holds non-numeric text (e.g. "high") degrades to 0.0 instead
@@ -892,7 +1130,7 @@ export async function getFaqChunks(
         ORDER BY indexed_at DESC, id DESC
     `;
 
-  const params: unknown[] = [...sourceNames, minConfidence];
+  const params: unknown[] = [...sanitizedSourceNames, minConfidence];
 
   if (limit != null) {
     sql += ` LIMIT $${confidenceParam + 1}`;


### PR DESCRIPTION
Follow-up to #114 (chunk write path NUL-byte sanitization). CR rounds on #114 surfaced the same root-cause class — Postgres TEXT/JSONB columns rejecting `0x00` with `invalid byte sequence for encoding "UTF8": 0x00` — at every OTHER text-typed bind on the chunks/index/collected_data/webhook_deliveries tables. This PR closes the rest.

## Why both writer AND reader classes matter

- **Writers** (`insertCollectedData`, `recordWebhookDelivery`, `upsertIndexState`) can crash `INSERT` / `UPDATE` on NUL-bearing input the same way the chunks `INSERT` did.
- **Readers** (`textSearchChunks`, `getIndexedItemIds`, `getIndexState`, `searchChunks`, `getFaqChunks`) can crash the `SELECT` identically (the encoding rejection applies to TEXT binds regardless of operation), OR — worse — return **zero rows** because the chunks rows were written NUL-stripped by #114 while the WHERE comparand still carries the byte. Silent inconsistency is the more dangerous failure mode.

## Highest-risk callers per writer

- `insertCollectedData` — `collect.ts` forwards arbitrary user MCP input; `bash-telemetry.ts` records raw shell-command strings (legitimately contain NUL, e.g. `printf '\x00' | xxd`).
- `upsertIndexState.error_message` — the orchestrator persists raw upstream errors here on a failed indexing pass. If the upstream error is itself the chunks-`INSERT` encoding error, the error string contains the offending `0x00` byte. An unsanitized `index_state` `UPDATE` then re-trips the same rejection — a one-shot failure becomes a poison-pill loop.
- `recordWebhookDelivery` — `event_type` / `repo` / `reason` come from incoming webhook bodies (partly attacker-influenced). The function is fire-and-forget, so the failure surfaces as silently lost tracking rows.

## What changed (sanitization sites)

All wrap `stripNulBytes(...)` at the bind site (same helper #114 introduced). The single `JSONB` blob (`insertCollectedData.data`) walks with `stripNulBytesDeep(...)` before `JSON.stringify`.

**Writers:**
- `insertCollectedData` — `tool_name` (TEXT) + `data` (JSONB)
- `recordWebhookDelivery` — `source`, `event_type`, `repo`, `decision`, `reason`
- `upsertIndexState` — `source_type`, `source_key`, `last_commit_sha`, `status`, `error_message`

**Readers:**
- `searchChunks` — `sourceName`, `version`
- `textSearchChunks` — `pattern`, `sourceName`, `version`
- `getIndexedItemIds` — `sourceName`
- `getIndexState` — `sourceType`, `sourceKey`
- `getFaqChunks` — every `sourceNames[i]`

## Test plan

- New file `src/__tests__/strip-nul-bytes-sweep.test.ts` (14 tests), structured parallel to `strip-nul-bytes.test.ts` from #114.
- Red-green discipline: each new test was run against the pre-fix `queries.ts` and confirmed RED (8/14 failed on the unsanitized baseline; the remaining 6 are early-return / null-preservation / no-NUL-passthrough invariants that hold both ways and pin the contract).
- Full suite: **340 files / 6386 tests passing** after the fix.

## Pre-push gates

- `npx prettier --check src/` — clean
- `npx tsc --noEmit` — clean
- `npm run build` — clean
- `npx vitest run` — 6386/6386
- `bash scripts/check-version-sync.sh` — `✓ Versions in sync: 1.15.2`
- Literal-NUL audit on changed files (`LC_ALL=C grep -lP '\x00' …`) — clean. Same lesson as #114's last-minute cleanup: text comments describing NUL bytes must use the textual escape `\^@`, not an embedded `0x00` (which would make git treat the file as binary and `gh pr diff` unreviewable).

## Out of scope (real follow-ups, NUL-orthogonal)

Intentionally deferred — same disposition as the items #114 left for later:

- `client.release(err)` explicit-error signaling on rollback paths.
- `getFaqChunks` `LIMIT` placeholder shape vs ordering interaction.
- `hybridSearchChunks` `rrfMerge` `minScore` semantics for keyword-only hits.

## Round-3 CR hardening

`textSearchChunks` now eager-sanitizes its `sourceName`/`version` filters at function entry (mirroring the eager-sanitize pattern used for `pattern`), eliminating the sanitize-vs-truthy ordering class of bug. This was the third recurrence of the same pattern in CR rounds; catching it at function entry — rather than at each bind site — would have also prevented it from leaking into the keyword half of `hybridSearchChunks` if/when that reuses this filter pair.
