### PR TITLE
Release v1.15.4 — re-ship v1.15.3 analytics changes with fixed SQL + defensive Promise.allSettled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,17 @@
 # @copilotkit/pathfinder
 
+## 1.15.4
+
+### Patch Changes
+
+- **Re-ship of v1.15.3 with the broken `getBlockedQueries` SQL fixed and defensive client-side panel isolation.** v1.15.3 was reverted via PR #117 within minutes of deploy because the `/api/analytics/blocked-queries` route 500'd against real Postgres and the page's `Promise.all` then nuked the entire `/analytics` dashboard. v1.15.4 re-ships all three v1.15.3 changes (blocked filter on empty-results, new Blocked Queries panel, Pacific timestamps) with the SQL and resilience defects fixed.
+- **`getBlockedQueries` SQL — rewrote as a CTE-backed correlated subquery.** The original v1.15.3 SQL grouped the outer query on `COALESCE(block_reason, '<unknown>')` but the correlated subquery referenced raw `query_log.block_reason`, which Postgres rejects as an ungrouped column reference (`subquery uses ungrouped column "query_log.block_reason" from outer query`). The fix pre-projects the COALESCEd expression into a CTE (`blocked_rows.block_reason_key`) so the outer GROUP BY and the inner correlated reference operate on the same column. Verified against the actual prod Postgres schema before push.
+- **Analytics page — `Promise.all` replaced with `Promise.allSettled`.** A single panel's fetch failure used to throw out of `Promise.all` and blank the entire `/analytics` page (this is what made the v1.15.3 SQL bug catastrophic instead of merely cosmetic). Each section now renders independently: the summary endpoint failing still surfaces via the top-level error banner (the page can't render statcards without it), but per-panel failures (empty queries / blocked queries / tool counts) degrade to an empty state with a `console.error` and leave the rest of the dashboard intact. Auth (401) errors still bubble to the outer catch since a bad token fails every endpoint identically.
+
+## 1.15.3 — REVERTED
+
+This release was reverted via PR #117 immediately after deploy. Its `getBlockedQueries` SQL was incompatible with real Postgres (ungrouped column reference inside a correlated subquery) and its client-side `Promise.all` rendering blanked the entire `/analytics` page on a single panel's failure. See v1.15.4 for the fixed re-ship.
+
 ## 1.15.2
 
 ### Patch Changes

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -4,19 +4,41 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Pathfinder Analytics</title>
-    <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230a0a0f'/%3E%3Cpolygon points='16,4 22,16 16,28 10,16' fill='none' stroke='%2300ccff' stroke-width='2.5' stroke-linejoin='round'/%3E%3C/svg%3E">
-    <meta name="description" content="Real-time analytics dashboard for your Pathfinder knowledge server.">
-    <meta property="og:type" content="website">
-    <meta property="og:url" content="https://pathfinder.copilotkit.dev/analytics">
-    <meta property="og:title" content="Pathfinder Analytics">
-    <meta property="og:description" content="Real-time analytics dashboard for your Pathfinder knowledge server.">
-    <meta property="og:image" content="https://pathfinder.copilotkit.dev/og-image.png">
-    <meta property="og:image:width" content="1200">
-    <meta property="og:image:height" content="630">
-    <meta name="twitter:card" content="summary_large_image">
-    <meta name="twitter:title" content="Pathfinder Analytics">
-    <meta name="twitter:description" content="Real-time analytics dashboard for your Pathfinder knowledge server.">
-    <meta name="twitter:image" content="https://pathfinder.copilotkit.dev/og-image.png">
+    <link
+      rel="icon"
+      type="image/svg+xml"
+      href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 32 32'%3E%3Crect width='32' height='32' rx='6' fill='%230a0a0f'/%3E%3Cpolygon points='16,4 22,16 16,28 10,16' fill='none' stroke='%2300ccff' stroke-width='2.5' stroke-linejoin='round'/%3E%3C/svg%3E"
+    />
+    <meta
+      name="description"
+      content="Real-time analytics dashboard for your Pathfinder knowledge server."
+    />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:url"
+      content="https://pathfinder.copilotkit.dev/analytics"
+    />
+    <meta property="og:title" content="Pathfinder Analytics" />
+    <meta
+      property="og:description"
+      content="Real-time analytics dashboard for your Pathfinder knowledge server."
+    />
+    <meta
+      property="og:image"
+      content="https://pathfinder.copilotkit.dev/og-image.png"
+    />
+    <meta property="og:image:width" content="1200" />
+    <meta property="og:image:height" content="630" />
+    <meta name="twitter:card" content="summary_large_image" />
+    <meta name="twitter:title" content="Pathfinder Analytics" />
+    <meta
+      name="twitter:description"
+      content="Real-time analytics dashboard for your Pathfinder knowledge server."
+    />
+    <meta
+      name="twitter:image"
+      content="https://pathfinder.copilotkit.dev/og-image.png"
+    />
     <!-- Pin to an exact version (not the floating '@4' tag) so an upstream
          patch release can't silently change what this page executes. The
          integrity hash binds the execution to a specific bytes-on-disk
@@ -389,7 +411,7 @@
         border: 0;
       }
     </style>
-  <script src="/pixels.js" defer></script>
+    <script src="/pixels.js" defer></script>
   </head>
   <body>
     <h1>Pathfinder Analytics</h1>
@@ -408,7 +430,9 @@
         ></canvas>
         <span class="chart-caption">Click a bar to filter to that day</span>
         <table id="dailyChartTable" class="sr-only">
-          <caption>Queries per day (data table for screen readers)</caption>
+          <caption>
+            Queries per day (data table for screen readers)
+          </caption>
           <thead>
             <tr>
               <th scope="col">Day</th>
@@ -427,7 +451,9 @@
           aria-describedby="sourceChartTable"
         ></canvas>
         <table id="sourceChartTable" class="sr-only">
-          <caption>Queries by source (data table for screen readers)</caption>
+          <caption>
+            Queries by source (data table for screen readers)
+          </caption>
           <thead>
             <tr>
               <th scope="col">Source</th>
@@ -468,6 +494,34 @@
           <th>Source</th>
           <th>Count</th>
           <th>Last Seen</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
+    <h2 id="blockedQueriesTitle" style="margin-bottom: 4px">
+      Blocked Queries &#x1F6E1;&#xFE0F;
+    </h2>
+    <p
+      id="blockedQueriesSubtitle"
+      style="
+        color: var(--text-secondary, #6b7280);
+        margin-top: 0;
+        margin-bottom: 12px;
+        font-size: 14px;
+      "
+    >
+      Off-topic queries short-circuited by the abuse blocklist before retrieval.
+      These are filtered out of "Empty Result Queries" above so blocked traffic
+      doesn't double-count as a real-user content gap.
+    </p>
+    <table id="blockedQueriesTable">
+      <thead>
+        <tr>
+          <th>Block Reason</th>
+          <th>Hits</th>
+          <th>Last Seen</th>
+          <th>Sample Queries</th>
         </tr>
       </thead>
       <tbody></tbody>
@@ -700,6 +754,27 @@
               last_seen: new Date(Date.now() - 3600 * 1000 * 8).toISOString(),
             },
           ],
