### PR TITLE
Preserve concrete specifics in Atlas distillation rewrites

### DIFF
--- a/src/__tests__/atlas-distillation-gate.test.ts
+++ b/src/__tests__/atlas-distillation-gate.test.ts
@@ -171,7 +171,47 @@ const FLIP_DISTILLED_TO_RESTATEMENT_CONTENT =
   `${FLIP_DISTILLED_TO_RESTATEMENT_MARKER}: the PR bumps the http client ` +
   "dependency to the latest patch release.";
 
+// PRESERVE-SPECIFICS gate-plumbing guard (companion to the real-LLM eval in
+// atlas-distillation-rewrite-eval.test.ts): an admin-ops-style candidate whose
+// MOCKED judge returns a `rewritten` verdict that RETAINS every concrete token.
+// This locks the CONTRACT that the gate flows the judge's rewrite content/title
+// through INTACT — it is a replay, so it stays green regardless of the prompt
+// (it is the plumbing guard, NOT the prompt proof). The prompt proof lives in
+// the opt-in real-LLM eval.
+const PRESERVE_MARKER = "PRESERVE-SPECIFICS-CASE";
+const PRESERVE_TITLE = `PR #412 (${PRESERVE_MARKER}): unify admin auth on ANALYTICS_TOKEN`;
+const PRESERVE_CONTENT =
+  `${PRESERVE_MARKER}: adds a POST /admin/:op endpoint, validates the ` +
+  "ANALYTICS_TOKEN header with timingSafeEqual, returns 202/400/401/503, and " +
+  "sets trust_proxy fail-closed. Removes the old PATHFINDER_ADMIN_TOKEN.";
+// The judge's rewrite: sharpened WHY prose that RETAINS every concrete token
+// (the post-fix behavior the real-LLM eval proves the prompt now produces).
+const PRESERVE_REWRITE_TITLE =
+  "POST /admin/:op unifies admin auth on ANALYTICS_TOKEN, timing-safe";
+const PRESERVE_REWRITE_CONTENT =
+  "The POST /admin/:op endpoint validates the ANALYTICS_TOKEN header with " +
+  "timingSafeEqual so a wrong token cannot be told apart by response timing; it " +
+  "returns 202 on success, 400 on a malformed body, 401 on a bad token, and 503 " +
+  "when overloaded. trust_proxy is fail-closed: an unresolved forwarded client " +
+  "IP is rejected. Collapsing PATHFINDER_ADMIN_TOKEN into ANALYTICS_TOKEN leaves " +
+  "operators one credential and one auth path to audit.";
+
 const fixtures: Fixture[] = [
+  // PRESERVE-SPECIFICS plumbing guard: rewritten verdict retaining the tokens.
+  {
+    match: {
+      systemMessage: DISTILL_SYSTEM_MARKER,
+      userMessage: PRESERVE_MARKER,
+    },
+    response: {
+      content: JSON.stringify({
+        verdict: "rewritten",
+        reason: "sharpened the WHY while keeping every endpoint/code/symbol",
+        title: PRESERVE_REWRITE_TITLE,
+        content: PRESERVE_REWRITE_CONTENT,
+      }),
+    },
+  },
   // Salvageable → rewritten (gated on the salvage marker in the user payload).
   {
     match: {
@@ -622,6 +662,36 @@ describe("enforceDistillation (aimock-backed real judge)", () => {
       ctxOn(process.cwd()),
     );
     expect(validated.approvable).toBe(true);
+  });
+
+  it("rewritten verdict flows the judge's specifics-preserving rewrite through INTACT (PRESERVE-SPECIFICS plumbing guard)", async () => {
+    // Companion to the opt-in real-LLM eval: that eval proves the PROMPT makes a
+    // real model retain concrete tokens on a rewrite; THIS aimock replay locks
+    // the GATE-PLUMBING contract — whatever content/title the judge returns on a
+    // `rewritten` verdict is what enforceDistillation swaps in, verbatim. So when
+    // the judge returns a specifics-preserving rewrite, the concrete tokens
+    // survive the gate.
+    const cand = makeCandidate({
+      title: PRESERVE_TITLE,
+      content: PRESERVE_CONTENT,
+      knowledge_type: "security",
+    });
+
+    const [gated] = await enforceDistillation([cand], { judge });
+
+    // Title/content are swapped for the judge's specifics-preserving rewrite.
+    expect(gated.title).toBe(PRESERVE_REWRITE_TITLE);
+    expect(gated.content).toBe(PRESERVE_REWRITE_CONTENT);
+    // The concrete verifiable detail flows through the gate intact.
+    expect(gated.content).toContain("POST /admin/:op");
+    expect(gated.content).toContain("timingSafeEqual");
+    expect(gated.content).toMatch(/\b401\b/);
+    expect(gated.content).toContain("trust_proxy");
+    expect(gated.title).toContain("POST /admin/:op");
+    // Salvage breadcrumb, not the restatement floor.
+    expect(gated.provenance.validated_against ?? "").toContain(
+      REWRITTEN_FROM_RESTATEMENT_MARKER,
+    );
   });
 
   it("restatement→rewritten flip strips a PRIOR run's stale RESTATEMENT_MARKER so validate no longer floors the salvage", async () => {

--- a/src/__tests__/atlas-distillation-gate.test.ts
+++ b/src/__tests__/atlas-distillation-gate.test.ts
@@ -517,6 +517,9 @@ describe("enforceDistillation (aimock-backed real judge)", () => {
   });
 
   beforeEach(() => {
+    // Defensive/no-op for these fixtures: aimock only consults match counts for
+    // sequenceIndex fixtures, and every fixture here matches on message content
+    // (no sequenceIndex). Kept so adding a sequenced fixture later stays correct.
     mock.resetMatchCounts();
   });
 

--- a/src/__tests__/atlas-distillation-rewrite-eval.test.ts
+++ b/src/__tests__/atlas-distillation-rewrite-eval.test.ts
@@ -1,0 +1,88 @@
+// Layer-2 REAL-LLM eval for the distillation judge's REWRITE branch (Theme A.1).
+//
+// ORG RULE: an aimock REPLAY test cannot prove a PROMPT change — the fixture is
+// canned, so it will pass regardless of what the prompt says. Proving that
+// DISTILLATION_SYSTEM_PROMPT actually stops the judge from paraphrasing away
+// concrete verifiable detail requires exercising the REAL failure surface: a
+// REAL OpenAI call through the REAL prompt. This file does exactly that.
+//
+// It is OPT-IN — gated on `OPENAI_API_KEY`. In normal CI (no key) the whole
+// suite is SKIPPED via `describe.skipIf`, so it never spends tokens or flakes on
+// missing credentials. It runs only when a real key is present (the red-green
+// proof for the prompt fix).
+//
+// The bug it guards: on a `rewritten` verdict the model used to paraphrase a
+// precise HOW/WHAT claim ("POST /admin/:op returns 401 via timingSafeEqual")
+// into generic WHY prose ("unified authentication enhances security"), dropping
+// every concrete identifier. The fix teaches the judge to RETAIN every
+// endpoint/status-code/symbol/config on a rewrite (or fall back to `distilled`
+// pass-through when it cannot). So the assertion is: whatever the verdict, the
+// returned content must still carry the source's concrete tokens.
+
+import { describe, expect, it } from "vitest";
+
+import { OpenAIDistiller } from "../atlas/llm.js";
+import type { DistillationJudgeInput } from "../atlas/llm.js";
+
+// The model the code actually uses (OpenAIDistiller's DEFAULT_MODEL). Pinned so
+// the eval exercises the real judge path, not some other model.
+const JUDGE_MODEL = "gpt-4o-mini";
+
+// An admin-ops-style fragment carrying dense concrete verifiable detail: an
+// endpoint route, four HTTP status codes, a named crypto symbol, a config key,
+// and a dropped env-var name. Crucially it is framed as a WHAT-restatement (a
+// "PR #N: unify …" title, terse "adds/validates/returns" body with a single
+// light "so operators manage one credential" why-hook) — that framing INVITES
+// the judge onto the `rewritten` branch instead of `distilled`, which is the
+// exact branch that pre-fix paraphrased every specific away into "unify
+// authentication … enhances security … simplify access control" (the
+// live-observed drop). Verified pre-fix: gpt-4o-mini rules this `rewritten` and
+// drops POST /admin/:op, 401, and trust_proxy on every run.
+const ADMIN_OPS_INPUT: DistillationJudgeInput = {
+  title: "PR #412: unify admin auth on ANALYTICS_TOKEN",
+  content:
+    "Adds a POST /admin/:op endpoint. Validates the ANALYTICS_TOKEN header " +
+    "with timingSafeEqual. Returns 202 on success, 400 on a malformed body, " +
+    "401 on a bad token, 503 when overloaded. Sets trust_proxy and rejects an " +
+    "unresolved forwarded client IP. Removes the old PATHFINDER_ADMIN_TOKEN " +
+    "so operators manage one credential instead of two.",
+  knowledge_type: "security",
+};
+
+// Assert on token PRESENCE, never exact strings — a rewrite is allowed to
+// rephrase the surrounding prose, it just must not DROP the concrete detail.
+function expectSpecificsRetained(content: string): void {
+  expect(content).toContain("POST /admin/:op");
+  expect(content).toContain("timingSafeEqual");
+  expect(content).toMatch(/\b401\b/);
+  expect(content).toContain("trust_proxy");
+}
+
+describe.skipIf(!process.env.OPENAI_API_KEY)(
+  "judgeDistillation REWRITE branch preserves concrete specifics (real LLM)",
+  () => {
+    it("a rewritten verdict RETAINS endpoints/status-codes/symbols/config (or falls back to distilled pass-through)", async () => {
+      // No baseURL → the REAL OpenAI API (honors OPENAI_API_KEY). temp 0 and the
+      // pinned model make this as reproducible as a real model allows.
+      const distiller = new OpenAIDistiller({ model: JUDGE_MODEL });
+
+      const verdict = await distiller.judgeDistillation(ADMIN_OPS_INPUT);
+
+      if (verdict.kind === "rewritten") {
+        // The failure surface: on a rewrite the concrete detail must survive.
+        expectSpecificsRetained(verdict.content);
+      } else if (verdict.kind === "distilled") {
+        // Acceptable pass: `distilled` is pure pass-through — the gate keeps the
+        // ORIGINAL content, which by construction carries all the specifics. This
+        // is the "prefer distilled over a lossy rewrite" fallback the fix adds.
+        expectSpecificsRetained(ADMIN_OPS_INPUT.content);
+      } else {
+        // A `restatement` verdict would DROP this fragment (no salvage), which is
+        // wrong for a dense concrete-mechanism claim — fail loud.
+        throw new Error(
+          `expected distilled or rewritten for a concrete-mechanism claim, got ${verdict.kind}`,
+        );
+      }
+    });
+  },
+);

--- a/src/__tests__/atlas-distillation-rewrite-eval.test.ts
+++ b/src/__tests__/atlas-distillation-rewrite-eval.test.ts
@@ -16,17 +16,15 @@
 // into generic WHY prose ("unified authentication enhances security"), dropping
 // every concrete identifier. The fix teaches the judge to RETAIN every
 // endpoint/status-code/symbol/config on a rewrite (or fall back to `distilled`
-// pass-through when it cannot). So the assertion is: whatever the verdict, the
-// returned content must still carry the source's concrete tokens.
+// pass-through when it cannot). So the contract is: a concrete-mechanism claim
+// is acceptably handled EITHER as `rewritten` whose content still carries the
+// source's concrete tokens, OR as `distilled` pass-through (which by definition
+// keeps the original intact) — but NEVER as `restatement` (which would drop it).
 
 import { describe, expect, it } from "vitest";
 
 import { OpenAIDistiller } from "../atlas/llm.js";
 import type { DistillationJudgeInput } from "../atlas/llm.js";
-
-// The model the code actually uses (OpenAIDistiller's DEFAULT_MODEL). Pinned so
-// the eval exercises the real judge path, not some other model.
-const JUDGE_MODEL = "gpt-4o-mini";
 
 // An admin-ops-style fragment carrying dense concrete verifiable detail: an
 // endpoint route, four HTTP status codes, a named crypto symbol, a config key,
@@ -62,26 +60,39 @@ describe.skipIf(!process.env.OPENAI_API_KEY)(
   "judgeDistillation REWRITE branch preserves concrete specifics (real LLM)",
   () => {
     it("a rewritten verdict RETAINS endpoints/status-codes/symbols/config (or falls back to distilled pass-through)", async () => {
-      // No baseURL → the REAL OpenAI API (honors OPENAI_API_KEY). temp 0 and the
-      // pinned model make this as reproducible as a real model allows.
-      const distiller = new OpenAIDistiller({ model: JUDGE_MODEL });
+      // No baseURL → the REAL OpenAI API (honors OPENAI_API_KEY). No `model`
+      // option → the distiller resolves its own unexported DEFAULT_MODEL, exactly
+      // as production does. This deliberately AVOIDS pinning a duplicated model
+      // literal in the test: a duplicated pin could silently drift from the source
+      // default and make the eval exercise a different model than production. By
+      // deferring to the distiller's default we exercise whatever production runs,
+      // with zero drift surface. (temp 0 keeps it as reproducible as a real model
+      // allows.)
+      const distiller = new OpenAIDistiller();
 
       const verdict = await distiller.judgeDistillation(ADMIN_OPS_INPUT);
 
+      // The semantic contract for a dense concrete-mechanism claim: it is
+      // acceptably handled EITHER as `rewritten` (whose content must retain every
+      // specific) OR as `distilled` pass-through (which by definition keeps the
+      // ORIGINAL content untouched). A `restatement` would DROP the fragment with
+      // no salvage — wrong for this input — so that outcome must fail loud.
+      //
+      // This assertion runs regardless of which verdict the model returns and is
+      // NOT implied by any enclosing guard: if a future regression routed this
+      // claim to `restatement`, it fails here. (Re-checking tokens on the static
+      // ADMIN_OPS_INPUT.content, or asserting `kind === "distilled"` inside a
+      // `kind === "distilled"` branch, would both be tautologies that verify
+      // nothing about the model's output.)
+      expect(["rewritten", "distilled"]).toContain(verdict.kind);
+
       if (verdict.kind === "rewritten") {
-        // The failure surface: on a rewrite the concrete detail must survive.
+        // The failure surface: on a rewrite the concrete detail must survive in
+        // the model's OWN returned content (a distilled verdict carries no content
+        // of its own — it is a pure pass-through signal — so there is nothing to
+        // token-check there, and the pass-through preserves the original by
+        // construction).
         expectSpecificsRetained(verdict.content);
-      } else if (verdict.kind === "distilled") {
-        // Acceptable pass: `distilled` is pure pass-through — the gate keeps the
-        // ORIGINAL content, which by construction carries all the specifics. This
-        // is the "prefer distilled over a lossy rewrite" fallback the fix adds.
-        expectSpecificsRetained(ADMIN_OPS_INPUT.content);
-      } else {
-        // A `restatement` verdict would DROP this fragment (no salvage), which is
-        // wrong for a dense concrete-mechanism claim — fail loud.
-        throw new Error(
-          `expected distilled or rewritten for a concrete-mechanism claim, got ${verdict.kind}`,
-        );
       }
     });
   },

--- a/src/atlas/llm.ts
+++ b/src/atlas/llm.ts
@@ -228,8 +228,8 @@ const DISTILLATION_SYSTEM_PROMPT = `You are a WHY-vs-WHAT judge for an engineeri
 You are given ONE candidate knowledge entry (title + content + knowledge_type). Institutional-memory knowledge must explain the WHY / HOW behind a decision, root cause, architecture choice, or operational reality — NOT merely RESTATE the WHAT that is already obvious from metadata (which PR merged, what a file is named, that a component was added).
 
 Classify the candidate into EXACTLY ONE verdict:
-- "distilled": already a why/how CLAIM (explains reasoning, tradeoffs, mechanism, or consequence). Keep as-is.
-- "rewritten": the SUBSTANCE is salvageable but the current title/content just restates WHAT happened; a why/how claim can be extracted. Provide the rewrite.
+- "distilled": already a why/how CLAIM (explains reasoning, tradeoffs, mechanism, or consequence). Keep as-is. A claim that already states a CONCRETE MECHANISM — specific endpoints/routes, HTTP status codes, error codes, named functions/methods/symbols, file paths, config keys, or specific numbers — is "distilled": keep it as-is; do NOT rewrite a concrete-mechanism claim up into higher-level rationale.
+- "rewritten": the SUBSTANCE is salvageable but the current title/content just restates WHAT happened; a why/how claim can be extracted. Provide the rewrite. The rewrite MUST RETAIN every concrete verifiable detail present in the source — API endpoints/routes, HTTP status codes, error codes, function/method/symbol names, file paths, config keys, and specific numbers. Sharpen the claim by adding the WHY/HOW AROUND those specifics; NEVER drop, generalize, or paraphrase them away. (Concretely: rewriting "POST /admin/:op returns 401 via timingSafeEqual" into "authentication enhances security" is WRONG — the endpoint, the code, and the symbol were all dropped.)
 - "restatement": a PURE WHAT restatement (e.g. "adds X/Y/Z components", "PR #N merged", a stack/component inventory) that carries NO new reasoning or verifiable engineering claim. Cannot be salvaged into a why/how claim from the given text.
 
 Return JSON with EXACTLY this structure:
@@ -243,6 +243,7 @@ Return JSON with EXACTLY this structure:
 Rules:
 - Be conservative about "distilled": if the content only names WHAT (files, components, PRs) with no reasoning, it is NOT distilled.
 - Only choose "rewritten" when the given text ACTUALLY contains extractable why/how substance — do NOT invent reasoning that is not present. If nothing is salvageable, choose "restatement".
+- PRESERVE-SPECIFICS is mandatory on "rewritten": if you cannot produce a rewrite that keeps EVERY identifier/endpoint/status-code/error-code/symbol/path/config-key/number from the source, return "distilled" instead (pass the original through unchanged). Losing a verifiable specific is worse than leaving the prose slightly WHAT-flavored.
 - title/content are REQUIRED for "rewritten" and ignored for the other verdicts.`;
 
 const DISTILL_DELTA_SYSTEM_PROMPT = `You are a knowledge-DELTA distiller for an engineering knowledge corpus.


### PR DESCRIPTION
Prompt-only fix so the Atlas distillation judge's **rewrite** branch retains concrete verifiable detail instead of abstracting it into generic WHY prose.

## How this was found

A live prod-read-only dry-run of the just-merged harvest pipeline (#135) over real memory fragments. One candidate — a precise admin-ops claim (`POST /admin/:op`, `202/400/401/503`, `timingSafeEqual`, `trust_proxy` fail-closed) — was rewritten by the judge into *"unified authentication enhances security and simplifies access control,"* **dropping every specific.** The 5 already-well-formed candidates were correctly passed through untouched; only the rewrite path over-abstracted.

## Root cause

`DISTILLATION_SYSTEM_PROMPT` had no preservation constraint — it asked for "why/how prose" and only guarded against *inventing* reasoning, never against *dropping* facts. Its WHY-vs-WHAT framing had no category for a precise HOW claim, so verifiable mechanics got recoded as low-value WHAT and "elevated" to rationale.

## The fix (3 edits to `DISTILLATION_SYSTEM_PROMPT`, no gate/parsing changes)

- Rewrite MUST retain every concrete verifiable detail (endpoints, HTTP/error codes, symbol names, paths, config keys, numbers); sharpen the WHY/HOW *around* them.
- A claim already stating a concrete mechanism is `distilled` — keep as-is, don't rewrite up into rationale.
- If a rewrite can't keep every specific, return `distilled` instead — losing a verifiable specific is worse than slightly-WHAT-flavored prose.

## Proof (real-LLM red-green — the actual failure surface, not fakes)

An opt-in eval (`OPENAI_API_KEY`-gated, `skipIf` so it's out of normal CI) runs the real judge on the admin-ops fragment:
- **RED (pre-fix):** verdict `rewritten`, `POST /admin/:op` dropped — 3/3.
- **GREEN (post-fix):** verdict `rewritten` retaining `POST /admin/:op` + `timingSafeEqual` + `202/400/401/503` + `trust_proxy` — 4/4.

Plus a Layer-1 aimock gate-plumbing contract guard, and this closes the `judgeDistillation` zero-coverage gap.

## Review

7 reviewers (Tier 2), 3 rounds. The prompt diff was clean (source-gate + generalist reviewers: no findings). One in-subject test-quality fix — the eval's `distilled`-fallback branch was made guard-independent (`toContain(["rewritten","distilled"])`, fails loud on a `restatement` regression) instead of a vacuous re-check. Converged with zero in-subject bucket-(a).

**Blast radius:** the pass-through cases can only become *more* likely to pass through; `restatement` untouched. 3410 tests green; the eval is `skipIf`-gated.

## Follow-ups (non-blocking, tracked in the CR ledger)

- Code-enforce PRESERVE-SPECIFICS with a gate-side token-retention guard (belt-and-braces beyond the prompt).
- Strengthen the eval's `distilled` path to assert the gate-layer pass-through invariant.
- Add a through-the-gate test for `stripGitHubMetadataHeader`.
- Pre-existing `llm.ts` hardening surfaced by review (public→internal floor, `CandidateFragmentSchema.parse`, embed finite-element check).
