### PR TITLE
Make index-health HEAD-fetch failures attributable and retry transient blips

### DIFF
--- a/.github/workflows/index-health-monitor.yml
+++ b/.github/workflows/index-health-monitor.yml
@@ -80,6 +80,86 @@ jobs:
           # --- GitHub API: prefetch HEAD commits ---
           HEAD_COMMITS_FILE="/tmp/head-commits.json"
 
+          # Fetch a single repo HEAD with bounded retries on transient GitHub
+          # failures. Echoes either the 8-char SHA, or an "ERROR:<reason>"
+          # sentinel carrying the real HTTP status so the drift check can emit
+          # an attributable message instead of a blind "(GitHub API error)".
+          # Transient (retried): 5xx, 429, and 403 with a rate-limit signal.
+          # A genuine 404 is a hard miss -- fail fast, do not retry.
+          fetch_head_commit() {
+            local repo="$1"
+            local branch="$2"
+            local max_attempts=3
+            local attempt=1
+            local http_code body reset reason
+            while [ "$attempt" -le "$max_attempts" ]; do
+              local response
+              # -w appends the status code on its own line; no -sf so we keep
+              # the body and exit non-zero only on transport failure (timeout).
+              if ! response=$(curl -s --max-time 30 -w $'\n%{http_code}' \
+                -H "Authorization: Bearer $GITHUB_TOKEN" \
+                "https://api.github.com/repos/${repo}/commits/${branch}"); then
+                # Transport-level failure (timeout, connection reset) -- transient.
+                http_code="000"
+                body=""
+              else
+                http_code="${response##*$'\n'}"
+                body="${response%$'\n'*}"
+              fi
+
+              case "$http_code" in
+                2*)
+                  echo "$body" | jq -r '.sha // empty' | head -c 8
+                  return 0
+                  ;;
+                404)
+                  # Hard miss -- bad repo/branch, never going to succeed.
+                  echo "ERROR:HTTP 404, repo or branch not found"
+                  return 0
+                  ;;
+                403)
+                  # 403 is transient only when it carries a rate-limit signal;
+                  # a plain 403 (bad token, no access) is a hard failure.
+                  if echo "$body" | grep -qiE 'rate limit'; then
+                    reason="HTTP 403, secondary rate limit"
+                    reset=$(echo "$body" | jq -r '.. | objects | .reset? // empty' | head -1)
+                  else
+                    echo "ERROR:HTTP 403, access denied"
+                    return 0
+                  fi
+                  ;;
+                429)
+                  reason="HTTP 429, rate limited"
+                  ;;
+                5*)
+                  reason="HTTP ${http_code}, server error"
+                  ;;
+                000)
+                  reason="connection error or timeout"
+                  ;;
+                *)
+                  # Unexpected non-transient status -- report it as-is.
+                  echo "ERROR:HTTP ${http_code}, unexpected response"
+                  return 0
+                  ;;
+              esac
+
+              # Transient: back off and retry (1s, 2s, ...).
+              if [ "$attempt" -lt "$max_attempts" ]; then
+                echo "  retrying ${repo}@${branch} after ${reason} (attempt ${attempt}/${max_attempts})" >&2
+                sleep "$attempt"
+              fi
+              attempt=$((attempt + 1))
+            done
+
+            if [ -n "${reset:-}" ]; then
+              echo "ERROR:${reason}, reset at epoch ${reset}, retried ${max_attempts}x"
+            else
+              echo "ERROR:${reason}, retried ${max_attempts}x"
+            fi
+            return 0
+          }
+
           prefetch_head_commits() {
             local entries=("$@")
             local seen=()
@@ -96,13 +176,8 @@ jobs:
               done
               [ "$already" = true ] && continue
               seen+=("$cache_key")
-              local sha=""
-              local api_response
-              if api_response=$(curl -sf --max-time 30 \
-                -H "Authorization: Bearer $GITHUB_TOKEN" \
-                "https://api.github.com/repos/${repo}/commits/${branch}" 2>/dev/null); then
-                sha=$(echo "$api_response" | jq -r '.sha // empty' | head -c 8)
-              fi
+              local sha
+              sha=$(fetch_head_commit "$repo" "$branch")
               local tmp
               tmp=$(jq --arg k "$cache_key" --arg v "$sha" '.[$k] = $v' "$HEAD_COMMITS_FILE")
               echo "$tmp" > "$HEAD_COMMITS_FILE"
@@ -208,6 +283,12 @@ jobs:
               head_commit=$(get_head_commit "$src_repo" "$src_branch")
               if [ -z "$head_commit" ]; then
                 issues+=("commit drift: ${src_key} -- could not fetch HEAD for ${src_repo}@${src_branch} (GitHub API error)")
+                continue
+              fi
+              # An "ERROR:<reason>" sentinel means the HEAD fetch failed; surface
+              # the real HTTP status instead of a blind "(GitHub API error)".
+              if [ "${head_commit#ERROR:}" != "$head_commit" ]; then
+                issues+=("commit drift: ${src_key} -- could not fetch HEAD for ${src_repo}@${src_branch} (${head_commit#ERROR:})")
                 continue
               fi
 


### PR DESCRIPTION
## What's broken

The index-health monitor's `prefetch_head_commits` curl ran with `-sf ... 2>/dev/null`. On *any* non-2xx or timeout, `-sf` makes curl exit non-zero, `2>/dev/null` throws away the real status, the `sha` stays empty, and every failure collapses into one blind line:

```
could not fetch HEAD for <repo>@<branch> (GitHub API error)
```

So a transient GitHub hiccup on the shared `GITHUB_TOKEN` (secondary-rate-limit 403s, brief 5xx) is indistinguishable from a real problem, and repos flap RED→GREEN run-to-run with nothing actionable in the alert. That's exactly what fired this morning: two false positives (`aimock-docs`, `pathfinder-docs`), different repos, identical blind message.

## The fix

Pull the per-repo fetch into `fetch_head_commit` and make it honest about what happened:

- **Capture the status.** Drop `-sf` and `2>/dev/null`; use `-w '%{http_code}'` to read the HTTP code and keep the body.
- **Retry transient failures** before declaring drift — 3 attempts with bounded backoff on `5xx`, `429`, and `403` that carries a rate-limit signal.
- **Fail fast on a genuine 404** (bad repo/branch) — no point retrying a hard miss. A plain non-rate-limit 403 (bad token / no access) is also treated as a hard failure.
- **Surface the real status** in the alert via an `ERROR:<reason>` sentinel, e.g. `(HTTP 403, secondary rate limit, retried 3x)`, with the rate-limit reset epoch when GitHub gives one.

Scope is the prefetch logic plus the one drift-check consumer line. `actionlint` (with its embedded shellcheck) and `zizmor` both pass clean on the modified file.

## Red-green proof

Exercised against the **real** function logic (extracted verbatim from the workflow) driven at a local mock HTTP server returning forced status codes — same curl surface, no fakes.

### RED (before the fix)

```
===== RED [secondary rate-limit 403] =====
ISSUE: commit drift: docs -- could not fetch HEAD for CopilotKit/CopilotKit@main (GitHub API error)
head-commits.json: { "CopilotKit/CopilotKit:main": "" }

===== RED [server 500] =====
ISSUE: commit drift: docs -- could not fetch HEAD for CopilotKit/CopilotKit@main (GitHub API error)
head-commits.json: { "CopilotKit/CopilotKit:main": "" }

===== RED [happy path 200] =====
HEAD ok: CopilotKit/CopilotKit@main = abcdef12
head-commits.json: { "CopilotKit/CopilotKit:main": "abcdef12" }
```

Both transient failures produce the same blind `(GitHub API error)` with an empty sha. Happy path already worked.

### GREEN (after the fix)

```
===== GREEN [secondary rate-limit 403, never recovers] =====
  retrying CopilotKit/CopilotKit@main after HTTP 403, secondary rate limit (attempt 1/3)
  retrying CopilotKit/CopilotKit@main after HTTP 403, secondary rate limit (attempt 2/3)
ISSUE: commit drift: docs -- could not fetch HEAD for CopilotKit/CopilotKit@main (HTTP 403, secondary rate limit, retried 3x)

===== GREEN [server 500, never recovers] =====
  retrying CopilotKit/CopilotKit@main after HTTP 500, server error (attempt 1/3)
  retrying CopilotKit/CopilotKit@main after HTTP 500, server error (attempt 2/3)
ISSUE: commit drift: docs -- could not fetch HEAD for CopilotKit/CopilotKit@main (HTTP 500, server error, retried 3x)

===== GREEN [secondary rate-limit 403, RECOVERS after 2 failures] =====
  retrying CopilotKit/CopilotKit@main after HTTP 403, secondary rate limit (attempt 1/3)
HEAD ok: CopilotKit/CopilotKit@main = abcdef12

===== GREEN [hard 404 (fail-fast, no retry)] =====
ISSUE: commit drift: docs -- could not fetch HEAD for CopilotKit/CopilotKit@main (HTTP 404, repo or branch not found)

===== GREEN [happy path 200] =====
HEAD ok: CopilotKit/CopilotKit@main = abcdef12
```

The transient cases now retry then emit the **real HTTP status**; the recovering case succeeds after one retry and yields the actual SHA (no false drift); the 404 fails fast with zero retries; the happy path still returns the real SHA.