+          "/api/analytics/blocked-queries": [
+            {
+              block_reason: "box-office",
+              hits: 142,
+              last_seen: new Date(Date.now() - 1800 * 1000).toISOString(),
+              sample_queries: [
+                "box office weekend",
+                "toy story 5 box office",
+                "weekend box office numbers",
+              ],
+            },
+            {
+              block_reason: "kalshi-scotus",
+              hits: 38,
+              last_seen: new Date(Date.now() - 3600 * 1000 * 2).toISOString(),
+              sample_queries: [
+                "cftc kalshi certiorari",
+                "scotus kalshi sports event contracts",
+              ],
+            },
+          ],
         };
 
         var originalFetch = window.fetch.bind(window);
@@ -804,6 +879,78 @@
         timeZone: "UTC",
       });
 
+      // ----------------------------------------------------------------
+      // Operator-facing absolute timestamps render in Pacific time
+      // (America/Los_Angeles, DST-aware via Intl.DateTimeFormat) — never
+      // UTC. The dashboard is operated from Pacific; UTC timestamps were
+      // forcing every operator to convert in their head. This formatter
+      // emits e.g. "2026-06-17 09:40:32 PDT" / "2026-01-15 09:40:32 PST"
+      // depending on whether the instant falls in DST.
+      //
+      // SCOPE: display only. The storage layer still writes UTC
+      // (Postgres `created_at TIMESTAMPTZ`), the server still computes
+      // windows in UTC, and the URL `from`/`to` contract is still a UTC
+      // calendar date (see parseISODate / todayISO / tomorrowISO above,
+      // which retain their explicit `timeZone: "UTC"` / `Date.UTC`
+      // construction). Only the absolute-instant cells in the per-row
+      // tables flip to Pacific.
+      // ----------------------------------------------------------------
+      var ANALYTICS_TZ = "America/Los_Angeles";
+      var analyticsTimeFmt = new Intl.DateTimeFormat("en-US", {
+        timeZone: ANALYTICS_TZ,
+        year: "numeric",
+        month: "2-digit",
+        day: "2-digit",
+        hour: "2-digit",
+        minute: "2-digit",
+        second: "2-digit",
+        hour12: false,
+        timeZoneName: "short",
+      });
+
+      /**
+       * Format a Date / ISO string / epoch ms for the /analytics
+       * operator-facing page. Pacific time, DST-aware. Returns an em-dash
+       * for missing / non-finite inputs so a malformed last_seen never
+       * renders the literal "Invalid Date" string.
+       *
+       * Output shape: "YYYY-MM-DD HH:MM:SS PDT" (or PST).
+       */
+      function formatAnalyticsTimestamp(value) {
+        if (value === null || value === undefined || value === "") {
+          return "—";
+        }
+        var d = value instanceof Date ? value : new Date(value);
+        if (!Number.isFinite(d.getTime())) return "—";
+        var parts = analyticsTimeFmt.formatToParts(d);
+        var get = function (type) {
+          for (var i = 0; i < parts.length; i++) {
+            if (parts[i].type === type) return parts[i].value;
+          }
+          return "";
+        };
+        // Intl en-US under hour12:false emits hour "24" for midnight on
+        // some engines. Normalize to "00" so the output is unambiguously
+        // ISO-shaped HH:MM:SS.
+        var hour = get("hour");
+        if (hour === "24") hour = "00";
+        return (
+          get("year") +
+          "-" +
+          get("month") +
+          "-" +
+          get("day") +
+          " " +
+          hour +
+          ":" +
+          get("minute") +
+          ":" +
+          get("second") +
+          " " +
+          get("timeZoneName")
+        );
+      }
+
       function parseISODate(s) {
         // Parse YYYY-MM-DD as a UTC-noon Date. UTC (not local) so the
         // resulting Date is frame-aligned with todayISO() — both use UTC
@@ -850,11 +997,7 @@
       function tomorrowISO() {
         var d = new Date();
         var t = new Date(
-          Date.UTC(
-            d.getUTCFullYear(),
-            d.getUTCMonth(),
-            d.getUTCDate() + 1,
-          ),
+          Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate() + 1),
         );
         var y = t.getUTCFullYear();
         var m = String(t.getUTCMonth() + 1).padStart(2, "0");
@@ -967,7 +1110,9 @@
         }
         var qs = params.toString();
         var newUrl =
-          window.location.pathname + (qs ? "?" + qs : "") + window.location.hash;
+          window.location.pathname +
+          (qs ? "?" + qs : "") +
+          window.location.hash;
         window.history.replaceState(null, "", newUrl);
       }
 
@@ -1536,9 +1681,7 @@
             var f = (
               document.getElementById("dateFromInput").value || ""
             ).trim();
-            var t = (
-              document.getElementById("dateToInput").value || ""
-            ).trim();
+            var t = (document.getElementById("dateToInput").value || "").trim();
             if (
               !/^\d{4}-\d{2}-\d{2}$/.test(f) ||
               !/^\d{4}-\d{2}-\d{2}$/.test(t)
@@ -1547,10 +1690,10 @@
                 dateErr.textContent = "Dates must be YYYY-MM-DD format";
                 dateErr.style.display = "block";
               }
-              console.warn(
-                "[analytics] dateApply rejected malformed input",
-                { from: f, to: t },
-              );
+              console.warn("[analytics] dateApply rejected malformed input", {
+                from: f,
+                to: t,
+              });
               return;
             }
             if (dateErr) {
@@ -1575,10 +1718,10 @@
                 dateErr.textContent = "End date cannot be in the future.";
                 dateErr.style.display = "block";
               }
-              console.warn(
-                "[analytics] dateApply rejected future range",
-                { from: f, to: t },
-              );
+              console.warn("[analytics] dateApply rejected future range", {
+                from: f,
+                to: t,
+              });
               return;
             }
             activeFrom = f;
@@ -1646,21 +1789,85 @@
             "/api/analytics/summary" + (fp ? "?" + fp.replace(/^&/, "") : "");
           var queriesUrl = "/api/analytics/queries?limit=50" + fp;
           var emptyUrl = "/api/analytics/empty-queries?limit=50" + fp;
+          // Blocked-queries panel intentionally does NOT take filter
+          // params: the rows it surfaces were short-circuited BEFORE
+          // retrieval, so tool/source/request-source carry no meaning. It
+          // still passes the same `days` window as everything else (read
+          // out of the parsed-filter `days` param when present, else
+          // server default).
+          var daysParam = "";
+          if (fp) {
+            var m = /[?&]days=([^&]+)/.exec(fp);
+            if (m) daysParam = "?days=" + m[1];
+          }
+          var blockedUrl = "/api/analytics/blocked-queries" + daysParam;
           // Same '?' / leading-'&' handling as summary above.
           var toolCountsUrl =
             "/api/analytics/tool-counts" +
             (fp ? "?" + fp.replace(/^&/, "") : "");
