### PR TITLE
Fix monthly gap-analysis Notion tables + route report to #engr

### DIFF
--- a/.github/workflows/monthly-gap-analysis.yml
+++ b/.github/workflows/monthly-gap-analysis.yml
@@ -101,9 +101,12 @@ jobs:
           NOTION_TOKEN: ${{ secrets.NOTION_TOKEN }}
           # Gap-Reports parent page.
           NOTION_PARENT_PAGE_ID: "3793aa38-1852-80a5-89d3-c3d37147aa22"
-          # Slack alert (new high-severity gaps only). Unset → no alert.
-          # Org-level secret shared by every workflow (see header).
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
+          # Gap report (new high-severity gaps only) → #engr. Unset → no alert.
+          # The gap report is a successful-run signal for engineering, so it
+          # routes to #engr via SLACK_WEBHOOK_ENGR (matching the weekly
+          # search-report success digest), NOT #oss-alerts. A run FAILURE is
+          # surfaced as a red CI run, not a Slack alert.
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ENGR }}
           # Stable path the download step writes to and the upload step reads
           # from, so prior-run state survives across runs via the artifact.
           GAP_STATE_PATH: /tmp/gap-state/pathfinder-gap-analysis-state.json

--- a/.github/workflows/monthly-gap-analysis.yml
+++ b/.github/workflows/monthly-gap-analysis.yml
@@ -19,10 +19,11 @@ name: Monthly Gap Analysis
 #   NOTION_TOKEN                Notion integration token used to publish the
 #                               report page. When unset, the Notion step is
 #                               skipped.
-#   SLACK_WEBHOOK_OSS_ALERTS    Incoming-webhook URL (org-level secret shared by
-#                               every workflow). Posted to ONLY when new
-#                               high-severity gaps are detected. When unset, no
-#                               alert is sent.
+#   SLACK_WEBHOOK_ENGR          Incoming-webhook URL (org-level secret) for #engr.
+#                               The gap report (a successful-run signal) posts
+#                               here ONLY when new high-severity gaps are
+#                               detected. When unset, no alert is sent. Run
+#                               FAILURES surface as a red CI run, not a Slack alert.
 #
 # Prior-run state (for new-gap diffing) is carried across runs as the
 # `gap-analysis-state` artifact rather than the Actions cache: caches are

--- a/scripts/gap-analysis/README.md
+++ b/scripts/gap-analysis/README.md
@@ -47,24 +47,25 @@ the very signal it measures.
 ## Required secrets
 
 Configure the per-repo ones as **repository secrets** (Settings → Secrets and
-variables → Actions); `SLACK_WEBHOOK_OSS_ALERTS` is an **org-level** secret
-shared by every workflow and is already provisioned. The workflow runs without
+variables → Actions); `SLACK_WEBHOOK_ENGR` is an **org-level** secret
+and is already provisioned. The workflow runs without
 any of them, but no-ops gracefully until they are provisioned, so CI/lint and
 dry runs stay green.
 
-| Secret                       | Purpose                                                                                                             | When unset                                                                 |
-| ---------------------------- | ------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------- |
-| `PATHFINDER_ANALYTICS_TOKEN` | Bearer token for `GET /api/analytics/*` on the production MCP (`https://mcp.copilotkit.ai`).                        | Script logs "skipping live fetch" and exits 0.                             |
-| `ANTHROPIC_API_KEY`          | Anthropic key for the single LLM classification/summarization pass.                                                 | Deterministic fallback report is produced from the clusters (no LLM call). |
-| `NOTION_TOKEN`               | Notion integration token used to publish the report page.                                                           | Notion publish step is skipped.                                            |
-| `SLACK_WEBHOOK_OSS_ALERTS`   | Org-level incoming-webhook URL (shared by every workflow). Posted to only when new high-severity gaps are detected. | No Slack alert is sent.                                                    |
+| Secret                       | Purpose                                                                                                                                          | When unset                                                                 |
+| ---------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------- |
+| `PATHFINDER_ANALYTICS_TOKEN` | Bearer token for `GET /api/analytics/*` on the production MCP (`https://mcp.copilotkit.ai`).                                                     | Script logs "skipping live fetch" and exits 0.                             |
+| `ANTHROPIC_API_KEY`          | Anthropic key for the single LLM classification/summarization pass.                                                                              | Deterministic fallback report is produced from the clusters (no LLM call). |
+| `NOTION_TOKEN`               | Notion integration token used to publish the report page.                                                                                        | Notion publish step is skipped.                                            |
+| `SLACK_WEBHOOK_ENGR`         | Org-level incoming-webhook URL for **#engr**. The gap report (a successful-run signal) posts here only when new high-severity gaps are detected. | No Slack alert is sent.                                                    |
 
