### PR TITLE
chore: release v1.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # @copilotkit/pathfinder
 
+## 1.16.0
+
+### Minor Changes
+
+- Config validation accepts minimal RAG configs — `indexing` and per-source `chunk` now optional with defaults (#124)
+- Fixed Atlas distiller LLM client "Premature close" errors, by disabling keep-alive on the test/proxy client (#127)
+
 ## 1.15.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@copilotkit/pathfinder",
-  "version": "1.15.4",
+  "version": "1.16.0",
   "description": "The knowledge server for AI agents — index docs, code, Notion, Slack, and Discord into searchable, agent-accessible knowledge via MCP. Supports OpenAI, Ollama, and local transformers.js embeddings.",
   "type": "module",
   "repository": {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -11,7 +11,7 @@ const program = new Command();
 program
   .name("pathfinder")
   .description("The knowledge server for AI agents")
-  .version("1.15.4");
+  .version("1.16.0");
 
 program
   .command("init")


### PR DESCRIPTION
## Release v1.16.0 (minor)

Releases the user-visible changes already merged to `main`: **#124** (config validation relaxation) and **#127** (Atlas distiller "Premature close" runtime fix). Current `1.15.4` → `1.16.0`. #128 was a CI-only vitest scoping change and is intentionally not in the changelog (does not ship).

### CHANGELOG

## 1.16.0

### Minor Changes

- Config validation accepts minimal RAG configs — `indexing` and per-source `chunk` now optional with defaults (#124)
- Fixed Atlas distiller LLM client "Premature close" errors, by disabling keep-alive on the test/proxy client (#127)

### Version bumps
- `package.json` `version`: 1.15.4 → 1.16.0
- `src/cli.ts` `.version(...)`: 1.15.4 → 1.16.0
- version-sync verified in agreement.

### Publishing
Merging this PR triggers `publish-release.yml` to publish `@copilotkit/pathfinder@1.16.0` to npm and create the tag/GitHub Release. Do not tag or release by hand.