### PR TITLE
Probe the RAG-dedup gate with the distilled title, not the full body

### DIFF
--- a/src/__tests__/atlas-rag-dedup.test.ts
+++ b/src/__tests__/atlas-rag-dedup.test.ts
@@ -226,6 +226,67 @@ describe("dedupAgainstRagCorpus — verbatim overlap is MARKED, never dropped", 
   });
 });
 
+describe("dedupAgainstRagCorpus — a LONG candidate is probed by its distilled title, not its full body (lexical-endpoint regression)", () => {
+  it("marks a long candidate whose full-body query would return NOTHING but whose title query finds the overlapping corpus passage", async () => {
+    // Regression guard for the full-body-probe bug (fixed 2026-07-06): the live
+    // endpoint is `plainto_tsquery`, which ANDs every query lexeme. A long
+    // (memory-sourced) candidate body ANDs hundreds of terms and matches NO
+    // single chunk ⇒ 0 hits ⇒ empty denominator ⇒ the gate never marked the
+    // overlap. This stub reproduces that AND-based behavior deterministically:
+    // it returns the overlapping corpus hit ONLY for a SHORT query (the length
+    // of a distilled title), and 0 hits for a long full-body query. The gate
+    // must send the short title query, so the duplicate is found and MARKED.
+    const distilledTitle = "AWS AgentCore deployment posture";
+    // A long body (>500 chars) that genuinely restates an indexed corpus
+    // passage — this is the shape of a memory-sourced fact.
+    const longBody = `${distilledTitle} — ${"the runtime persists conversation memory across sessions and gates every tool call through a governance adapter so operators can review, approve, or redirect agent actions before they execute. ".repeat(6)}`;
+    const cand = makeCandidate({
+      canonical_key: "memory:cpk-runtime:agentcore-long",
+      subsystem: "cpk-runtime",
+      title: distilledTitle,
+      content: longBody,
+    });
+    // The corpus hit that overlaps the candidate body verbatim (title + body).
+    const corpusHit = verbatimHit(`${cand.title}\n${cand.content}`);
+
+    // Stub the AND-based lexical endpoint: a long query (a full body) matches
+    // nothing; a short query (the distilled title) returns the overlapping hit.
+    const SHORT_QUERY_MAX = 120;
+    const searchMock = vi.fn(async (q: { text: string }) =>
+      q.text.length <= SHORT_QUERY_MAX ? [corpusHit] : [],
+    );
+    const client = { search: searchMock } as unknown as AtlasHttpClient;
+
+    const out = await dedupAgainstRagCorpus([cand], { client });
+
+    // The gate sent the SHORT title query (well under the stub's cutoff), so the
+    // duplicate was found and MARKED — never dropped.
+    expect(searchMock).toHaveBeenCalledTimes(1);
+    expect(searchMock.mock.calls[0][0].text.length).toBeLessThanOrEqual(
+      SHORT_QUERY_MAX,
+    );
+    expect(out).toHaveLength(1);
+    expect(out[0].provenance.validated_against).toBeTruthy();
+    expect(out[0].evidence.some((e) => e.kind === "fused_from")).toBe(true);
+    expect(() => CandidateSchema.parse(out[0])).not.toThrow();
+  });
+
+  it("PROOF that the OLD full-body probe would have MISSED it: a full-body query against the same AND-based stub returns nothing", async () => {
+    // Companion to the above — pins WHY the fix is load-bearing. If the gate
+    // reverted to sending the full body, this same stub returns [] and the
+    // candidate would ride through UN-marked (the bug).
+    const distilledTitle = "AWS AgentCore deployment posture";
+    const longBody = `${distilledTitle} — ${"the runtime persists conversation memory across sessions and gates every tool call through a governance adapter. ".repeat(6)}`;
+    const fullBody = `${distilledTitle}\n${longBody}`;
+    const SHORT_QUERY_MAX = 120;
+    const stub = (text: string) => (text.length <= SHORT_QUERY_MAX ? [1] : []);
+    // The full body is long ⇒ the AND-based stub returns nothing (the bug).
+    expect(stub(fullBody)).toHaveLength(0);
+    // The distilled title is short ⇒ the stub returns the hit (the fix).
+    expect(stub(distilledTitle).length).toBeGreaterThan(0);
+  });
+});
+
 describe("dedupAgainstRagCorpus — batch + count invariant (NEVER drops)", () => {
   it("returns exactly as many candidates as it received (mixed overlap/no-overlap)", async () => {
     const overlapping = makeCandidate({
@@ -339,12 +400,13 @@ describe("dedupAgainstRagCorpus — the §6.2 duplication mark is rank-NEUTRAL",
   });
 });
 
-describe("dedupAgainstRagCorpus — long candidate bodies are truncated before the probe", () => {
-  it("bounds the probe text length so a huge body cannot blow the query-string limit", async () => {
-    // A candidate whose distilled body is far larger than any safe query-string
-    // budget. The probe text the gate sends must be truncated, not the full body.
-    const hugeContent = "lorem ipsum dolor sit amet ".repeat(2000); // ~54 KB
-    const cand = makeCandidate({ content: hugeContent });
+describe("dedupAgainstRagCorpus — a pathologically long title is truncated before the probe", () => {
+  it("bounds the probe text length so a huge title cannot blow the query-string limit", async () => {
+    // The probe query is the distilled TITLE, so the query-string budget applies
+    // to a pathologically long title. The probe text the gate sends must be
+    // truncated to a safe leading slice, not sent whole.
+    const hugeTitle = "lorem ipsum dolor sit amet ".repeat(2000); // ~54 KB
+    const cand = makeCandidate({ title: hugeTitle });
 
     let probedText = "";
     const searchMock = vi.fn(async (q: { text: string }) => {
@@ -359,10 +421,10 @@ describe("dedupAgainstRagCorpus — long candidate bodies are truncated before t
     expect(searchMock).toHaveBeenCalledTimes(1);
     // The probe text is bounded well under a typical URL limit (a leading slice
     // is sufficient for the containment heuristic). It must be far smaller than
-    // the ~54 KB body.
+    // the ~54 KB title.
     expect(probedText.length).toBeGreaterThan(0);
     expect(probedText.length).toBeLessThanOrEqual(2048);
-    expect(probedText.length).toBeLessThan(hugeContent.length);
+    expect(probedText.length).toBeLessThan(hugeTitle.length);
   });
 });
 
@@ -374,16 +436,19 @@ describe("dedupAgainstRagCorpus — probe truncation is byte-aware, not just cha
   // failure, and 5 consecutive non-ASCII candidates abort the run with an
   // "endpoint down" misdiagnosis. The probe text must bound the ENCODED
   // length, not the char count.
-
-  // ≥ MIN_CANDIDATE_TOKENS distinct ASCII tokens in the title (tokenSet only
-  // extracts [a-z0-9] runs — CJK contributes no tokens, and a token-poor
-  // candidate would skip the probe entirely), with the CJK bulk in content.
+  //
+  // The probe query is the distilled TITLE, so the byte-bound guard applies to a
+  // pathological (non-ASCII, over-long) TITLE. The CJK bulk therefore lives in
+  // the title here; ASCII tokens in content keep the candidate over the
+  // MIN_CANDIDATE_TOKENS floor (measured over the FULL body, so a token-poor
+  // title alone would otherwise skip the probe).
   function cjkCandidate(i: number): Candidate {
     return makeCandidate({
       canonical_key: `github-pr:cpk-runtime:cjk-${i}`,
-      title: `knowledge base duplicate detection probe ${i}`,
-      content:
-        `候補の重複検出は照合対象の本文全体で行う必要がある第${i}`.repeat(120), // ~3000 chars of BMP CJK — far past the 2048-char slice
+      title: `候補の重複検出は照合対象の本文全体で行う必要がある第${i}`.repeat(
+        120,
+      ), // ~3000 chars of BMP CJK — far past the 2048-char slice
+      content: `knowledge base duplicate detection probe ${i}`,
     });
   }
 
@@ -441,8 +506,11 @@ describe("dedupAgainstRagCorpus — probe truncation is byte-aware, not just cha
     // failure. The probe text must back off to a pair boundary (richText
     // surrogate-split precedent).
     const cand = makeCandidate({
-      title: "emoji heavy reaction thread distilled summary",
-      content: "😀".repeat(2000), // 4000 code units, all surrogate pairs
+      // The probe query is the TITLE, so the surrogate-boundary hazard lives
+      // there: an over-long emoji-heavy title. ASCII tokens in content keep the
+      // candidate over the MIN_CANDIDATE_TOKENS floor.
+      title: "😀".repeat(2000), // 4000 code units, all surrogate pairs
+      content: "emoji heavy reaction thread distilled summary",
     });
     let probedText = "";
     const searchMock = vi.fn(async (q: { text: string }) => {
@@ -464,11 +532,32 @@ describe("dedupAgainstRagCorpus — probe truncation is byte-aware, not just cha
     );
   });
 
-  it("candidateProbeQueryText leaves a short ASCII candidate untouched (no needless truncation)", async () => {
+  it("candidateProbeQueryText sends the distilled TITLE, not the full body (lexical-endpoint fix)", async () => {
+    // The probe query is the SHORT, high-signal distilled title — NOT the full
+    // title+body. The lexical `plainto_tsquery` endpoint ANDs every query
+    // lexeme, so a long full-body query returns 0 hits and the gate never marks
+    // a long (memory-sourced) duplicate; the title is the short topical query
+    // the engine returns strong hits for. (Regression guard for the
+    // full-body-probe bug fixed 2026-07-06.)
     const cand = makeCandidate();
-    expect(candidateProbeQueryText(cand)).toBe(
-      `${cand.title}\n${cand.content}`.trim(),
-    );
+    expect(candidateProbeQueryText(cand)).toBe(cand.title.trim());
+    // Explicitly NOT the full body: the content prose must not ride the query.
+    expect(candidateProbeQueryText(cand)).not.toContain(cand.content);
+  });
+
+  it("candidateProbeQueryText query is the TITLE ALONE — subsystem/claimSlugHint synthetic slugs are NOT appended (they AND the lexical match to zero)", async () => {
+    // The endpoint's tsquery is AND-based: appending the structural key
+    // components (synthetic slugs like `cpk-runtime`, rarely verbatim in a prose
+    // chunk) would AND the match down to zero, re-opening the same "0 hits ⇒
+    // never marked" gap (verified against prod: title alone → hits,
+    // title+subsystem → 0). Pin the probe to the title alone.
+    const cand = makeCandidate({
+      subsystem: "cpk-runtime",
+      title: "Two-layer shim forwards v1 calls to the v2 engine",
+    });
+    const probe = candidateProbeQueryText(cand);
+    expect(probe).toBe(cand.title.trim());
+    expect(probe).not.toContain("cpk-runtime");
   });
 });
 
@@ -479,13 +568,14 @@ describe("dedupAgainstRagCorpus — malformed upstream content (lone MID-STRING 
     // module's never-abort invariant; moving the call INSIDE the try would
     // instead mis-count the throw as a PROBE failure toward the fail-fast
     // streak). So the function must be throw-proof against malformed UTF-16
-    // already embedded in upstream title/content — not just at the slice
-    // boundary, which is all trimLoneTrailingHighSurrogate covers.
+    // already embedded in the upstream TITLE (the probe source) — not just at
+    // the slice boundary, which is all trimLoneTrailingHighSurrogate covers.
     const cand = makeCandidate({
       canonical_key: "github-pr:cpk-runtime:lone-surrogate",
-      title: "malformed upstream content carries a lone surrogate",
-      // A lone HIGH surrogate and a lone LOW surrogate, both mid-string.
-      content: "prose before \uD800 the gap \uDFFF prose after the surrogates",
+      // A lone HIGH surrogate and a lone LOW surrogate, both mid-string, in the
+      // TITLE (which is what the probe query is built from).
+      title: "prose before \uD800 the gap \uDFFF prose after the surrogates",
+      content: "malformed upstream title carries a lone surrogate",
     });
     let probedText = "";
     const searchMock = vi.fn(async (q: { text: string }) => {
@@ -516,16 +606,15 @@ describe("candidateProbeQueryText — the byte bound is measured with the WIRE e
     // `client.search` serializes the query with `new URLSearchParams({ text })`
     // (form-urlencoded) — NOT encodeURIComponent. The two diverge on
     // `! ' ( ) ~` (kept literal by encodeURIComponent = 1 char each, but
-    // percent-encoded on the wire = 3 chars each). Composition COMPUTED so the
-    // old encodeURIComponent measure stays ≤ MAX_PROBE_TEXT_ENCODED_BYTES (no
-    // shrink fires) while the real wire length blows ~3 KB past it:
-    //   sliced 2048 chars = title 33 (28 letters + 5 spaces) + "\n"
-    //                     + 1504 "!" + 510 CJK
-    //   encodeURIComponent: 28 + 5*3 + 3 + 1504*1 + 510*9 = 6140 ≤ 6144
-    //   wire (URLSearchParams): 28 + 5*1 + 3 + 1504*3 + 510*9 = 9138 > 6144
+    // percent-encoded on the wire = 3 chars each). The probe query is the
+    // distilled TITLE, so the pathological `!'()~`-dense mixed-script payload
+    // lives there. The 2048-char slice is 1504 "!" + 544 CJK; its wire length
+    // (1504*3 + 544*9 = 9408) blows well past MAX_PROBE_TEXT_ENCODED_BYTES, so
+    // the byte-aware shrink must fire and bring it within budget — and it must
+    // do so measured with the WIRE encoder, not encodeURIComponent.
     const cand = makeCandidate({
-      title: "bang paren tilde wire bound probe",
-      content: "!".repeat(1504) + "気".repeat(600),
+      title: "!".repeat(1504) + "気".repeat(600),
+      content: "bang paren tilde wire bound probe body tokens",
     });
 
     const probedText = candidateProbeQueryText(cand);
@@ -774,7 +863,9 @@ describe("dedupAgainstRagCorpus — a probe error never aborts the batch", () =>
     // subsequent candidate is still probed and (here) annotated.
     const flaky = makeCandidate({
       canonical_key: "github-pr:cpk-runtime:flaky-probe",
-      title: "Probe blows up for this one",
+      // The distinguishing token lives in the TITLE, since the probe query is
+      // the distilled title (not the body).
+      title: "Probe transiently fails for this one",
       content: "Prose whose corpus probe transiently fails.",
     });
     const overlapping = makeCandidate({

--- a/src/atlas/rag-dedup.ts
+++ b/src/atlas/rag-dedup.ts
@@ -30,6 +30,15 @@
 // `GET /api/search` is LIVE on the server: lexical tsvector search over the
 // indexed chunks table, mounted alongside the atlas ratification routes and
 // authenticated with the same bearer (see src/server.ts / client.ts).
+//
+// Probe-query shape: because that endpoint is LEXICAL (tsvector) and AND-based,
+// the probe sends a SHORT, high-signal query — the candidate's distilled
+// `title` alone — NOT the full body. A full-body query ANDs hundreds of terms
+// and returns ZERO hits, which silently disabled the gate for long
+// (memory-sourced) facts (empty denominator ⇒ never marked). The overlap
+// DECISION is still computed against the FULL candidate token set — the short
+// query only FINDS the corpus passages; it does not weaken the overlap judgment
+// (see candidateProbeSource / candidateProbeQueryText below).
 
 import type { AtlasHttpClient, SearchHit } from "../atlas/client.js";
 import { RAG_CORPUS_OVERLAP_REF_PREFIX } from "../atlas/canonicalize.js";
@@ -150,8 +159,11 @@ export async function dedupAgainstRagCorpus(
       continue;
     }
 
-    // The query text sent over the network is truncated (URL-length safety);
-    // the containment denominator above is NOT — see candidateProbeQueryText.
+    // The query text sent over the network is a SHORT, high-signal query built
+    // from the distilled title (+ subsystem/claimSlugHint), not the full body —
+    // a full-body query returns 0 hits on the lexical endpoint. The containment
+    // denominator above is still the FULL candidate token set — see
+    // candidateProbeQueryText / candidateProbeSource.
     const probeQueryText = candidateProbeQueryText(cand);
     // Set iff the probe itself resolved this iteration — distinguishes a probe
     // failure (counts toward the fail-fast streak) from a post-probe failure
@@ -228,31 +240,70 @@ function candidateFullText(cand: Candidate): string {
   return `${cand.title}\n${cand.content}`.trim();
 }
 
-// The text we send to `client.search` over the wire. SAME surface as
-// candidateFullText, but truncated so the probe stays within `GET` query-string
-// limits — a large body would otherwise 414/400 and be swallowed by the
-// per-candidate try/catch (a silent no-op for the largest candidates), or — for
-// non-ASCII corpora — manufacture a 4xx PROBE-failure streak that trips the
-// consecutive fail-fast with an "endpoint down" misdiagnosis (see
-// MAX_PROBE_TEXT_ENCODED_BYTES). Truncation is therefore TWO-stage: the cheap
-// char slice first, then a proportional shrink until the WIRE-encoded length
-// (wireEncodedLength — the same URLSearchParams serialization client.search
-// produces) fits the byte budget (one pass usually lands it; a mixed-script
-// tail may take a second). This function must NEVER throw: it is called
-// OUTSIDE the per-candidate try (a throw here would unwind the whole harvest;
-// moving the call INSIDE would instead mis-count the throw as a probe failure
-// toward the fail-fast streak). So the slice is first sanitized to WELL-FORMED
-// UTF-16 — a lone surrogate already embedded mid-string in malformed upstream
-// title/content becomes U+FFFD — and cut points stay surrogate-safe (richText
-// precedent): a boundary inside an astral pair backs off one unit. A leading
-// slice is sufficient to *find* the overlapping corpus passage; the precision
-// of the overlap decision is then computed against the FULL candidate text
-// (candidateFullText), not this truncated query. Exported for the byte-bound
-// test (fragmentIdentity precedent).
+// The SHORT, high-signal text the probe query is built from — the candidate's
+// already-distilled `title`. This is what we send to the LEXICAL search
+// endpoint to FIND corpus passages; it is deliberately NOT candidateFullText (a
+// full body returns 0 hits on a tsvector engine — see candidateProbeQueryText).
+//
+// Title-ONLY, deliberately: the endpoint's tsvector query is AND-based (every
+// query term must appear in a chunk to match), so every EXTRA term can only
+// shrink the result set, never grow it. Appending the STRUCTURAL key components
+// (`subsystem` / `claimSlugHint`) — which are synthetic slugs like
+// `cpk-runtime`, rarely present verbatim in a prose chunk — ANDs the match down
+// to ZERO, re-introducing the very "0 hits ⇒ never marked" gap this fix closes
+// (verified against prod 2026-07-06: title alone → 5 hits, title+subsystem →
+// 0). The distilled title is by construction the short topical query the engine
+// returns strong hits for; keep the probe to exactly that. If a future
+// candidate has a weak/empty title, the sub-token floor (MIN_CANDIDATE_TOKENS,
+// measured over the FULL body) already short-circuits the probe — a missed
+// annotation, never a lost row.
+//
+// The schema requires `title` non-empty, so this is never empty for a real
+// candidate; the `.trim()` guards a whitespace-only pathological title (which
+// then falls to the MIN_CANDIDATE_TOKENS floor as above).
+function candidateProbeSource(cand: Candidate): string {
+  return cand.title.trim();
+}
+
+// The text we send to `client.search` over the wire. This is DELIBERATELY NOT
+// candidateFullText: `GET /api/search` is a LEXICAL tsvector search, and a
+// long, multi-hundred-token full-body query returns ZERO hits on that engine
+// (every extra term ANDs into the query, and a memory-sourced fact's full body
+// of ~500–2000+ chars has no single corpus chunk that satisfies all of them).
+// A full-body probe therefore silently disabled the gate for exactly the LONG
+// (memory-sourced) facts it most needs to catch: 0 hits ⇒ empty containment
+// denominator ⇒ never marked as overlap (confirmed empirically 2026-07-06 —
+// a genuine corpus duplicate wrapped in narrative prose came back NOVEL, while
+// the SAME candidate's distilled title returned the overlapping chunk).
+//
+// So the probe is a SHORT, high-signal query built from the candidate's
+// already-distilled `title` — the same short topical phrase a human would type
+// to find this fact, and precisely what the tsvector engine returns strong hits
+// for. The title ALONE (not + subsystem/claimSlugHint): the engine's query is
+// AND-based, so every extra synthetic-slug term ANDs the match down toward zero
+// (see candidateProbeSource). The overlap DECISION is still computed against
+// the FULL candidate token set (candidateFullText) in bestOverlap — this only
+// changes what we send to FIND candidate corpus passages, not how precisely we
+// judge the overlap.
+//
+// The char/byte-safety machinery below is retained: a title can still carry
+// malformed UTF-16 or non-ASCII that expands on the wire, and this function is
+// still called OUTSIDE the per-candidate try (a
+// throw here would unwind the whole harvest; moving the call INSIDE would
+// instead mis-count the throw as a probe failure toward the fail-fast streak).
+// So the query is first sanitized to WELL-FORMED UTF-16 — a lone surrogate
+// already embedded mid-string in a malformed upstream title becomes U+FFFD —
+// truncated to the char slice, then proportionally shrunk until the
+// WIRE-encoded length (wireEncodedLength — the same URLSearchParams
+// serialization client.search produces) fits the byte budget, with cut points
+// kept surrogate-safe (richText precedent): a boundary inside an astral pair
+// backs off one unit. In practice a distilled title is far under both bounds,
+// so no truncation fires; the bounds are belt-and-braces for a pathological
+// title. Exported for the byte-bound test (fragmentIdentity precedent).
 export function candidateProbeQueryText(cand: Candidate): string {
   let text = toWellFormedUtf16(
     trimLoneTrailingHighSurrogate(
-      candidateFullText(cand).slice(0, MAX_PROBE_TEXT_CHARS),
+      candidateProbeSource(cand).slice(0, MAX_PROBE_TEXT_CHARS),
     ),
   );
   let encodedLength = wireEncodedLength(text);


### PR DESCRIPTION
## Root cause

`dedupAgainstRagCorpus` (`src/atlas/rag-dedup.ts`) probed the live RAG search endpoint (`GET /api/search` on `mcp.copilotkit.ai`) with the candidate's **full** distilled `title` + `content` body (truncated to ~2 KB) as a single query.

That endpoint is a **lexical** search: `textSearchChunks` (`src/db/queries.ts`) runs `tsv @@ plainto_tsquery('english', $1)`, and `plainto_tsquery` **ANDs every query lexeme** — a chunk matches only if it contains *all* of them. A long, memory-sourced candidate body has hundreds of distinct lexemes spread across many sources, so **no single indexed chunk contains them all → 0 hits**. With zero hits the containment denominator is empty, so the gate classified the candidate NOVEL and never marked the overlap.

Net: the "must not duplicate the existing RAG corpus" bar (spec §6.2 / §10 bar 6) was **silently unenforced for long (memory-sourced) facts** — exactly the candidates most likely to re-index already-indexed prose. Short topical queries were unaffected (a distilled title matches fine).

## The fix

Send a **short, high-signal query built from the candidate's already-distilled `title`** instead of the full body. The title is the short topical phrase the tsvector engine returns strong hits for.

- **Title alone**, deliberately: appending the structural key components (`subsystem` / `claimSlugHint` — synthetic slugs like `cpk-runtime`, rarely present verbatim in a prose chunk) ANDs the lexical match back down to zero, re-opening the same gap. Verified against prod: `"AWS AgentCore"` → 5 hits, `"AWS AgentCore cpk-runtime"` → 0 hits.
- The overlap **decision is unchanged**: containment is still computed over the FULL candidate token set (`candidateFullText`); only the query used to *find* corpus passages is shortened.
- The mark-only / never-drop invariant, idempotent re-annotation, fail-fast streak, and the char/byte/surrogate-safety machinery are all retained (the byte-bound guard now applies to a pathological title). No LLM introduced into the dedup path.

Deterministic, no new dependencies, no prod writes.

## RED → GREEN proof (live prod search surface)

Exercised the real `AtlasHttpClient` + real `dedupAgainstRagCorpus` against `https://mcp.copilotkit.ai/api/search` (read-only). The candidate is a genuine long corpus duplicate: a real indexed chunk (`AWS AgentCore`, `docs.copilotkit.ai/deploy/agentcore`) restated with a short synthesizing reframe — the shape of a distilled memory fact. Same candidate, same endpoint, only the code differs.

**RED (before — full-body probe):**
```
=== CANDIDATE (a genuine corpus duplicate) ===
title: AWS AgentCore
content length: 2569

=== PROBE QUERY that the gate actually sends ===
probe length: 2048
probe head: AWS AgentCore - **Human-in-the-loop** — let users review, approve, or redirect agent actions - **AgentCore memory** — conversation history persists across sessi

=== DIRECT probe of the gate's query against prod ===
hits: 0

=== GATE RESULT (real dedupAgainstRagCorpus vs prod) ===
out length: 1
validated_against: (none — classified NOVEL)
fused_from evidence: []

>>> RED: the genuine corpus duplicate was NOT marked (gate unenforced for long facts).
```

**GREEN (after — title probe):**
```
=== CANDIDATE (a genuine corpus duplicate) ===
title: AWS AgentCore
content length: 2569

=== PROBE QUERY that the gate actually sends ===
probe length: 13
probe head: AWS AgentCore

=== DIRECT probe of the gate's query against prod ===
hits: 5

=== GATE RESULT (real dedupAgainstRagCorpus vs prod) ===
out length: 1
validated_against: rag-corpus-overlap:https://docs.copilotkit.ai/deploy/agentcore
fused_from evidence: [{"kind":"fused_from","ref":"rag-corpus-overlap:https://docs.copilotkit.ai/deploy/agentcore"}]

>>> GREEN: the genuine corpus duplicate was MARKED as overlap.
```

The live probe was run via a temporary harness (deleted before commit; not in the diff).

## Files changed

- `src/atlas/rag-dedup.ts` — new `candidateProbeSource` (title-only); `candidateProbeQueryText` builds the probe from it; header/inline comments updated.
- `src/__tests__/atlas-rag-dedup.test.ts` — new regression tests (title probe used, subsystem/claimSlugHint NOT appended, and a long candidate that would be missed by the full-body probe is marked via the title probe); byte/surrogate-safety tests re-pointed to a pathological title (the new probe source).

## Tests / quality gate

- `atlas-*` suite: **33 files, 825 tests pass** (30 in `atlas-rag-dedup`).
- Full suite: **171 files, 3195 tests pass** (`npm test`).
- `npm run build` (tsc): clean. `npx tsc --noEmit -p tsconfig.scripts.json`: clean. Prettier: my two files are clean.
- Note: the `prettier` CI job is **already failing on `main`** (11 pre-existing unformatted files, none touched here) — a broken-main condition unrelated to this change; left out of scope to keep the diff focused.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
