### PR TITLE
Repoint weekly search-query report to the Gap Reports Notion page

### DIFF
--- a/.github/workflows/weekly-search-report.yml
+++ b/.github/workflows/weekly-search-report.yml
@@ -76,8 +76,8 @@ jobs:
           # SLACK_ENGR_WEBHOOK; the org-level secret is SLACK_WEBHOOK_ENGR.
           # Unset → the success ping is simply skipped.
           SLACK_ENGR_WEBHOOK: ${{ secrets.SLACK_WEBHOOK_ENGR }}
-          # Pathfinder project page where weekly reports land.
-          NOTION_PARENT_PAGE_ID: "3373aa38-1852-8152-a10b-e4aa1b8a667e"
+          # Gap Reports page where weekly reports land.
+          NOTION_PARENT_PAGE_ID: "3793aa38-1852-80a5-89d3-c3d37147aa22"
           # Production analytics API base.
           ANALYTICS_BASE_URL: "https://mcp.copilotkit.ai"
           # 7-day lookback window.

--- a/scripts/weekly-search-report/weekly-search-report.ts
+++ b/scripts/weekly-search-report/weekly-search-report.ts
@@ -935,7 +935,7 @@ export interface RunDeps {
 }
 
 const DEFAULT_BASE_URL = "https://mcp.copilotkit.ai";
-const DEFAULT_PARENT_PAGE_ID = "3373aa38-1852-8152-a10b-e4aa1b8a667e";
+const DEFAULT_PARENT_PAGE_ID = "3793aa38-1852-80a5-89d3-c3d37147aa22";
 
 /**
  * Build the real (network-backed) fetchJson bound to a base URL + token, modeled


### PR DESCRIPTION
## What

Consolidates the **weekly** and **monthly** reports onto a single Notion destination — the **Gap Reports** page (`3793aa38-1852-80a5-89d3-c3d37147aa22`). The weekly search-query report previously published to the old Analytics/pathfinder page (`3373aa38-1852-8152-a10b-e4aa1b8a667e`); it now lands on the same Gap Reports page the monthly gap-analysis already uses.

The monthly gap-analysis workflow is untouched (it already pointed at Gap Reports).

## Changed locations

1. `.github/workflows/weekly-search-report.yml` (line 80) — `NOTION_PARENT_PAGE_ID` env → Gap Reports id (adjacent comment updated to match).
2. `scripts/weekly-search-report/weekly-search-report.ts` (line 938) — `DEFAULT_PARENT_PAGE_ID` fallback → Gap Reports id.

## Verification

Old id — zero hits across the whole repo:

```
$ git grep -n "3373aa38-1852-8152-a10b-e4aa1b8a667e"
(no output — exit 1)
```

New id — both weekly locations now present alongside the pre-existing monthly ones:

```
$ git grep -n "3793aa38-1852-80a5-89d3-c3d37147aa22"
.github/workflows/monthly-gap-analysis.yml:104:          NOTION_PARENT_PAGE_ID: "3793aa38-1852-80a5-89d3-c3d37147aa22"
.github/workflows/weekly-search-report.yml:80:          NOTION_PARENT_PAGE_ID: "3793aa38-1852-80a5-89d3-c3d37147aa22"
scripts/gap-analysis/README.md:71:(`3793aa38-1852-80a5-89d3-c3d37147aa22`) and can be overridden with the
scripts/gap-analysis/monthly-gap-analysis.ts:126:  process.env.NOTION_PARENT_PAGE_ID ?? "3793aa38-1852-80a5-89d3-c3d37147aa22";
scripts/weekly-search-report/weekly-search-report.ts:938:const DEFAULT_PARENT_PAGE_ID = "3793aa38-1852-80a5-89d3-c3d37147aa22";
```

The weekly script has no `--dry-run` mode, so no live run was performed (that would post to Slack #engr and publish a real Notion page). Verification is grep/inspection-based.

Quality gate: prettier clean on the edited TS file, `tsc --noEmit` clean, full test suite green (3554 passed / 1 skipped).