### PR TITLE
Fix broken release→Docker publish pipeline (stale :latest at v1.15.0)

### DIFF
--- a/.github/workflows/publish-docker.yml
+++ b/.github/workflows/publish-docker.yml
@@ -1,7 +1,23 @@
 name: Publish Docker
 on:
   push:
-    tags: ['v*']
+    tags: ["v*"]
+  workflow_call:
+    inputs:
+      tag:
+        description: "Git tag / version to build and publish (e.g. v1.16.0)"
+        required: true
+        type: string
+    secrets:
+      SLACK_WEBHOOK_OSS_ALERTS:
+        description: "Slack webhook for OSS publish alerts (optional)"
+        required: false
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Git tag / version to build and publish (e.g. v1.16.0)"
+        required: true
+        type: string
 permissions: {}
 jobs:
   docker:
@@ -11,8 +27,28 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Resolve image ref
+        id: ref
+        env:
+          # For push:tags the ref is github.ref_name; for workflow_call /
+          # workflow_dispatch it comes from the explicit `tag` input.
+          INPUT_TAG: ${{ inputs.tag }}
+          PUSH_REF: ${{ github.ref_name }}
+        run: |
+          if [ -n "${INPUT_TAG}" ]; then
+            REF="${INPUT_TAG}"
+          else
+            REF="${PUSH_REF}"
+          fi
+          if [ -z "${REF}" ]; then
+            echo "::error::Could not resolve a tag/ref to build"
+            exit 1
+          fi
+          echo "ref=${REF}" >> "$GITHUB_OUTPUT"
+          echo "Building Docker image for ref: ${REF}"
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
+          ref: ${{ steps.ref.outputs.ref }}
           persist-credentials: false
       - uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a # v4.0.0
       - uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
@@ -26,7 +62,7 @@ jobs:
           push: true
           tags: |
             ghcr.io/copilotkit/pathfinder:latest
-            ghcr.io/copilotkit/pathfinder:${{ github.ref_name }}
+            ghcr.io/copilotkit/pathfinder:${{ steps.ref.outputs.ref }}
           platforms: linux/amd64,linux/arm64
           cache-from: type=gha
           cache-to: type=gha,mode=max