-> **Slack env var name:** the _script_ reads the webhook URL from `SLACK_WEBHOOK`,
-> not `SLACK_WEBHOOK_OSS_ALERTS`. The workflow bridges the two by mapping the
-> org secret into the script's variable
-> (`SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}`). So in CI the alert
-> uses the shared org webhook automatically, but a **local** run must export
-> `SLACK_WEBHOOK` itself — otherwise the alert step is a silent no-op.
+> **Slack env var name + channel:** the _script_ reads the webhook URL from
+> `SLACK_WEBHOOK`, not `SLACK_WEBHOOK_ENGR`. The workflow bridges the two by
+> mapping the org secret into the script's variable
+> (`SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ENGR }}`), so in CI the gap report
+> posts to **#engr** automatically; a **local** run must export `SLACK_WEBHOOK`
+> itself — otherwise the alert step is a silent no-op. Run FAILURES are surfaced
+> as a red CI run, not a Slack alert.
 
 The Notion parent page id defaults to the Gap-Reports page
 (`3793aa38-1852-80a5-89d3-c3d37147aa22`) and can be overridden with the
@@ -97,14 +98,14 @@ PATHFINDER_ANALYTICS_TOKEN=... NOTION_TOKEN=... \
 
 ### Useful env overrides
 
-| Var                     | Default                                   | Notes                                                                                                                |
-| ----------------------- | ----------------------------------------- | -------------------------------------------------------------------------------------------------------------------- |
-| `ANALYTICS_BASE_URL`    | `https://mcp.copilotkit.ai`               | Point at a local/staging MCP.                                                                                        |
-| `GAP_ANALYSIS_DAYS`     | `30`                                      | Lookback window.                                                                                                     |
-| `GAP_STATE_PATH`        | `/tmp/pathfinder-gap-analysis-state.json` | Prior-run state for new-gap diffing.                                                                                 |
-| `ANTHROPIC_MODEL`       | `claude-haiku-4-5-20251001`               | Override the model id.                                                                                               |
-| `NOTION_PARENT_PAGE_ID` | Gap-Reports page                          | Where the report page is created.                                                                                    |
-| `SLACK_WEBHOOK`         | _(unset)_                                 | Webhook the alert posts to. The workflow maps `SLACK_WEBHOOK_OSS_ALERTS` into it; set it directly for a local alert. |
+| Var                     | Default                                   | Notes                                                                                                                       |
+| ----------------------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `ANALYTICS_BASE_URL`    | `https://mcp.copilotkit.ai`               | Point at a local/staging MCP.                                                                                               |
+| `GAP_ANALYSIS_DAYS`     | `30`                                      | Lookback window.                                                                                                            |
+| `GAP_STATE_PATH`        | `/tmp/pathfinder-gap-analysis-state.json` | Prior-run state for new-gap diffing.                                                                                        |
+| `ANTHROPIC_MODEL`       | `claude-haiku-4-5-20251001`               | Override the model id.                                                                                                      |
+| `NOTION_PARENT_PAGE_ID` | Gap-Reports page                          | Where the report page is created.                                                                                           |
+| `SLACK_WEBHOOK`         | _(unset)_                                 | Webhook the gap report posts to (#engr). The workflow maps `SLACK_WEBHOOK_ENGR` into it; set it directly for a local alert. |
 
 ## Files
 

--- a/scripts/gap-analysis/monthly-gap-analysis.test.ts
+++ b/scripts/gap-analysis/monthly-gap-analysis.test.ts
@@ -1175,6 +1175,46 @@ describe("markdownToNotionBlocks", () => {
       }
     }
   });
