### PR TITLE
docs: add a live MCP status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# pathfinder [![npm version](https://img.shields.io/npm/v/@copilotkit/pathfinder)](https://www.npmjs.com/package/@copilotkit/pathfinder)
+# pathfinder [![npm version](https://img.shields.io/npm/v/@copilotkit/pathfinder)](https://www.npmjs.com/package/@copilotkit/pathfinder) [![MCP status](https://mcpvitals.com/badge/78061f72f4.svg)](https://mcpvitals.com/status/78061f72f4)
 
 The knowledge server for AI agents — index your docs, code, Notion pages, Slack threads, and Discord forums into searchable, agent-accessible knowledge via MCP. One config file, one command, works with any AI coding agent.
 


### PR DESCRIPTION
Hi CopilotKit team 👋

I run [MCP Vitals](https://mcpvitals.com) (MCP server health monitoring). I set up a free public monitor for the hosted Pathfinder endpoint (`mcp.pathfinder.copilotkit.dev/mcp`) — real `initialize → tools/list` handshake, currently healthy.

This PR adds a small live status badge next to the npm badge (shows up/down at a glance, catches tool-schema drift):

[![MCP status](https://mcpvitals.com/badge/78061f72f4.svg)](https://mcpvitals.com/status/78061f72f4)

Free, public uptime page, no signup. Close if not wanted — all good 🙏