@@ -34,7 +70,7 @@ jobs:
         if: success()
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}
-          REF_NAME: ${{ github.ref_name }}
+          REF_NAME: ${{ steps.ref.outputs.ref }}
         run: |
           if [ -n "$SLACK_WEBHOOK" ]; then
             payload=$(jq -nc --arg ref "$REF_NAME" \

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -136,3 +136,20 @@ jobs:
               -H "Content-Type: application/json" \
               -d "$payload" || true
           fi
+
+  # Build & push the Docker image in the SAME run, right after the npm
+  # publish + tag succeed. The tag push above uses GITHUB_TOKEN, which does
+  # NOT trigger the `on: push: tags` event in publish-docker.yml, so we
+  # invoke that workflow directly via workflow_call instead of relying on
+  # the tag-push event firing it.
+  docker:
+    needs: [build, publish]
+    if: needs.build.outputs.published == 'false'
+    uses: ./.github/workflows/publish-docker.yml
+    permissions:
+      contents: read
+      packages: write
+    with:
+      tag: v${{ needs.build.outputs.version }}
+    secrets:
+      SLACK_WEBHOOK_OSS_ALERTS: ${{ secrets.SLACK_WEBHOOK_OSS_ALERTS }}


### PR DESCRIPTION
## Root cause

`publish-release.yml` pushes the `v*` git tag with `secrets.GITHUB_TOKEN` (Ensure git tag exists step, `git push origin "${TAG}"`). **GitHub does not trigger downstream workflows from events made with `GITHUB_TOKEN`**, so `publish-docker.yml` (`on: push: tags: ['v*']`) never fires on a release.

Result: the last Docker publish was the *manually*-tagged **v1.15.0**; v1.15.1–v1.15.4 and **v1.16.0** all skipped Docker. `ghcr.io/copilotkit/pathfinder:latest` has been stale at 1.15.0 — missing the issue-#88 fix that shipped to npm as 1.16.0.

No app-token secrets exist in the repo (`gh secret list` → only `ANTHROPIC_API_KEY`, `NOTION_TOKEN`, `PATHFINDER_ANALYTICS_TOKEN`, `RAILWAY_API_TOKEN`; no variables), so the app-token alternative is not viable. **Chosen approach: make `publish-docker.yml` reusable (`workflow_call`) and invoke it as a job from `publish-release.yml`** — Docker builds in the same run right after npm publish + tag succeed, sidestepping the `GITHUB_TOKEN`-trigger limitation entirely with no new secret.

## Changes

**`.github/workflows/publish-docker.yml`**
- Add `workflow_call` and `workflow_dispatch` triggers, each with a required `tag` input, **while keeping** `push: tags: ['v*']`.
- New "Resolve image ref" step computes `ref` = `inputs.tag` (call/dispatch) or `github.ref_name` (push); checkout uses that ref; image is always tagged `:latest` + `:<ref>`.
- Declares optional `SLACK_WEBHOOK_OSS_ALERTS` `workflow_call` secret. ghcr login + Slack-notify steps preserved; permissions `contents: read` + `packages: write`.

**`.github/workflows/publish-release.yml`**
- New `docker` job: `needs: [build, publish]`, `if: published == 'false'`, `uses: ./.github/workflows/publish-docker.yml` with `tag: v${{ needs.build.outputs.version }}`. Passes the Slack secret explicitly (not `secrets: inherit`) to satisfy zizmor's `secrets-inherit` audit.

## Local Docker build proof (mandatory gate)

`docker buildx build -f Dockerfile -t pathfinder:test --load .` → **success** (real docker driver, not depot):
```
#12 [build 2/2] RUN npm run build  → @copilotkit/pathfinder@1.16.0 build / tsc
#20 exporting to image
#20 exporting manifest list sha256:0f9be1f328201f3b953b2102b121b8db58fb1d34c354dfa2fe2e95ab36acb37e done
#20 naming to docker.io/library/pathfinder:test done
#20 DONE 3.5s
```

## Static gates
- prettier `--check` on both workflows: **clean**
- actionlint: **clean (exit 0)**
- zizmor `--min-severity medium`: **No findings to report** (the `secrets-inherit` medium was resolved by switching to explicit secret pass-through)

## RED → GREEN evidence

**RED (current state, pre-fix):**
- `gh run list --workflow publish-docker.yml` → last run is **v1.15.0** (2026-06-15). No docker run exists for v1.15.1..v1.16.0.
- The v1.16.0 release publish ran successfully (`Publish Release` run 28195343560, 2026-06-25) but **no docker run followed**.
- `docker manifest inspect ghcr.io/copilotkit/pathfinder:v1.16.0` → **manifest unknown** (image does not exist).
- `:latest` digest `sha256:80b0393ce19505520583e0190b979217f6c0bda60f1060082e760fb3e385485b` == `:v1.15.0` digest (GHCR version tags `['v1.15.0','latest']`). So `:latest` IS v1.15.0.

**GREEN (to be confirmed after merge — see backfill):** a `publish-docker` run for v1.16.0 completes `success` and `:latest` digest changes to the v1.16.0 build. Backfill plan below.

## Backfill v1.16.0 (after merge)

The backfill needs the `workflow_dispatch` trigger on `main`, so it runs **after this PR merges**:

```
gh workflow run publish-docker.yml --ref main -f tag=v1.16.0
```

Then verify GREEN:
```
gh run list --workflow publish-docker.yml --limit 1            # new run for v1.16.0
gh run view <id> --json status,conclusion,jobs                 # conclusion: success
docker manifest inspect ghcr.io/copilotkit/pathfinder:v1.16.0  # now exists
docker buildx imagetools inspect ghcr.io/copilotkit/pathfinder:latest    # digest != 80b0393c...
docker buildx imagetools inspect ghcr.io/copilotkit/pathfinder:v1.16.0   # == :latest digest
```

Going forward, every release auto-publishes Docker in the same run as the npm publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)