+
+  it("renders a markdown table as a native Notion table block (not pipe paragraphs)", () => {
+    // Header + separator + 2 data rows. The old code emitted each `|...|` line as
+    // a paragraph containing literal pipes; the fix must emit ONE native `table`
+    // block whose table_row children carry the cell text (separator row dropped,
+    // first row as header).
+    const md = [
+      "| Cluster | Hits | Variants |",
+      "| --- | --- | --- |",
+      "| agent state | 10 | 1 |",
+      "| theming | 4 | 2 |",
+    ].join("\n");
+    const blocks = markdownToNotionBlocks(md);
+
+    // Exactly one block, of type "table" — NOT four pipe paragraphs.
+    expect(blocks).toHaveLength(1);
+    expect(blocks[0].type).toBe("table");
+    expect(
+      blocks.some((b) => b.type === "paragraph" && blockText(b).includes("|")),
+    ).toBe(false);
+
+    const table = (blocks[0] as any).table;
+    expect(table.table_width).toBe(3);
+    expect(table.has_column_header).toBe(true);
+    // Header row + 2 data rows = 3 table_row children (separator dropped).
+    expect(table.children).toHaveLength(3);
+    for (const row of table.children) {
+      expect(row.type).toBe("table_row");
+    }
+
+    // Cell text is reachable via each cell's rich_text spans.
+    const cellText = (cell: any[]): string =>
+      cell.map((r) => r.text.content).join("");
+    const rowText = (row: any): string[] =>
+      row.table_row.cells.map((c: any[]) => cellText(c));
+
+    expect(rowText(table.children[0])).toEqual(["Cluster", "Hits", "Variants"]);
+    expect(rowText(table.children[1])).toEqual(["agent state", "10", "1"]);
+    expect(rowText(table.children[2])).toEqual(["theming", "4", "2"]);
+  });
 });
 
 // ── batchBlocks (respect Notion's 100-children-per-request cap) ───────────────

--- a/scripts/gap-analysis/monthly-gap-analysis.ts
+++ b/scripts/gap-analysis/monthly-gap-analysis.ts
@@ -26,14 +26,15 @@
  *                               publish step is skipped.
  *   NOTION_PARENT_PAGE_ID       Parent page under which a new dated report page
  *                               is created each run. Defaults to Plans/Proposals.
- *   SLACK_WEBHOOK               Incoming-webhook URL the script posts new
- *                               high-severity alerts to. The WORKFLOW maps the
- *                               org-level secret into it
- *                               (SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}),
- *                               so a CI run alerts via the shared org webhook
- *                               while a local run must export SLACK_WEBHOOK
- *                               itself or the alert is a silent no-op. If unset,
- *                               no Slack alert.
+ *   SLACK_WEBHOOK               Incoming-webhook URL the script posts the gap
+ *                               report (new high-severity gaps) to. The gap
+ *                               report is a successful-run signal, so the
+ *                               WORKFLOW maps the #engr org-level secret into it
+ *                               (SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ENGR }}),
+ *                               so a CI run posts to #engr while a local run
+ *                               must export SLACK_WEBHOOK itself or the alert is
+ *                               a silent no-op. If unset, no Slack alert. (Run
+ *                               FAILURES are surfaced as a red CI run, not Slack.)
  *
  * Other env:
  *   ANALYTICS_BASE_URL          Override the analytics host (default prod).

--- a/scripts/gap-analysis/monthly-gap-analysis.ts
+++ b/scripts/gap-analysis/monthly-gap-analysis.ts
@@ -921,13 +921,32 @@ type NotionBlockType =
   | "heading_2"
   | "heading_3"
   | "bulleted_list_item"
-  | "paragraph";
+  | "paragraph"
+  | "table";
 
 interface NotionBlock {
   object: "block";
   type: NotionBlockType;
   [key: string]: unknown;
 }