-          var results = await Promise.all([
+          // Per-section isolation via Promise.allSettled: a single panel's
+          // fetch failure used to throw out of Promise.all and blank the
+          // entire /analytics page (see v1.15.3 revert PR #117 — broken
+          // /api/analytics/blocked-queries took the whole dashboard down).
+          // Now each panel is rendered independently; failures degrade to
+          // an inline empty state and a console.error, leaving the rest of
+          // the dashboard intact. AnalyticsAuthError still bubbles via the
+          // settled[0] (summary) path — a 401 means EVERY endpoint will
+          // 401, so the outer catch still wins.
+          var settled = await Promise.allSettled([
             fetchJson(summaryUrl, gen),
             fetchJson(queriesUrl, gen),
             fetchJson(emptyUrl, gen),
             fetchJson(toolCountsUrl, gen),
+            fetchJson(blockedUrl, gen),
           ]);
           if (gen !== loadGeneration) return; // stale response — abort
-          var summary = results[0];
-          var topQueries = results[1];
-          var emptyQueries = results[2];
-          var toolCounts = results[3];
+
+          // Auth errors are special: a 401 on any endpoint means the token
+          // is bad for ALL of them, so surface auth failure via the outer
+          // catch (consistent UX with the pre-allSettled flow). Look for
+          // the first AnalyticsAuthError in the settled set and re-throw.
+          for (var si = 0; si < settled.length; si++) {
+            var r = settled[si];
+            if (
+              r.status === "rejected" &&
+              r.reason &&
+              r.reason.name === "AnalyticsAuthError"
+            ) {
+              throw r.reason;
+            }
+          }
+
+          // Per-section value extraction with logged-failure fallback.
+          // Each helper returns the resolved value or a safe default and
+          // emits a console.error so operators can diagnose via devtools.
+          function settledValueOr(settledResult, label, fallback) {
+            if (settledResult.status === "fulfilled")
+              return settledResult.value;
+            console.error(
+              "[analytics] " + label + " fetch failed:",
+              settledResult.reason,
+            );
+            return fallback;
+          }
+          var summary = settledValueOr(settled[0], "summary", {});
+          var topQueries = settledValueOr(settled[1], "top queries", []);
+          var emptyQueries = settledValueOr(settled[2], "empty queries", []);
+          var toolCounts = settledValueOr(settled[3], "tool counts", []);
+          var blockedQueries = settledValueOr(
+            settled[4],
+            "blocked queries",
+            [],
+          );
+
+          // If the summary itself rejected (non-auth — e.g. 500), the
+          // dashboard can't render statcards meaningfully. Throw to the
+          // outer catch so the error banner shows. Per-panel failures
+          // (empty/blocked/tool-counts) degrade in-place via the empty
+          // states their renderers already handle.
+          if (settled[0].status === "rejected") {
+            throw settled[0].reason;
+          }
 
           // Clear any previous error
           document.getElementById("error").style.display = "none";
@@ -1895,9 +2102,7 @@
           // (#dailyChartTable). Canvas elements are opaque to assistive tech
           // and HTML scrapers; the sr-only table gives both consumers the
           // same numbers the visible bars encode.
-          var dailyTableBody = document.querySelector(
-            "#dailyChartTable tbody",
-          );
+          var dailyTableBody = document.querySelector("#dailyChartTable tbody");
           if (dailyTableBody) {
             dailyTableBody.innerHTML =
               perDayArr
@@ -1910,7 +2115,7 @@
                     "</td></tr>"
                   );
                 })
-                .join("") || "<tr><td colspan=\"2\">No data</td></tr>";
+                .join("") || '<tr><td colspan="2">No data</td></tr>';
           }
 
           // Source chart - destroy previous instance
@@ -1968,7 +2173,7 @@
                     "</td></tr>"
                   );
                 })
-                .join("") || "<tr><td colspan=\"2\">No data</td></tr>";
+                .join("") || '<tr><td colspan="2">No data</td></tr>';
           }
 
           // Top queries table (now with Tool column)
