### PR TITLE
Block the awards-show and election scraping wave by topic family

### DIFF
--- a/src/__tests__/abuse-blocklist.test.ts
+++ b/src/__tests__/abuse-blocklist.test.ts
@@ -71,6 +71,98 @@ describe("checkBlocklist — positive matches", () => {
       reason: "pattern:sports-event-contracts",
       query: "sport event contract market",
     },
+    // --- Awards-show family (2026 scraping wave) -------------------------
+    {
+      name: "awards-show (emmy + nominations)",
+      reason: "pattern:awards-show",
+      query: "Emmy Awards Beef Season 2 nominations 78th",
+    },
+    {
+      name: "awards-show (emmy + outstanding category)",
+      reason: "pattern:awards-show",
+      query: "Emmy 2026 Outstanding Lead Actor Limited Series nominees",
+    },
+    {
+      name: "awards-show (emmy + bare 'awards')",
+      reason: "pattern:awards-show",
+      query: "Emmy Awards bracket win probability 2 3 awards",
+    },
+    {
+      name: "awards-show (grammy + record of the year / winners)",
+      reason: "pattern:awards-show",
+      query: "GRAMMY Record of the Year historical winners base rates",
+    },
+    {
+      name: "awards-show (oscar + nominations)",
+      reason: "pattern:awards-show",
+      query: "Dune Messiah Oscar nominations 2027",
+    },
+    {
+      name: "awards-show (academy awards + best actress)",
+      reason: "pattern:awards-show",
+      query: "Julianne Moore 2027 Academy Awards Best Actress",
+    },
+    {
+      name: "awards-show-year (emmy + year, no category word)",
+      reason: "pattern:awards-show-year",
+      query: "Betty Gilpin Widow's Bay Emmy 2026",
+    },
+    {
+      name: "awards-show-year (grammy + year)",
+      reason: "pattern:awards-show-year",
+      query: "Olivia Dean Art of Loving GRAMMY 2027",
+    },
+    // --- Elections / prediction-market family (2026 scraping wave) -------
+    {
+      name: "election-politics (congressional + district)",
+      reason: "pattern:election-politics",
+      query: "Michigan congressional districts 2026 midterm elections",
+    },
+    {
+      name: "election-politics (house seats + midterm + forecast)",
+      reason: "pattern:election-politics",
+      query: "California House seats 2026 midterm election forecast",
+    },
+    {
+      name: "election-politics (congressional district + midterm)",
+      reason: "pattern:election-politics",
+      query: "Iowa 1st congressional district 2026 midterm",
+    },
+    {
+      name: "election-politics (senate + turnout)",
+      reason: "pattern:election-politics",
+      query: "Ohio Senate election 2026 turnout",
+    },
+    {
+      name: "election-politics (presidential + candidates/polls)",
+      reason: "pattern:election-politics",
+      query: "Brazil 2026 presidential election candidates polls",
+    },
+    {
+      name: "election-politics (governor + election)",
+      reason: "pattern:election-politics",
+      query: "Alaska governor 2026 election",
+    },
+    {
+      name: "election-politics-year (redistricting + year)",
+      reason: "pattern:election-politics-year",
+      query: "Missouri congressional redistricting 2026",
+    },
+    {
+      name: "election-politics-year (senate + year, no contest word)",
+      reason: "pattern:election-politics-year",
+      query: "Dan Sullivan Alaska Senate 2026",
+    },
+    {
+      name: "election-polling (bare 'election' + polling)",
+      reason: "pattern:election-polling",
+      query: "Swedish election 2026 Centre Party polling",
+    },
+    {
+      name: "election-polling (bare 'election' + polls)",
+      reason: "pattern:election-polling",
+      query: "Swedish Liberals Liberalerna 2026 election polls threshold",
+    },
   ];
 
   for (const { name, reason, query } of positives) {
@@ -122,6 +214,33 @@ describe("checkBlocklist — legitimate queries do not match", () => {
     "configure copilot runtime with anthropic",
     "MCP server health endpoint",
     "How to debug a langgraph agent",
+    // Near-misses for the awards-show family. The topic term must co-occur
+    // with an awards-context term (or, for the unambiguous show names, a
+    // year); a bare "award"/"season"/"series" in a product context, or a
+    // person named Oscar, must stay out.
+    "award badge component in the docs sidebar",
+    "series and season fields in the demo catalog config",
+    "Oscar asked in Discord whether the 2026 roadmap includes Angular support",
+    "beef up the error handling in the runtime adapter",
+    "state of the art embedding models for retrieval",
+    // Near-misses for the elections family. Every hazard word here is a real
+    // CopilotKit/AG-UI term: "poll"/"polling" (transport), "race" (race
+    // condition), "state" (React state), "primary" (CSS color), "candidate"
+    // (index keys), "seats" (billing), "district"/"governor"/"forecast"
+    // (product nouns), "polly" (AWS Polly TTS). None may match on its own.
+    "Raft leader election polling interval for agent runner replicas",
+    "how do I poll the runtime endpoint until the run finishes",
+    "long-polling transport fallback for MCP sessions",
+    "AWS Polly text-to-speech integration with CopilotKit",
+    "polly",
+    "race condition connect while run finishes isRunning implementation",
+    "how to manage React state in a CopilotKit component",
+    "CSS variables --copilot-kit-primary-color CopilotKit theme customization Vue v2",
+    "forecast chart component for the dashboard demo",
+    "candidate keys for the vector index lookup",
+    "cpufreq governor settings for the CI runner",
+    "how many seats does the Intelligence Cloud free plan include per developer",
+    "district heating dashboard demo with a map component",
   ];
 
   for (const query of negatives) {

--- a/src/mcp/abuse-blocklist.ts
+++ b/src/mcp/abuse-blocklist.ts
@@ -44,6 +44,67 @@ const PATTERNS: { name: string; regex: RegExp }[] = [
     name: "sports-event-contracts",
     regex: /\bsports?\s*event\s*contracts?\b/i,
   },
+
+  // -------------------------------------------------------------------------
+  // Awards-show scraping (Sept 2026 wave). The bot rotates show titles and
+  // nominee names constantly ("Widow's Bay", "Beef", "The Pitt", ...), so
+  // per-title regexes are a treadmill. Instead: require a SHOW NAME to
+  // co-occur with an AWARDS-CONTEXT term. Both patterns use `(?=...)`
+  // lookaheads over `[\s\S]*` so the two halves match in either order and
+  // across newlines (indexed GitHub/Discord bodies are multi-line).
+  // -------------------------------------------------------------------------
+  {
+    name: "awards-show",
+    regex:
+      /^(?=[\s\S]*\b(?:emmys?|grammys?|oscars?|academy\s+awards?|golden\s+globes?|tony\s+awards?|baftas?)\b)(?=[\s\S]*\b(?:awards?|nominations?|nominees?|nominated|winners?|wins|red\s+carpet|outstanding|best\s+(?:actor|actress|picture|director|album|song|new\s+artist|international\s+feature|(?:limited\s+)?series)|album\s+of\s+(?:the\s+)?year|record\s+of\s+the\s+year|song\s+of\s+the\s+year|ceremony|shortlists?|frontrunners?|contenders?|snubs?|lead\s+act(?:or|ress)|supporting\s+act(?:or|ress)|guest\s+act(?:or|ress)|limited\s+series|variety\s+series)\b)/i,
+  },
+  // Same show names paired with a bare 4-digit year ("Betty Gilpin Widow's
+  // Bay Emmy 2026"), which carries no category word. `oscars?` is
+  // deliberately EXCLUDED here: "Oscar" is a common given name, and
+  // "Oscar ... 2026" in a Discord/GitHub body is a plausible legitimate
+  // query. Oscar-flavoured abuse still gets caught by `awards-show` above,
+  // which requires a real awards-context term.
+  {
+    name: "awards-show-year",
+    regex:
+      /^(?=[\s\S]*\b(?:emmys?|grammys?|academy\s+awards?|golden\s+globes?|tony\s+awards?|baftas?)\b)(?=[\s\S]*\b20\d\d\b)/i,
+  },
+
+  // -------------------------------------------------------------------------
+  // US/international election + prediction-market scraping (Sept 2026 wave).
+  // Same co-occurrence shape. The hazard list here is long because almost
+  // every electoral word has a legitimate software meaning: "poll"/"polling"
+  // (transport), "race" (race condition), "state" (React state), "primary"
+  // (CSS color), "candidate" (index keys), "seat" (billing), "district",
+  // "forecast", "turnout". NONE of them is blocked on its own — each only
+  // counts as CONTEXT, and a match additionally requires a POLITICAL-DOMAIN
+  // term that has no software meaning (presidential, congressional, senate,
+  // midterm, redistricting, ...).
+  // -------------------------------------------------------------------------
+  {
+    name: "election-politics",
+    regex:
+      /^(?=[\s\S]*\b(?:presidential|gubernatorial|governor|senate|senatorial|congressional|parliamentary|midterms?|redistricting|electorate|electoral\s+college|caucus|house\s+(?:seats?|districts?))\b)(?=[\s\S]*\b(?:elections?|primar(?:y|ies)|ballots?|turnout|votes?|voting|voters?|candidates?|polls?|polling|nominations?|incumbents?|seats?|districts?|races?|forecasts?|constituency)\b)/i,
+  },
+  // Political-domain term + a bare year ("Dan Sullivan Alaska Senate 2026",
+  // "Missouri congressional redistricting 2026") — the bot's terse shape,
+  // which carries no contest word at all.
+  {
+    name: "election-politics-year",
+    regex:
+      /^(?=[\s\S]*\b(?:presidential|gubernatorial|governor|senate|senatorial|congressional|parliamentary|midterms?|redistricting|electorate|electoral\s+college|caucus|house\s+(?:seats?|districts?))\b)(?=[\s\S]*\b20\d\d\b)/i,
+  },
+  // The bot also asks about national elections with no office word at all
+  // ("Swedish election 2026 Centre Party polling"). Bare "election" + a
+  // ballot-box term is the only signal left, so this pattern carves out the
+  // one real software collision: Raft/consensus LEADER election, which
+  // legitimately co-occurs with "polling". The negative lookbehind keeps
+  // "Raft leader election polling interval" out of the blocklist.
+  {
+    name: "election-polling",
+    regex:
+      /^(?=[\s\S]*\b(?<!\bleader\s)elections?\b)(?=[\s\S]*\b(?:polls?|polling|turnout|ballots?|voters?|electorate|constituency|caucus)\b)/i,
+  },
 ];
 
 /**


### PR DESCRIPTION
## What

The off-topic scraper behind the existing box-office blocklist entries moved on to two new topics, both visible on https://mcp.copilotkit.ai/analytics?days=7 :

1. **Awards shows** — "Widow's Bay Emmy Awards 2026", "Beef Netflix Emmy Awards 2026 Season 2 nominations", "GRAMMY Record of the Year historical winners base rates", "Dune Messiah Oscar nominations 2027", ...
2. **Elections / prediction markets** — "Missouri congressional redistricting 2026", "California House seats 2026 midterm election forecast", "Ohio Senate election 2026 turnout", "Brazil 2026 presidential election candidates polls", ...

The bot rotates titles and names constantly, so a regex per abuse string is a treadmill. This adds **five patterns across two families**, all topic+context co-occurrence using order-independent `(?=[\s\S]*...)` lookaheads (multi-line safe — indexed GitHub/Discord bodies contain newlines).

| pattern | requires |
|---|---|
| `awards-show` | show name (`emmy/grammy/oscar/academy award/golden globe/tony award/bafta`) **AND** awards context (`awards, nomination(s), nominee(s), winner(s), outstanding, best actor/actress/…, album/record/song of the year, lead/supporting/guest actor, limited series, variety series, ceremony, frontrunner, …`) |
| `awards-show-year` | show name **excluding `oscar`** **AND** a bare `20\d\d` |
| `election-politics` | political-domain term (`presidential, gubernatorial, governor, senate, senatorial, congressional, parliamentary, midterm, redistricting, electorate, electoral college, caucus, house seats/districts`) **AND** contest term (`election(s), primary/primaries, ballot, turnout, vote/voting/voters, candidates, polls/polling, nominations, incumbents, seats, districts, races, forecasts, constituency`) |
| `election-politics-year` | political-domain term **AND** a bare `20\d\d` |
| `election-polling` | bare `election(s)` **not preceded by `leader`** **AND** a ballot-box term (`polls/polling/turnout/ballots/voters/electorate/constituency/caucus`) |

Exact regexes are in the diff.

### False-positive hazards handled explicitly

Nothing ambiguous is blocked on its own. `poll`/`polling` (transport), `race` (race condition), `state` (React state), `primary` (CSS color), `candidate` (index keys), `seat` (billing), `district`, `forecast`, `turnout`, `beef`, `art` count only as **context** and always require a political/awards term alongside. Specific carve-outs:

- **`oscar` is excluded from the bare-year pattern** — it is a common given name; "Oscar … 2026" in a Discord body is plausible. Oscar abuse is still caught by `awards-show`, which requires a real awards term.
- **`election-polling` has a `(?<!\bleader\s)` lookbehind** — Raft/consensus *leader election* legitimately co-occurs with "polling".
- **`polly` is deliberately NOT blocked** — almost certainly AWS Polly (TTS), a real integration term. It stays in the empty-results panel.

Each new pattern has both a positive test (the real abuse string) and a negative test (a near-miss real query), per the module header contract. 18 new positives, 13 new negatives.

## RED → GREEN (local)

**RED** — tests added first, blocklist unchanged (`npx vitest run src/__tests__/abuse-blocklist.test.ts`):

```
 ❯ src/__tests__/abuse-blocklist.test.ts (68 tests | 18 failed) 7ms
⎯⎯⎯⎯⎯⎯ Failed Tests 18 ⎯⎯⎯⎯⎯⎯⎯
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show (emmy + nominations)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show (emmy + outstanding category)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show (emmy + bare 'awards')
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show (grammy + record of the year / winners)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show (oscar + nominations)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show (academy awards + best actress)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show-year (emmy + year, no category word)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: awards-show-year (grammy + year)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics (congressional + district)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics (house seats + midterm + forecast)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics (congressional district + midterm)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics (senate + turnout)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics (presidential + candidates/polls)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics (governor + election)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics-year (redistricting + year)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-politics-year (senate + year, no contest word)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-polling (bare 'election' + polling)
 FAIL  src/__tests__/abuse-blocklist.test.ts > checkBlocklist — positive matches > matches: election-polling (bare 'election' + polls)
 ❯ src/__tests__/abuse-blocklist.test.ts:171:30
 Test Files  1 failed (1)
      Tests  18 failed | 50 passed (68)
```

**GREEN** — same tests, after the fix:

```
 Test Files  1 passed (1)
      Tests  68 passed (68)
```

Full suite (`npm test`):

```
 Test Files  177 passed | 1 skipped (178)
      Tests  3590 passed | 1 skipped (3591)
```

`npm run build` and `npx tsc --noEmit` clean; both touched files are prettier-clean.

## Real-corpus value test

Pulled the production corpus from `/api/analytics/queries` + `/api/analytics/empty-queries` (`days=30`, plus per-day `from`/`to` slices to get past the 200-row cap, `request_source=all`) → **5,980 unique queries**. Ran the compiled `checkBlocklist` over all of them:

```
corpus size: 5980
blocked by pre-existing 7 patterns: 0     (already excluded from these endpoints)
NEWLY blocked: 165
{
  'pattern:election-politics': 81,
  'pattern:awards-show': 73,
  'pattern:election-politics-year': 5,
  'pattern:awards-show-year': 3,
  'pattern:election-polling': 3
}
```

**165 abuse queries newly blocked, 0 legitimate queries blocked.** All 165 were reviewed individually; every one is an awards-show or election/prediction-market query, and none contains a single CopilotKit/AG-UI/MCP/software term (`grep -icE "copilot|agui|ag-ui|mcp|react|runtime|agent|langgraph|typescript|hook|api|component"` over the match list → 0).

## Deliberately not blocked

- `polly` (AWS Polly), see above.
- "Treg Taylor Alaska governor 2026"-style queries **are** caught (governor + year), but a hypothetical `cpufreq governor` query without a year is not — that is the intended asymmetry.
- No IP-layer blocking: the traffic comes from Anthropic's shared `Claude-User` egress pool, which also serves tens of thousands of legitimate Claude-mediated sessions. Detection stays query-content-level.