+
+interface NotionTableRow {
+  type: "table_row";
+  table_row: { cells: NotionRichText[][] };
+}
+
+interface NotionTableBlock extends NotionBlock {
+  type: "table";
+  table: {
+    table_width: number;
+    has_column_header: boolean;
+    has_row_header: boolean;
+    children: NotionTableRow[];
+  };
+}
+
+/** Max DATA rows (excluding header) emitted per Notion table. */
+export const NOTION_MAX_TABLE_ROWS = 100;
 
 /**
  * Split a single line's text into <=NOTION_RICH_TEXT_LIMIT-char rich_text spans.
@@ -959,12 +978,98 @@ function makeBlock(type: NotionBlockType, text: string): NotionBlock {
   };
 }
 
+/** A markdown table row line starts and ends with a pipe (after trimming). */
+function isTableLine(line: string): boolean {
+  const t = line.trim();
+  return t.startsWith("|") && t.endsWith("|") && t.length > 1;
+}
+
+/** A `| --- | :--: |`-style separator row that delimits header from body. */
+function isSeparatorRow(line: string): boolean {
+  return splitTableRow(line).every((c) => /^:?-{1,}:?$/.test(c.trim()));
+}
+
+/**
+ * Split one `| a | b |` line into its cell strings (drops the outer pipes).
+ * Splits on UNESCAPED pipes only, so a `\|` inside a cell stays part of that
+ * cell.
+ */
+function splitTableRow(line: string): string[] {
+  const t = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  // Negative lookbehind: a `|` not preceded by a backslash is a delimiter.
+  return t.split(/(?<!\\)\|/);
+}
+
+/**
+ * Un-escape a markdown table cell (Notion cells are not markdown, so a `\|`
+ * escape must be undone) and trim surrounding space.
+ */
+function tableCellText(raw: string): string {
+  return raw.replace(/\\\|/g, "|").trim();
+}
+
+function makeTableRow(cells: string[]): NotionTableRow {
+  return {
+    type: "table_row",
+    table_row: { cells: cells.map((c) => lineToRichText(tableCellText(c))) },
+  };
+}
+
+/**
+ * Build a native Notion `table` block from a contiguous run of `|...|` lines.
+ * The separator row is dropped; the first remaining row is the header. Tables
+ * are capped at NOTION_MAX_TABLE_ROWS data rows (a trailing truncation note is
+ * the caller's responsibility) and every cell respects the rich_text cap.
+ */
+function tableRunToBlock(run: string[]): {
+  block: NotionTableBlock;
+  truncatedFrom: number | null;
+} {
+  const rows = run.filter((l) => !isSeparatorRow(l)).map(splitTableRow);
+  const width = rows.reduce((max, r) => Math.max(max, r.length), 0);
+  const header = rows[0] ?? [];
+  const dataRows = rows.slice(1);
+  const totalData = dataRows.length;
+  const keptData =
+    totalData > NOTION_MAX_TABLE_ROWS
+      ? dataRows.slice(0, NOTION_MAX_TABLE_ROWS)
+      : dataRows;
+
+  // Pad ragged rows to a uniform width so Notion accepts the table.
+  const pad = (cells: string[]): string[] =>
+    cells.length >= width
+      ? cells
+      : [...cells, ...Array(width - cells.length).fill("")];
+
+  const children: NotionTableRow[] = [
+    makeTableRow(pad(header)),
+    ...keptData.map((r) => makeTableRow(pad(r))),
+  ];
+
+  return {
+    block: {
+      object: "block",
+      type: "table",
+      table: {
+        table_width: width,
+        has_column_header: true,
+        has_row_header: false,
+        children,
+      },
+    },
+    truncatedFrom: totalData > NOTION_MAX_TABLE_ROWS ? totalData : null,
+  };
+}
+
 /**
  * Convert a markdown report into native Notion block objects so the published
- * page renders headings and bullet lists instead of the literal `#`/`-` source.
- * Line-by-line mapping:
+ * page renders headings, bullet lists, and tables instead of the literal
+ * `#`/`-`/`|` source. Line-by-line mapping:
  *   `# `   → heading_1   `## ` → heading_2   `### ` → heading_3
  *   `- `/`* ` → bulleted_list_item
+ *   a contiguous run of `|...|` lines → one native `table` block (separator row
+ *     dropped, first row as header); tables longer than NOTION_MAX_TABLE_ROWS
+ *     data rows are capped with a trailing truncation note
  *   blank line → skipped (Notion spacing comes from block structure)
  *   anything else → paragraph
  * The report's FIRST line is a redundant top-level `# CopilotKit Docs (MCP) Gap Analysis —
@@ -976,10 +1081,34 @@ function makeBlock(type: NotionBlockType, text: string): NotionBlock {
 export function markdownToNotionBlocks(markdown: string): NotionBlock[] {
   const blocks: NotionBlock[] = [];
   const rawLines = markdown.split("\n");
-  rawLines.forEach((line, idx) => {
+
+  for (let idx = 0; idx < rawLines.length; idx++) {
+    const line = rawLines[idx];
     // Drop the leading duplicate-title H1 line (only the very first line).
-    if (idx === 0 && line.startsWith("# ")) return;
-    if (line.trim() === "") return; // blank → no empty paragraph block
+    if (idx === 0 && line.startsWith("# ")) continue;
+
+    // Gather a contiguous run of table lines and emit one table block.
+    if (isTableLine(line)) {
+      const run: string[] = [];
+      while (idx < rawLines.length && isTableLine(rawLines[idx])) {
+        run.push(rawLines[idx]);
+        idx++;
+      }
+      idx--; // step back: the for-loop's idx++ re-consumes the non-table line
+      const { block, truncatedFrom } = tableRunToBlock(run);
+      blocks.push(block);
+      if (truncatedFrom !== null) {
+        blocks.push(
+          makeBlock(
+            "paragraph",
+            `(table truncated to first ${NOTION_MAX_TABLE_ROWS} rows of ${truncatedFrom})`,
+          ),
+        );
+      }
+      continue;
+    }
+
+    if (line.trim() === "") continue; // blank → no empty paragraph block
     if (line.startsWith("### ")) {
       blocks.push(makeBlock("heading_3", line.slice(4)));
     } else if (line.startsWith("## ")) {
@@ -991,7 +1120,7 @@ export function markdownToNotionBlocks(markdown: string): NotionBlock[] {
     } else {
       blocks.push(makeBlock("paragraph", line));
     }
-  });
+  }
   return blocks;
 }
 


### PR DESCRIPTION
## Summary

Two fixes to the **monthly gap-analysis** report (surfaced when its first-ever run was dispatched — the cron `0 4 1 * *` had never fired):

- **Render report tables as native Notion tables.** `markdownToNotionBlocks` was emitting markdown table rows as literal `| pipe | text |` paragraphs (the "Top query clusters" table was unreadable in Notion). Ported the already-merged weekly-report fix (native `table`/`table_row` blocks, header row, separator dropped, 100-row cap). Verified by a `workflow_dispatch --ref` run that published a real Notion table.
- **Route the gap report to #engr** (`SLACK_WEBHOOK_ENGR`) instead of #oss-alerts. The "new high-severity gaps" report is a successful-run signal for engineering — same routing as the weekly search-report digest. Run **failures** still surface as a red CI run (no Slack). Synced the stale `SLACK_WEBHOOK_OSS_ALERTS` references in the workflow header, the script docstring, and `scripts/gap-analysis/README.md`.

## Test plan

- [x] Red-green: `markdownToNotionBlocks` table input now yields a `table` block (was a pipe-text paragraph). Full suite **6523** green; `tsc` (root + scripts), `prettier`, `actionlint` clean.
- [x] End-to-end verified: branch `workflow_dispatch` published a gap report whose "Top query clusters" rendered as a proper Notion table.
- [x] #engr routing wired to the existing `SLACK_WEBHOOK_ENGR` org secret (verified-good from the weekly digest).

7-agent CR + confirmation round; converged. Pre-existing gap-analysis debt (sortGaps tiebreak, dead `chunkText`, `recoverWrappedArray` empty-named-array, unvalidated fetch casts, workflow cold-start/retention, cluster-cell pipe-escape, README "Plans/Proposals" vs Gap-Reports) tracked as follow-ups — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)