@@ -2008,26 +2213,16 @@
             asArray(emptyQueries)
               .map(function (q) {
                 // Guard against missing / non-parseable last_seen values.
-                // `new Date(undefined).toLocaleString()` yields the literal
-                // string "Invalid Date", which would be rendered raw and
-                // looks like a bug. Fall back to an em dash instead, and
-                // route the result through esc() on interpolation.
+                // `formatAnalyticsTimestamp` already handles null /
+                // undefined / "Invalid Date" gracefully (returns "\u2014"), so
+                // we don't repeat the guard here.
                 //
-                // Render as ISO-8601 in UTC (e.g. "2026-04-29 06:10:04 UTC")
-                // rather than the browser locale's mixed month-first / 12h
-                // format. The dashboard is internal and read across
-                // timezones; an explicit, sortable, timezone-labelled
-                // timestamp avoids ambiguity. Trim ISO milliseconds and the
-                // "T"/"Z" separators for readability while keeping it
-                // unambiguously parseable.
-                var lastSeenRaw = q.last_seen ? new Date(q.last_seen) : null;
-                var lastSeenStr =
-                  lastSeenRaw && Number.isFinite(lastSeenRaw.getTime())
-                    ? lastSeenRaw
-                        .toISOString()
-                        .replace("T", " ")
-                        .replace(/\.\d{3}Z$/, " UTC")
-                    : "\u2014";
+                // Renders Pacific time (America/Los_Angeles, DST-aware)
+                // rather than UTC \u2014 the dashboard is operated from
+                // Pacific. Storage and URL contracts remain UTC; only the
+                // display flips. See the formatAnalyticsTimestamp JSDoc
+                // for full scope and rationale.
+                var lastSeenStr = formatAnalyticsTimestamp(q.last_seen);
                 return (
                   '<tr class="empty"><td>' +
                   esc(q.query_text) +
@@ -2044,6 +2239,60 @@
               })
               .join("") ||
             '<tr><td colspan="5">No empty-result queries.</td></tr>';
+
+          // Blocked queries title — append window label so it tracks the
+          // same window as Top Queries / Empty Queries.
+          var blockedTitle = document.getElementById("blockedQueriesTitle");
+          if (blockedTitle) {
+            // Replace the entire title text + the trailing shield glyph,
+            // using a real span node so we don't have to manually escape
+            // anything in winLabel.
+            blockedTitle.textContent = "Blocked Queries (" + winLabel + ") ";
+            var shield = document.createElement("span");
+            shield.textContent = "🛡️";
+            blockedTitle.appendChild(shield);
+          }
+
+          // Blocked queries table. Each row is one block_reason bucket
+          // with hits, last_seen (Pacific via formatAnalyticsTimestamp),
+          // and up to 5 sample queries joined by " · " for compactness.
+          var blockedBody = document.querySelector(
+            "#blockedQueriesTable tbody",
+          );
+          if (blockedBody) {
+            blockedBody.innerHTML =
+              asArray(blockedQueries)
+                .map(function (b) {
+                  var samples = Array.isArray(b.sample_queries)
+                    ? b.sample_queries
+                    : [];
+                  // Truncate each sample to ~80 chars so a single
+                  // long-tail query can't blow up the column width;
+                  // join with " · " so the cell stays readable. esc()
+                  // each fragment individually before concatenation.
+                  var samplesHtml =
+                    samples
+                      .map(function (s) {
+                        var text = String(s);
+                        if (text.length > 80) text = text.slice(0, 77) + "…";
+                        return esc(text);
+                      })
+                      .join(" · ") || "—";
+                  return (
+                    "<tr><td>" +
+                    esc(b.block_reason) +
+                    "</td><td>" +
+                    esc(safeNumber(b.hits).toLocaleString()) +
+                    "</td><td>" +
+                    esc(formatAnalyticsTimestamp(b.last_seen)) +
+                    "</td><td>" +
+                    samplesHtml +
+                    "</td></tr>"
+                  );
+                })
+                .join("") ||
+              '<tr><td colspan="4">No blocked queries in this window.</td></tr>';
+          }
         } catch (err) {
           // Stale-response guard also applies to failures: a slow old
           // request that rejects after a newer load() has already

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/pathfinder",
-  "version": "1.15.2",
+  "version": "1.15.4",
   "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
   "type": "module",
   "repository": {

--- a/src/__tests__/analytics-auth-length-check.test.ts
+++ b/src/__tests__/analytics-auth-length-check.test.ts
@@ -19,6 +19,7 @@ vi.mock("../db/analytics.js", () => ({
   getAnalyticsSummary: vi.fn(),
   getTopQueries: vi.fn(),
   getEmptyQueries: vi.fn(),
+  getBlockedQueries: vi.fn(),
   getToolCounts: vi.fn(),
 }));
 
@@ -79,6 +80,7 @@ describe("analyticsAuth length-check early return (R4-18)", () => {
       getAnalyticsSummary: async () => ({ total: 0 }) as never,
       getTopQueries: async () => [],
       getEmptyQueries: async () => [],
+      getBlockedQueries: async () => [],
       getToolCounts: async () => [],
     });
     server = http.createServer(app);

--- a/src/__tests__/analytics-error-log-ip.test.ts
+++ b/src/__tests__/analytics-error-log-ip.test.ts
@@ -13,6 +13,7 @@ vi.mock("../db/analytics.js", () => ({
   getAnalyticsSummary: vi.fn(),
   getTopQueries: vi.fn(),
   getEmptyQueries: vi.fn(),
+  getBlockedQueries: vi.fn(),
   getToolCounts: vi.fn(),
 }));
 
@@ -45,6 +46,9 @@ function buildApp() {
       throw new Error("db boom");
     },
     getEmptyQueries: async () => {
+      throw new Error("db boom");
+    },
+    getBlockedQueries: async () => {
       throw new Error("db boom");
     },
     getToolCounts: async () => {

--- a/src/__tests__/analytics-sendfile-correlation.test.ts
+++ b/src/__tests__/analytics-sendfile-correlation.test.ts
@@ -17,6 +17,7 @@ vi.mock("../db/analytics.js", () => ({
   getAnalyticsSummary: vi.fn(),
   getTopQueries: vi.fn(),
   getEmptyQueries: vi.fn(),
+  getBlockedQueries: vi.fn(),
   getToolCounts: vi.fn(),
 }));
 

--- a/src/__tests__/analytics-server.test.ts
+++ b/src/__tests__/analytics-server.test.ts
@@ -6,12 +6,14 @@ import path from "node:path";
 const mockGetAnalyticsSummary = vi.fn();
 const mockGetTopQueries = vi.fn();
 const mockGetEmptyQueries = vi.fn();
+const mockGetBlockedQueries = vi.fn();
 const mockGetToolCounts = vi.fn();
 
 vi.mock("../db/analytics.js", () => ({
   getAnalyticsSummary: (...args: unknown[]) => mockGetAnalyticsSummary(...args),
   getTopQueries: (...args: unknown[]) => mockGetTopQueries(...args),
   getEmptyQueries: (...args: unknown[]) => mockGetEmptyQueries(...args),
+  getBlockedQueries: (...args: unknown[]) => mockGetBlockedQueries(...args),
   getToolCounts: (...args: unknown[]) => mockGetToolCounts(...args),
 }));
 
@@ -82,6 +84,8 @@ function buildTestApp() {
       mockGetTopQueries(...args),
     getEmptyQueries: (...args: Parameters<typeof mockGetEmptyQueries>) =>
       mockGetEmptyQueries(...args),
+    getBlockedQueries: (...args: Parameters<typeof mockGetBlockedQueries>) =>
+      mockGetBlockedQueries(...args),
     getToolCounts: (...args: Parameters<typeof mockGetToolCounts>) =>
       mockGetToolCounts(...args),
     analyticsHtmlPath,
@@ -362,6 +366,86 @@ describe("Analytics server routes (HTTP-level)", () => {
         error: "misconfigured",
         error_description: "Analytics config read failed",
       });
+      consoleErrSpy.mockRestore();
+    });
+  });
+
+  // ---- /api/analytics/blocked-queries (v1.15.3) ----------------------------
+
+  describe("GET /api/analytics/blocked-queries (v1.15.3)", () => {
+    it("returns blocked-row groups with a valid token", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "secret",
+      });
+      mockGetBlockedQueries.mockResolvedValue([
+        {
+          block_reason: "box-office",
+          hits: 142,
+          last_seen: "2026-06-17T16:40:32.000Z",
+          sample_queries: ["box office weekend"],
+        },
+      ]);
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/blocked-queries?days=7",
+        { Authorization: "Bearer secret" },
+      );
+
+      expect(res.status).toBe(200);
+      const body = JSON.parse(res.body);
+      expect(Array.isArray(body)).toBe(true);
+      expect(body[0].block_reason).toBe("box-office");
+      expect(body[0].hits).toBe(142);
+      // The route forwards the parsed days value to the DB call.
+      expect(mockGetBlockedQueries).toHaveBeenCalledWith(7);
+    });
+
+    it("returns 401 without a token", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "secret",
+      });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/blocked-queries",
+      );
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 500 with a clean error envelope when the DB call rejects", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "secret",
+      });
+      mockGetBlockedQueries.mockRejectedValue(new Error("boom"));
+      const consoleErrSpy = vi
+        .spyOn(console, "error")
+        .mockImplementation(() => {});
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/blocked-queries",
+        { Authorization: "Bearer secret" },
+      );
+
+      expect(res.status).toBe(500);
+      const body = JSON.parse(res.body);
+      expect(body.error).toBe("Failed to fetch blocked queries");
       consoleErrSpy.mockRestore();
     });
   });

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -281,6 +281,7 @@ describe("analytics dashboard UI — date preset wiring", () => {
       },
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls, chartInstances } = await loadDashboard(endpoints);
@@ -386,6 +387,7 @@ describe("analytics dashboard UI — date preset wiring", () => {
         "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
         "/api/analytics/queries": () => [],
         "/api/analytics/empty-queries": () => [],
+        "/api/analytics/blocked-queries": () => [],
       };
 
       const { dom, calls } = await loadDashboard(endpoints);
@@ -474,6 +476,7 @@ describe("analytics dashboard UI — date preset wiring", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls } = await loadDashboard(endpoints);
@@ -542,6 +545,7 @@ describe("analytics dashboard UI — dynamic window labels", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
   }
 
@@ -697,6 +701,7 @@ describe("analytics dashboard UI — daily bar click drills down", () => {
         "/api/analytics/tool-counts": () => canned(3, 500).toolCounts,
         "/api/analytics/queries": () => [],
         "/api/analytics/empty-queries": () => [],
+        "/api/analytics/blocked-queries": () => [],
       };
 
       const { dom, calls, chartInstances } = await loadDashboard(endpoints);
@@ -760,6 +765,7 @@ describe("analytics dashboard UI — custom-range apply", () => {
       "/api/analytics/tool-counts": () => canned(3, 100).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls } = await loadDashboard(endpoints);
@@ -827,6 +833,178 @@ describe("analytics dashboard UI — custom-range apply", () => {
   });
 });
 
+describe("analytics dashboard UI — Pacific timestamps (v1.15.3)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders Empty Queries last_seen in Pacific time with PDT/PST marker, not UTC", async () => {
+    // Two instants — one in DST (June, PDT = UTC-7) and one in standard
+    // (January, PST = UTC-8) — verify the formatter picks the right
+    // marker for each.
+    const dstInstant = "2026-06-17T16:40:32.000Z"; // 09:40:32 PDT
+    const stdInstant = "2026-01-15T17:40:32.000Z"; // 09:40:32 PST
+
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 0).summary,
+      "/api/analytics/tool-counts": () => [],
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [
+        {
+          query_text: "summer-query",
+          tool_name: "search-docs",
+          source_name: "docs",
+          count: 1,
+          last_seen: dstInstant,
+        },
+        {
+          query_text: "winter-query",
+          tool_name: "search-docs",
+          source_name: "docs",
+          count: 1,
+          last_seen: stdInstant,
+        },
+      ],
+      "/api/analytics/blocked-queries": () => [],
+    };
+
+    const { dom } = await loadDashboard(endpoints);
+    const rows = Array.from(
+      dom.window.document.querySelectorAll("#emptyQueriesTable tbody tr"),
+    );
+    expect(rows.length).toBe(2);
+
+    const cells = rows.map((r) =>
+      Array.from(r.querySelectorAll("td")).map((c) => c.textContent ?? ""),
+    );
+    // Row order matches the array we sent (count is the same, server
+    // doesn't re-sort here — the client renders what it receives).
+    // PDT row (June 17, 09:40:32 PDT — UTC-7).
+    expect(cells[0][4]).toContain("PDT");
+    expect(cells[0][4]).toContain("2026-06-17");
+    expect(cells[0][4]).toContain("09:40:32");
+    expect(cells[0][4]).not.toContain("UTC");
+    // PST row (Jan 15, 09:40:32 PST — UTC-8).
+    expect(cells[1][4]).toContain("PST");
+    expect(cells[1][4]).toContain("2026-01-15");
+    expect(cells[1][4]).toContain("09:40:32");
+    expect(cells[1][4]).not.toContain("UTC");
+  });
+
+  it("renders an em-dash for missing / non-parseable last_seen instead of 'Invalid Date'", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 0).summary,
+      "/api/analytics/tool-counts": () => [],
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [
+        {
+          query_text: "q1",
+          tool_name: "t",
+          source_name: "s",
+          count: 1,
+          last_seen: null,
+        },
+        {
+          query_text: "q2",
+          tool_name: "t",
+          source_name: "s",
+          count: 1,
+          last_seen: "not-a-date",
+        },
+      ],
+      "/api/analytics/blocked-queries": () => [],
+    };
+
+    const { dom } = await loadDashboard(endpoints);
+    const rows = Array.from(
+      dom.window.document.querySelectorAll("#emptyQueriesTable tbody tr"),
+    );
+    expect(rows.length).toBe(2);
+    const lastSeenCells = rows.map(
+      (r) => r.querySelectorAll("td")[4]?.textContent ?? "",
+    );
+    // Both should render the em-dash, not "Invalid Date".
+    expect(lastSeenCells[0]).toBe("—");
+    expect(lastSeenCells[1]).toBe("—");
+  });
+});
+
+describe("analytics dashboard UI — Blocked Queries panel (v1.15.3)", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches /api/analytics/blocked-queries on load and renders one row per block_reason", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 0).summary,
+      "/api/analytics/tool-counts": () => [],
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [
+        {
+          block_reason: "box-office",
+          hits: 142,
+          last_seen: "2026-06-17T16:40:32.000Z",
+          sample_queries: ["box office weekend", "toy story 5 box office"],
+        },
+        {
+          block_reason: "kalshi-scotus",
+          hits: 5,
+          last_seen: "2026-06-17T05:00:00.000Z",
+          sample_queries: ["cftc kalshi certiorari"],
+        },
+      ],
+    };
+
+    const { dom, calls } = await loadDashboard(endpoints);
+
+    // The endpoint must have been called.
+    expect(
+      calls.some((u) => u.startsWith("/api/analytics/blocked-queries")),
+    ).toBe(true);
+
+    // The panel must exist and have two body rows.
+    const rows = Array.from(
+      dom.window.document.querySelectorAll("#blockedQueriesTable tbody tr"),
+    );
+    expect(rows.length).toBe(2);
+
+    const firstCells = Array.from(rows[0].querySelectorAll("td")).map(
+      (c) => c.textContent ?? "",
+    );
+    expect(firstCells[0]).toBe("box-office");
+    expect(firstCells[1]).toBe("142");
+    // Pacific time marker for the rendered last_seen.
+    expect(firstCells[2]).toContain("PDT");
+    expect(firstCells[2]).not.toContain("UTC");
+    // Sample queries joined by " · ".
+    expect(firstCells[3]).toContain("box office weekend");
+    expect(firstCells[3]).toContain("toy story 5 box office");
+    expect(firstCells[3]).toContain("·");
+  });
+
+  it("renders an explanatory 'No blocked queries' row when the panel is empty", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 0).summary,
+      "/api/analytics/tool-counts": () => [],
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
+    };
+
+    const { dom } = await loadDashboard(endpoints);
+    const rows = Array.from(
+      dom.window.document.querySelectorAll("#blockedQueriesTable tbody tr"),
+    );
+    expect(rows.length).toBe(1);
+    expect(rows[0].textContent).toContain("No blocked queries");
+  });
+});
+
 describe("analytics dashboard UI — HTML escaping", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -856,6 +1034,7 @@ describe("analytics dashboard UI — HTML escaping", () => {
       "/api/analytics/tool-counts": () => [],
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom } = await loadDashboard(endpoints);
@@ -941,6 +1120,7 @@ describe("analytics dashboard UI — unfilteredSourcesCache", () => {
       ],
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
   }
 
@@ -1077,6 +1257,7 @@ describe("analytics dashboard UI — loadGeneration race guard", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom } = await loadDashboard(endpoints);
@@ -1145,6 +1326,7 @@ describe("analytics dashboard UI — error banner", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
     // Swallow the [analytics] load() console.error — it's intentional and
     // the test assertion lives on the banner, not on the log.
@@ -1177,6 +1359,7 @@ describe("analytics dashboard UI — error banner", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { dom } = await loadDashboard(endpoints);
@@ -1218,6 +1401,7 @@ describe("analytics dashboard UI — error banner", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
     // Swallow the intentional console.error from load()'s catch + the
     // fetchJson parse-fail log, since the test assertion lives on the
@@ -1247,6 +1431,7 @@ describe("analytics dashboard UI — error banner", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { dom } = await loadDashboard(endpoints);
@@ -1274,6 +1459,7 @@ describe("analytics dashboard UI — error banner", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
     const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     const { dom } = await loadDashboard(endpoints);
@@ -1310,6 +1496,7 @@ describe("analytics dashboard UI — fetchJson 401/403 auth failure", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
     // Prime sessionStorage with a stale token BEFORE the page loads so the
     // dashboard picks it up as TOKEN at init time. We need to seed the
@@ -1397,6 +1584,7 @@ describe("analytics dashboard UI — custom-range invalid input", () => {
       "/api/analytics/tool-counts": () => canned(3, 500).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls } = await loadDashboard(endpoints);
@@ -1609,6 +1797,7 @@ describe("analytics dashboard UI — p95 sampled badge", () => {
       "/api/analytics/tool-counts": () => [],
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom } = await loadDashboard(endpoints);
@@ -1636,6 +1825,7 @@ describe("analytics dashboard UI — p95 sampled badge", () => {
       "/api/analytics/tool-counts": () => [],
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom } = await loadDashboard(endpoints);
@@ -1668,6 +1858,7 @@ describe("analytics dashboard UI — Today preset exclusive highlight", () => {
       "/api/analytics/tool-counts": () => canned(1, 500).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom } = await loadDashboard(endpoints);
@@ -1729,6 +1920,7 @@ describe("analytics dashboard UI — daily chart drill-down malformed-day reject
       "/api/analytics/tool-counts": () => canned(3, 500).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls, chartInstances } = await loadDashboard(endpoints);
@@ -1795,6 +1987,7 @@ describe("analytics dashboard UI — custom-range backwards swap", () => {
       "/api/analytics/tool-counts": () => canned(3, 100).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls } = await loadDashboard(endpoints);
@@ -1902,6 +2095,7 @@ describe("analytics dashboard UI — fetchJson stale-401 generation guard", () =
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     // Inline the loadDashboard dance so we can seed sessionStorage + prime
@@ -2055,6 +2249,7 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls } = await loadDashboardAtUrl(
@@ -2085,6 +2280,7 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, calls } = await loadDashboardAtUrl(
@@ -2118,6 +2314,7 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, win } = await loadDashboardAtUrl(
@@ -2171,6 +2368,7 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, win } = await loadDashboardAtUrl(
@@ -2226,6 +2424,7 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { calls } = await loadDashboardAtUrl(
@@ -2256,6 +2455,7 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
         "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
         "/api/analytics/queries": () => [],
         "/api/analytics/empty-queries": () => [],
+        "/api/analytics/blocked-queries": () => [],
       };
 
       const { calls } = await loadDashboardAtUrl(
@@ -2279,6 +2479,7 @@ describe("analytics dashboard UI — URL-persisted time window", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { calls } = await loadDashboardAtUrl(
@@ -2435,6 +2636,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(3, 500).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, win, chartInstances } = await loadDashboardAtUrl(
@@ -2495,6 +2697,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { win } = await loadDashboardAtUrl(
@@ -2519,6 +2722,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { win } = await loadDashboardAtUrl(
@@ -2545,6 +2749,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, win } = await loadDashboardAtUrl(
@@ -2573,6 +2778,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, win, calls } = await loadDashboardAtUrl(
@@ -2655,6 +2861,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, win, calls } = await loadDashboardAtUrl(
@@ -2734,6 +2941,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     // Tokyo early-morning scenario: UTC today is 2026-04-20, but the user's
@@ -2766,6 +2974,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     const { dom, win, calls } = await loadDashboardAtUrl(
@@ -2848,6 +3057,7 @@ describe("analytics dashboard UI — URL persistence parity", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
 
     // URL deep-link path: today+2 is unambiguously future-future and must
@@ -2958,6 +3168,7 @@ describe("analytics dashboard UI — data availability label", () => {
       "/api/analytics/tool-counts": () => canned(1, 0).toolCounts,
       "/api/analytics/queries": () => [],
       "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
     };
   }
 

--- a/src/__tests__/analytics.test.ts
+++ b/src/__tests__/analytics.test.ts
@@ -11,6 +11,7 @@ import {
   getAnalyticsSummary,
   getTopQueries,
   getEmptyQueries,
+  getBlockedQueries,
   getToolCounts,
   cleanupOldQueryLogs,
   REDACTED_QUERY_TEXT,
@@ -750,6 +751,113 @@ describe("getEmptyQueries edge cases", () => {
     mockQuery.mockResolvedValueOnce({ rows: [] });
     const result = await getEmptyQueries(7, 0);
     expect(result).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getEmptyQueries — excludes blocked rows (v1.15.3)
+// ---------------------------------------------------------------------------
+
+describe("getEmptyQueries blocked-exclusion", () => {
+  it("filters on blocked = false in the WHERE clause", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getEmptyQueries();
+
+    const [sql] = mockQuery.mock.calls[0];
+    // Must AND with blocked = false so blocked-and-empty rows don't
+    // double-count in the "real users searched and found nothing" view.
+    expect(sql).toContain("blocked = false");
+    // Sanity: must still gate on result_count = 0 (the original filter
+    // isn't replaced — it's intersected with blocked = false).
+    expect(sql).toContain("result_count = 0");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBlockedQueries
+// ---------------------------------------------------------------------------
+
+describe("getBlockedQueries", () => {
+  it("returns blocked-rows grouped by block_reason", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          block_reason: "box-office",
+          hits: 42,
+          last_seen: "2026-06-17T10:00:00Z",
+          sample_queries: ["box office weekend", "toy story 5 box office"],
+        },
+        {
+          block_reason: "kalshi-scotus",
+          hits: 5,
+          last_seen: "2026-06-17T05:00:00Z",
+          sample_queries: ["cftc kalshi certiorari"],
+        },
+      ],
+    });
+
+    const result = await getBlockedQueries(7);
+
+    expect(result).toHaveLength(2);
+    expect(result[0].block_reason).toBe("box-office");
+    expect(result[0].hits).toBe(42);
+    expect(result[0].sample_queries).toEqual([
+      "box office weekend",
+      "toy story 5 box office",
+    ]);
+  });
+
+  it("filters on blocked = true and a windowed created_at", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getBlockedQueries(7);
+
+    const [sql, params] = mockQuery.mock.calls[0];
+    expect(sql).toContain("blocked = true");
+    // Window uses a parameterized interval — days is passed as a string
+    // so `($N || ' days')::interval` composes correctly.
+    expect(sql).toContain("NOW() - ($1 || ' days')::interval");
+    expect(params).toEqual(["7"]);
+  });
+
+  it("groups by COALESCE(block_reason, '<unknown>') so null-reason rows stay visible", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getBlockedQueries();
+
+    const [sql] = mockQuery.mock.calls[0];
+    // v1.15.4: the COALESCE projection moved into a CTE
+    // (`blocked_rows.block_reason_key`) so the outer GROUP BY and the
+    // correlated subquery reference the same column expression. Without
+    // the CTE, Postgres rejected the correlated subquery's
+    // `query_log.block_reason` reference as ungrouped (the outer was
+    // grouped on COALESCE(block_reason, '<unknown>'), not raw
+    // block_reason). Assertions pin both halves:
+    expect(sql).toContain("COALESCE(block_reason, '<unknown>')");
+    expect(sql).toContain("AS block_reason_key");
+    expect(sql).toContain("GROUP BY block_reason_key");
+  });
+
+  it("orders by hits DESC", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+    await getBlockedQueries();
+
+    const [sql] = mockQuery.mock.calls[0];
+    expect(sql).toContain("ORDER BY hits DESC");
+  });
+
+  it("coerces missing sample_queries to an empty array", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          block_reason: "x",
+          hits: 1,
+          last_seen: "2026-06-17T00:00:00Z",
+          sample_queries: null,
+        },
+      ],
+    });
+
+    const result = await getBlockedQueries();
+    expect(result[0].sample_queries).toEqual([]);
   });
 });
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("The knowledge server for AI agents")
-  .version("1.15.2");
+  .version("1.15.4");
 
 program
   .command("init")

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -238,6 +238,27 @@ export interface EmptyQuery {
   last_seen: string;
 }
 
+/**
+ * Aggregate row for the "Blocked Queries" analytics panel — one row per
+ * `block_reason` value, summarizing how many times that off-topic / abuse
+ * pattern fired in the window. Surfaced separately from {@link EmptyQuery}
+ * so operators can see the abuse blocklist actively short-circuiting traffic
+ * (the same rows are excluded from the empty-results list to avoid
+ * double-counting blocked queries as "real users found nothing").
+ *
+ * `block_reason` is the raw classifier label (e.g. `box-office`,
+ * `kalshi-scotus`, `scary-movie-2026`); the dashboard renders it verbatim.
+ * `sample_queries` is a deduplicated, alphabetically-sorted preview capped at
+ * 5 entries per reason so the panel can show concrete examples without
+ * leaking the long tail.
+ */
+export interface BlockedQueryGroup {
+  block_reason: string;
+  hits: number;
+  last_seen: string;
+  sample_queries: string[];
+}
+
 export interface ToolCount {
   tool_type: string;
   count: number;
@@ -1035,6 +1056,15 @@ export async function getTopQueries(
  * that happens to return zero entries is not a real "user searched and found
  * nothing" gap, so surfacing a literal `<browse>` row in the Empty-Result
  * dashboard would be misleading noise.
+ *
+ * Blocked rows (`blocked = true`) are ALSO excluded: those queries were
+ * short-circuited by the abuse blocklist (v1.15.2) before they ever reached
+ * the index, so `result_count = 0` is a known by-design outcome — not a
+ * content gap. They surface in {@link getBlockedQueries} instead so operators
+ * can see the blocklist actively catching abuse without polluting the
+ * "real users searched and found nothing" view. `blocked` is
+ * `BOOLEAN NOT NULL DEFAULT FALSE` so the predicate is safe for historical
+ * rows that predate the column (they read back as `false`).
  */
 export async function getEmptyQueries(
   days: number = 7,
@@ -1054,6 +1084,10 @@ export async function getEmptyQueries(
   const limitIdx = browseIdx + 1;
   const baseClauses = [
     "result_count = 0",
+    // Exclude rows the v1.15.2 abuse blocklist short-circuited (see JSDoc).
+    // The column is BOOLEAN NOT NULL DEFAULT FALSE so a plain `= false` is
+    // correct for both historical (pre-column) and current rows.
+    "blocked = false",
     ...dw.clauses,
     ...rs.clauses,
     `query_text != $${redactedIdx}`,
@@ -1090,6 +1124,82 @@ export async function getEmptyQueries(
     source_name: (r.source_name as string) ?? null,
     count: r.count as number,
     last_seen: r.last_seen as string,
+  }));
+}
+
+/**
+ * Get rows the v1.15.2 abuse blocklist short-circuited (`blocked = true`),
+ * grouped by `block_reason` so operators can see at a glance which patterns
+ * are firing and how often. Counterpart to {@link getEmptyQueries}, which now
+ * excludes these rows so a blocked query doesn't double-count as both
+ * "blocked" and "empty result".
+ *
+ * Returns up to 5 sample `query_text` values per `block_reason` (deduplicated,
+ * alphabetically sorted) so the panel can show concrete examples without
+ * leaking the long tail or unbounded text.
+ *
+ * Rows with `blocked = true` but `block_reason IS NULL` (defensive — should
+ * not happen since the writer sets both atomically) collapse into a single
+ * `<unknown>` bucket so they remain visible rather than silently dropping.
+ *
+ * Window semantics intentionally match {@link getEmptyQueries}:
+ * `created_at > NOW() - INTERVAL '<days> days'`. No filter parameter — the
+ * blocklist panel is operational-only and the filter wiring (tool/source/
+ * request_source) doesn't carry meaning for short-circuited rows that never
+ * reached the retrieval layer.
+ */
+export async function getBlockedQueries(
+  days: number = 7,
+): Promise<BlockedQueryGroup[]> {
+  const pool = getPool();
+
+  // Plain `interval N days` is bound via a parameterized integer so the
+  // operator-facing panel can't be SQL-injected through the days arg even
+  // if a future route surfaces it. Postgres rejects negative intervals on
+  // the `created_at >` half-bound anyway, but defense-in-depth.
+  //
+  // CTE pre-projects `block_reason` to its display value (`'<unknown>'` for
+  // NULL) so the outer GROUP BY operates on the same expression the
+  // correlated subquery filters on — without the CTE, Postgres rejects the
+  // correlated reference as an ungrouped column (the outer GROUP BY is on
+  // `COALESCE(block_reason, '<unknown>')`, not raw `block_reason`).
+  const { rows } = await pool.query(
+    `WITH blocked_rows AS (
+       SELECT
+         COALESCE(block_reason, '<unknown>') AS block_reason_key,
+         query_text,
+         created_at
+       FROM query_log
+       WHERE blocked = true
+         AND created_at > NOW() - ($1 || ' days')::interval
+     )
+     SELECT
+        block_reason_key AS block_reason,
+        count(*)::int AS hits,
+        max(created_at)::text AS last_seen,
+        (
+          SELECT array_agg(s ORDER BY s)
+          FROM (
+            SELECT DISTINCT query_text AS s
+            FROM blocked_rows AS inner_q
+            WHERE inner_q.block_reason_key = blocked_rows.block_reason_key
+            ORDER BY query_text
+            LIMIT 5
+          ) sub
+        ) AS sample_queries
+     FROM blocked_rows
+     GROUP BY block_reason_key
+     ORDER BY hits DESC`,
+    [String(days)],
+  );
+
+  return rows.map((r: Record<string, unknown>) => ({
+    block_reason: r.block_reason as string,
+    hits: r.hits as number,
+    last_seen: r.last_seen as string,
+    sample_queries: Array.isArray(r.sample_queries)
+      ? (r.sample_queries as string[])
+      : [],
   }));
 }
 

--- a/src/server.ts
+++ b/src/server.ts
@@ -84,6 +84,7 @@ import {
   getAnalyticsSummary,
   getTopQueries,
   getEmptyQueries,
+  getBlockedQueries,
   getToolCounts,
   normalizeRequestSource,
   REQUEST_SOURCE_HEADER,
@@ -3038,6 +3039,7 @@ export interface AnalyticsRouteDeps {
   getAnalyticsSummary?: typeof getAnalyticsSummary;
   getTopQueries?: typeof getTopQueries;
   getEmptyQueries?: typeof getEmptyQueries;
+  getBlockedQueries?: typeof getBlockedQueries;
   getToolCounts?: typeof getToolCounts;
   analyticsHtmlPath?: string;
 }
@@ -3054,6 +3056,7 @@ export function registerAnalyticsRoutes(
   const _getAnalyticsSummary = deps.getAnalyticsSummary ?? getAnalyticsSummary;
   const _getTopQueries = deps.getTopQueries ?? getTopQueries;
   const _getEmptyQueries = deps.getEmptyQueries ?? getEmptyQueries;
+  const _getBlockedQueries = deps.getBlockedQueries ?? getBlockedQueries;
   const _getToolCounts = deps.getToolCounts ?? getToolCounts;
   const _analyticsHtmlPath =
     deps.analyticsHtmlPath ?? path.resolve(__dirname, "../docs/analytics.html");
@@ -3161,6 +3164,33 @@ export function registerAnalyticsRoutes(
           err,
         );
         res.status(500).json({ error: "Failed to fetch empty queries" });
+      }
+    },
+  );
+
+  app.get(
+    "/api/analytics/blocked-queries",
+    analyticsAuth,
+    async (req: Request, res: Response) => {
+      // Blocked-queries panel has no filter wiring: it surfaces rows the
+      // abuse blocklist short-circuited BEFORE retrieval, so tool/source/
+      // request-source filters carry no meaning here (the row never reached
+      // the layer those filters describe). We still parse `days` so the
+      // window matches the rest of the dashboard.
+      const daysParsed = parseDaysOrError(req);
+      if (!daysParsed.ok) {
+        res.status(daysParsed.status).json(daysParsed.body);
+        return;
+      }
+      try {
+        const groups = await _getBlockedQueries(daysParsed.value);
+        res.json(groups);
+      } catch (err) {
+        console.error(
+          `[analytics] Blocked queries failed (days=${daysParsed.value} ip=${clientIp(req, trustProxy)}):`,
+          err,
+        );
+        res.status(500).json({ error: "Failed to fetch blocked queries" });
       }
     },
   );


### PR DESCRIPTION
## Summary

Re-ships the three reverted v1.15.3 changes (blocked filter on empty-results, new Blocked Queries panel, Pacific timestamps) with the two defects fixed that took v1.15.3 down within minutes of deploy (reverted via PR #117):

1. **`getBlockedQueries` SQL — rewrote as a CTE-backed correlated subquery.** v1.15.3 grouped the outer query on `COALESCE(block_reason, '<unknown>')` but the correlated subquery referenced raw `query_log.block_reason`, which Postgres rejects as an ungrouped column reference (`subquery uses ungrouped column "query_log.block_reason" from outer query`). The CTE (`blocked_rows.block_reason_key`) pre-projects the COALESCEd expression so the outer `GROUP BY` and the inner correlated reference operate on the same column.
2. **`Promise.all` → `Promise.allSettled` in `docs/analytics.html`.** A single panel's fetch failure used to throw out of `Promise.all` and blank the entire `/analytics` page (which is what made v1.15.3's SQL bug catastrophic instead of merely cosmetic). Each panel now renders independently. Auth (401) still bubbles to the outer catch since a bad token fails every endpoint identically; a failed summary still surfaces via the top-level banner. Per-panel failures degrade to an empty state with `console.error`.

## Local verification (the discipline that was missing on v1.15.3)

Booted Pathfinder locally against the real prod `DATABASE_URL`:

- `/api/analytics/blocked-queries?days=7` returned **HTTP 200** + valid JSON. Verified with three test rows inserted into prod: response correctly grouped one bucket by `block_reason='hotfix-test'` (2 hits, 2 sample_queries) and one `<unknown>` bucket for the NULL row (1 hit, 1 sample_query). Test rows then deleted; prod has zero blocked rows in the 7-day window (current state).
- `/api/analytics/empty-queries?days=7` returned HTTP 200, no abuse strings (toy story / box office / kalshi / scotus) leaked into results.
- `/analytics` page returned HTTP 200 with no rendered error banner.

Pre-fix SQL was directly verified to fail against prod psql with the exact error above. Post-fix SQL was directly verified to return real grouped rows when run against prod psql with a wider window (`days=30` returns ~13k legacy `<unknown>` rows). Both pre-fix and post-fix were observed end-to-end against the actual production schema before push.

## Test plan

- [ ] CI green
- [ ] Post-deploy: `/analytics` renders all sections, no error banner
- [ ] `/api/analytics/blocked-queries?days=7` returns 200 + grouped JSON