### PR TITLE
atlas: disable keep-alive on the test/proxy LLM client to fix Premature close

### DIFF
--- a/src/atlas/llm.ts
+++ b/src/atlas/llm.ts
@@ -18,6 +18,8 @@
 // the typed shapes below.
 
 import OpenAI from "openai";
+import { Agent as HttpAgent } from "node:http";
+import { Agent as HttpsAgent } from "node:https";
 
 import type { CandidateFragment, Classification } from "./types.js";
 import { mostRestrictiveSensitivity } from "./types.js";
@@ -301,9 +303,26 @@ export class OpenAIDistiller implements LlmDistiller {
             "mock server for tests.",
         );
       }
+      // When a baseURL is configured it is, in this repo, only ever a local
+      // aimock/proxy server (see the comment above). Under the full test suite
+      // every aimock-backed file runs its own in-process server in parallel
+      // (src + the built dist copy, so ~2x the servers), and the OpenAI SDK's
+      // node-fetch pools keep-alive sockets. Under that contention a server can
+      // close an idle pooled socket exactly as a request reuses it, which
+      // node-fetch surfaces as `FetchError: ... Premature close` — a flaky,
+      // load-dependent failure across every aimock test (deterministic in CI).
+      // Pinning a non-keep-alive agent for the mock/proxy case forces a fresh
+      // socket per request, removing the reuse race. Production (no baseURL →
+      // real OpenAI over HTTPS) keeps the SDK's default keep-alive agent.
+      const httpAgent = baseURL
+        ? baseURL.startsWith("https:")
+          ? new HttpsAgent({ keepAlive: false })
+          : new HttpAgent({ keepAlive: false })
+        : undefined;
       this.client = new OpenAI({
         apiKey,
         ...(baseURL ? { baseURL } : {}),
+        ...(httpAgent ? { httpAgent } : {}),
       });
     }
   }


### PR DESCRIPTION
## What

Disable HTTP keep-alive on `OpenAIDistiller`'s client **only when a `baseURL` is configured** (in this repo, always a local aimock/proxy server in tests). Production (no `baseURL` → real OpenAI over HTTPS) keeps the SDK's default keep-alive agent. One-file change in `src/atlas/llm.ts`.

## Root cause

The `Static Quality` `test` job went green on 2026-06-23 and red on 2026-06-25 with **no material code change** — it is a load-dependent flake that turned deterministic under CI's contention, not a date/time bomb.

The Atlas LLM seam (`OpenAIDistiller`) is exercised against an in-process aimock server through the OpenAI SDK, whose node-fetch transport pools keep-alive sockets. Under the full suite, every aimock-backed test file runs its own server in parallel — doubled by the committed-then-rebuilt `dist/` copy. A server can close an idle pooled socket exactly as a request reuses it, which node-fetch surfaces as `FetchError: ... Premature close`. This affected **all** aimock-backed suites (`atlas-llm`, `atlas-exclude`, `atlas-adapter-episodic`, `atlas-artifact-sync`), including the 9 `atlas-artifact-sync` failures in this report.

Pinning a non-keep-alive `http`/`https` Agent for the mock/proxy case forces a fresh socket per request, removing the reuse race.

## Verbatim RED (from CI run 28190002185, 2026-06-25)

```
FAIL src/__tests__/atlas-artifact-sync.test.ts > syncApprovalArtifact (S17) > rejects a checked candidate that an english exclusion rule drops (via aimock)
FAIL src/__tests__/atlas-artifact-sync.test.ts > syncApprovalArtifact (S17) > feeds a checked candidate's CHILD-BLOCK prose to english rules ...
FAIL src/__tests__/atlas-artifact-sync.test.ts > syncApprovalArtifact (S17) > stamps a DATE-ONLY freshness.as_of on a reconstructed badge-less row (X24)
... (9 failed in src + 9 in dist copy)
FetchError: Invalid response body while trying to fetch http://127.0.0.1:45235/v1/chat/completions: Premature close
AssertionError: expected [Function] to throw error including '[atlas/llm] expected a JSON object fr…' but got 'Invalid response body while trying to…'
  Received: "Invalid response body while trying to fetch http://127.0.0.1:37779/v1/chat/completions: Premature close"
```

## Local RED-GREEN proof (real surface: OpenAIDistiller + real aimock server + OpenAI SDK transport)

The race is environment-sensitive (deterministic on CI's contended Ubuntu runner, invisible on a fast 18-core dev box under the natural suite). To prove the fix on the real failure surface, a harness drove a real `OpenAIDistiller` against a real `LLMock` through a TCP proxy that reaps idle keep-alive sockets — modeling a server closing a pooled socket as the client reuses it. The ONLY variable is the keep-alive setting the fix toggles:

```
RED  (keep-alive ON, pre-fix transport):  mode=keepalive ok=23 failures=17   ← socket-reuse race fires
GREEN (non-keep-alive Agent, the fix):    mode=fixed     ok=40 failures=0     ← race eliminated
```

The SDK masks the torn-socket-on-reuse as "Connection error" locally; CI's node-fetch transport surfaces the same race as "Premature close" — same root cause, same fix.

### GREEN: affected suites (src + built dist), post-fix

```
$ npx vitest run "atlas-artifact-sync" "atlas-llm" "atlas-exclude" "atlas-adapter-episodic"  (src + dist)
 Test Files  8 passed (8)
      Tests  156 passed (156)
```

The 9 `atlas-artifact-sync` failures (and the parallel `dist` copies) all pass.

## Other Static Quality gates (run locally, all green)

```
prettier --check          → All matched files use Prettier code style!
tsc --noEmit -p tsconfig.scripts.json → (no errors)
npm run build             → exit 0
check-version-sync.sh     → ✓ Versions in sync: 1.15.4
```

## Scope

One file (`src/atlas/llm.ts`). No changes to notification workflows, RAG config, or anything unrelated. `dist/` is gitignored and regenerated by CI's `npm run build`, so no committed compiled copy to sync.
