### PR TITLE
Carry a scope hint on every empty search/knowledge result

### DIFF
--- a/src/__tests__/empty-result-scope-hint.test.ts
+++ b/src/__tests__/empty-result-scope-hint.test.ts
@@ -1,0 +1,359 @@
+import { describe, it, expect, vi, beforeAll, beforeEach } from "vitest";
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { InMemoryTransport } from "@modelcontextprotocol/sdk/inMemory.js";
+import type {
+  SearchToolConfig,
+  KnowledgeToolConfig,
+  ChunkResult,
+} from "../types.js";
+
+// Empty results used to return the bare string "No results found." (and
+// "No FAQ results found." on the knowledge path), which teaches the caller
+// nothing: neither an off-topic caller (that this server is domain-scoped)
+// nor a real user who hit a genuine documentation gap. Every empty response
+// must now carry the same `domain` + `hint` payload shape the abuse
+// blocklist already returns on its blocked path.
+vi.mock("../db/queries.js", () => ({
+  searchChunks: vi.fn(),
+  textSearchChunks: vi.fn(),
+  hybridSearchChunks: vi.fn(),
+  getFaqChunks: vi.fn(),
+  getFaqChunksByIds: vi.fn(),
+}));
+vi.mock("../db/analytics.js", () => ({
+  logQuery: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("../config.js", () => ({
+  getServerConfig: vi.fn().mockReturnValue({}),
+  getAnalyticsConfig: vi.fn().mockReturnValue(undefined),
+}));
+
+import { registerSearchTool } from "../mcp/tools/search.js";
+import { registerKnowledgeTool } from "../mcp/tools/knowledge.js";
+import {
+  searchChunks,
+  textSearchChunks,
+  hybridSearchChunks,
+  getFaqChunks,
+  getFaqChunksByIds,
+} from "../db/queries.js";
+
+const mockSearchChunks = vi.mocked(searchChunks);
+const mockTextSearchChunks = vi.mocked(textSearchChunks);
+const mockHybridSearchChunks = vi.mocked(hybridSearchChunks);
+const mockGetFaqChunks = vi.mocked(getFaqChunks);
+const mockGetFaqChunksByIds = vi.mocked(getFaqChunksByIds);
+const mockEmbed = vi.fn();
+
+function searchConfig(
+  overrides: Partial<SearchToolConfig> = {},
+): SearchToolConfig {
+  return {
+    name: "search-docs",
+    type: "search",
+    description: "Search the documentation.",
+    source: "docs",
+    default_limit: 5,
+    max_limit: 20,
+    result_format: "docs",
+    search_mode: "vector",
+    ...overrides,
+  };
+}
+
+const knowledgeConfig: KnowledgeToolConfig = {
+  name: "get-faq",
+  type: "knowledge",
+  description: "Browse or search the FAQ.",
+  sources: ["slack-support", "discord-support"],
+  min_confidence: 0.7,
+  default_limit: 2,
+  max_limit: 10,
+};
+
+function textOf(result: unknown): string {
+  return (result as { content: Array<{ type: string; text: string }> })
+    .content[0].text;
+}
+
+type EmptyPayload = {
+  results: unknown[];
+  reason: string;
+  domain: string;
+  hint: string;
+};
+
+/**
+ * Every empty-result payload must parse as JSON and carry the scope hint.
+ * `domain` is derived from the tool's configured source(s); the hint must
+ * name that domain, must not accuse the caller of being off-topic (most
+ * recipients are legitimate users hitting a docs gap), and must point an
+ * out-of-scope caller at a web search instead.
+ */
+function expectScopeHint(text: string, domain: string): EmptyPayload {
+  expect(text).not.toBe("No results found.");
+  expect(text).not.toBe("No FAQ results found.");
+  const payload = JSON.parse(text) as EmptyPayload;
+  expect(payload.results).toEqual([]);
+  expect(payload.reason).toBe("no_results");
+  expect(payload.domain).toBe(domain);
+  expect(typeof payload.hint).toBe("string");
+  expect(payload.hint).toContain(domain);
+  expect(payload.hint.toLowerCase()).toContain("web search");
+  // Not the blocked path — `blocked` stays reserved for a blocklist match.
+  expect(payload).not.toHaveProperty("blocked");
+  return payload;
+}
+
+async function connect(register: (server: McpServer) => void): Promise<Client> {
+  const server = new McpServer({ name: "test", version: "1.0.0" });
+  register(server);
+  const [clientTransport, serverTransport] =
+    InMemoryTransport.createLinkedPair();
+  await server.connect(serverTransport);
+  const client = new Client({ name: "test-client", version: "1.0.0" });
+  await client.connect(clientTransport);
+  return client;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("search tool: empty results carry a scope hint", () => {
+  let docsClient: Client;
+  let codeClient: Client;
+  let rawClient: Client;
+  let keywordClient: Client;
+  let hybridClient: Client;
+
+  beforeAll(async () => {
+    const embeddingClient = { embed: mockEmbed };
+    docsClient = await connect((s) =>
+      registerSearchTool(s as never, embeddingClient as never, searchConfig()),
+    );
+    codeClient = await connect((s) =>
+      registerSearchTool(
+        s as never,
+        embeddingClient as never,
+        searchConfig({
+          name: "search-code",
+          source: "code",
+          result_format: "code",
+        }),
+      ),
+    );
+    rawClient = await connect((s) =>
+      registerSearchTool(
+        s as never,
+        embeddingClient as never,
+        searchConfig({
+          name: "search-raw",
+          source: "notes",
+          result_format: "raw",
+        }),
+      ),
+    );
+    keywordClient = await connect((s) =>
+      registerSearchTool(
+        s as never,
+        embeddingClient as never,
+        searchConfig({
+          name: "search-keyword",
+          source: "docs",
+          search_mode: "keyword",
+        }),
+      ),
+    );
+    hybridClient = await connect((s) =>
+      registerSearchTool(
+        s as never,
+        embeddingClient as never,
+        searchConfig({
+          name: "search-hybrid",
+          source: "ag-ui-docs",
+          search_mode: "hybrid",
+        }),
+      ),
+    );
+  });
+
+  it("docs format: empty vector search returns the domain + hint payload", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    const result = await docsClient.callTool({
+      name: "search-docs",
+      arguments: { query: "how do I configure the sidebar theme" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expectScopeHint(textOf(result), "docs");
+  });
+
+  it("code format: empty vector search returns the domain + hint payload", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    const result = await codeClient.callTool({
+      name: "search-code",
+      arguments: { query: "nonexistent symbol" },
+    });
+
+    expectScopeHint(textOf(result), "code");
+  });
+
+  it("raw format: empty vector search returns the domain + hint payload", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]);
+
+    const result = await rawClient.callTool({
+      name: "search-raw",
+      arguments: { query: "nothing here" },
+    });
+
+    expectScopeHint(textOf(result), "notes");
+  });
+
+  it("keyword mode: empty results carry the hint too", async () => {
+    mockTextSearchChunks.mockResolvedValueOnce([]);
+
+    const result = await keywordClient.callTool({
+      name: "search-keyword",
+      arguments: { query: "nothing here" },
+    });
+
+    expectScopeHint(textOf(result), "docs");
+  });
+
+  it("hybrid mode: empty results carry the hint too", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockHybridSearchChunks.mockResolvedValueOnce([]);
+
+    const result = await hybridClient.callTool({
+      name: "search-hybrid",
+      arguments: { query: "nothing here" },
+    });
+
+    expectScopeHint(textOf(result), "ag-ui-docs");
+  });
+
+  it("min_score filtering down to zero results also carries the hint", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    const lowScoreHit: ChunkResult = {
+      id: 1,
+      source_name: "docs",
+      source_url: "https://docs.example.com/x",
+      title: "X",
+      content: "content",
+      repo_url: null,
+      file_path: "docs/x.md",
+      start_line: null,
+      end_line: null,
+      language: null,
+      similarity: 0.05,
+    };
+    mockSearchChunks.mockResolvedValueOnce([lowScoreHit]);
+
+    const result = await docsClient.callTool({
+      name: "search-docs",
+      arguments: { query: "barely related", min_score: 0.9 },
+    });
+
+    expectScopeHint(textOf(result), "docs");
+  });
+
+  it("non-empty results are unchanged (no hint payload)", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([
+      {
+        id: 1,
+        source_name: "docs",
+        source_url: "https://docs.example.com/x",
+        title: "Getting Started",
+        content: "the content",
+        repo_url: null,
+        file_path: "docs/x.md",
+        start_line: null,
+        end_line: null,
+        language: null,
+        similarity: 0.9,
+      },
+    ]);
+
+    const result = await docsClient.callTool({
+      name: "search-docs",
+      arguments: { query: "getting started" },
+    });
+
+    const text = textOf(result);
+    expect(text).toContain("SNIPPET 1");
+    expect(text).not.toContain("no_results");
+  });
+});
+
+describe("knowledge tool: empty results carry a scope hint", () => {
+  let client: Client;
+  const domain = "slack-support, discord-support";
+
+  beforeAll(async () => {
+    client = await connect((s) =>
+      registerKnowledgeTool(
+        s as never,
+        { embed: mockEmbed } as never,
+        knowledgeConfig,
+      ),
+    );
+  });
+
+  it("browse mode: empty FAQ listing returns the domain + hint payload", async () => {
+    mockGetFaqChunks.mockResolvedValueOnce([]);
+
+    const result = await client.callTool({ name: "get-faq", arguments: {} });
+
+    expect(result.isError).toBeFalsy();
+    expectScopeHint(textOf(result), domain);
+  });
+
+  it("search mode: zero vector hits return the domain + hint payload", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+    const result = await client.callTool({
+      name: "get-faq",
+      arguments: { query: "how do I rotate an api key" },
+    });
+
+    expectScopeHint(textOf(result), domain);
+  });
+
+  it("search mode: hits filtered out by confidence return the hint payload", async () => {
+    mockEmbed.mockResolvedValueOnce([0.1]);
+    mockSearchChunks
+      .mockResolvedValueOnce([
+        {
+          id: 7,
+          source_name: "slack-support",
+          source_url: null,
+          title: null,
+          content: "Q: x\n\nA: y",
+          repo_url: null,
+          file_path: "C1:1:0",
+          start_line: null,
+          end_line: null,
+          language: null,
+          similarity: 0.9,
+        },
+      ])
+      .mockResolvedValueOnce([]);
+    mockGetFaqChunksByIds.mockResolvedValueOnce([]);
+
+    const result = await client.callTool({
+      name: "get-faq",
+      arguments: { query: "low confidence" },
+    });
+
+    expectScopeHint(textOf(result), domain);
+  });
+});

--- a/src/__tests__/knowledge-mcp.test.ts
+++ b/src/__tests__/knowledge-mcp.test.ts
@@ -169,7 +169,11 @@ describe("knowledge tool browse mode (no query)", () => {
     expect(result.isError).toBeFalsy();
     const text = (result.content as Array<{ type: string; text: string }>)[0]
       .text;
-    expect(text).toBe("No FAQ results found.");
+    expect(JSON.parse(text)).toMatchObject({
+      results: [],
+      reason: "no_results",
+      domain: "slack-support, discord-faq",
+    });
     expect(mockGetFaqChunks).toHaveBeenCalled();
     expect(mockEmbed).not.toHaveBeenCalled();
   });
@@ -335,7 +339,11 @@ describe("knowledge tool search mode (with query)", () => {
 
     const text = (result.content as Array<{ type: string; text: string }>)[0]
       .text;
-    expect(text).toBe("No FAQ results found.");
+    expect(JSON.parse(text)).toMatchObject({
+      results: [],
+      reason: "no_results",
+      domain: "slack-support, discord-faq",
+    });
   });
 
   it("sorts merged results by similarity descending", async () => {
@@ -412,7 +420,11 @@ describe("knowledge tool search mode (with query)", () => {
     const text = (result.content as Array<{ type: string; text: string }>)[0]
       .text;
     // 0.85 < 0.9, should be filtered out
-    expect(text).toBe("No FAQ results found.");
+    expect(JSON.parse(text)).toMatchObject({
+      results: [],
+      reason: "no_results",
+      domain: "slack-support, discord-faq",
+    });
   });
 });
 

--- a/src/__tests__/knowledge-tool.test.ts
+++ b/src/__tests__/knowledge-tool.test.ts
@@ -24,13 +24,19 @@ function makeFaqResult(overrides: Partial<FaqChunkResult>): FaqChunkResult {
 }
 
 describe("formatFaqResults", () => {
-  it('returns "No FAQ results found." for empty array', () => {
-    expect(formatFaqResults([])).toBe("No FAQ results found.");
+  it("returns the scope-hint payload for an empty array", () => {
+    const payload = JSON.parse(formatFaqResults([], ["slack-support"]));
+    expect(payload).toEqual({
+      results: [],
+      reason: "no_results",
+      domain: "slack-support",
+      hint: expect.stringContaining("slack-support"),
+    });
   });
 
   it("formats a single result with QUESTION/ANSWER/SOURCE/CONFIDENCE", () => {
     const results = [makeFaqResult({})];
-    const output = formatFaqResults(results);
+    const output = formatFaqResults(results, ["slack-support"]);
     expect(output).toContain("Q&A 1");
     expect(output).toContain("QUESTION: How to configure headers?");
     expect(output).toContain(
@@ -45,7 +51,7 @@ describe("formatFaqResults", () => {
       makeFaqResult({ id: 1, title: "Q1", confidence: 0.9 }),
       makeFaqResult({ id: 2, title: "Q2", confidence: 0.8 }),
     ];
-    const output = formatFaqResults(results);
+    const output = formatFaqResults(results, ["slack-support"]);
     expect(output).toContain("Q&A 1");
     expect(output).toContain("Q&A 2");
   });
@@ -54,13 +60,13 @@ describe("formatFaqResults", () => {
     const results = [
       makeFaqResult({ source_url: null, file_path: "C123:456:0" }),
     ];
-    const output = formatFaqResults(results);
+    const output = formatFaqResults(results, ["slack-support"]);
     expect(output).toContain("SOURCE: C123:456:0");
   });
 
   it("uses (untitled) when title is null", () => {
     const results = [makeFaqResult({ title: null })];
-    const output = formatFaqResults(results);
+    const output = formatFaqResults(results, ["slack-support"]);
     expect(output).toContain("QUESTION: (untitled)");
   });
 
@@ -70,7 +76,7 @@ describe("formatFaqResults", () => {
         content: "Q: What is X?\n\nA: X is a thing that does Y and Z.",
       }),
     ];
-    const output = formatFaqResults(results);
+    const output = formatFaqResults(results, ["slack-support"]);
     expect(output).toContain("ANSWER: X is a thing that does Y and Z.");
   });
 
@@ -80,7 +86,7 @@ describe("formatFaqResults", () => {
         content: "Just some plain text answer.",
       }),
     ];
-    const output = formatFaqResults(results);
+    const output = formatFaqResults(results, ["slack-support"]);
     expect(output).toContain("ANSWER: Just some plain text answer.");
   });
 });

--- a/src/__tests__/knowledge.test.ts
+++ b/src/__tests__/knowledge.test.ts
@@ -197,7 +197,11 @@ describe("knowledge tool search mode — FAQ metadata fetched by result id", () 
 
     const text = (result.content as Array<{ type: string; text: string }>)[0]
       .text;
-    expect(text).toBe("No FAQ results found.");
+    expect(JSON.parse(text)).toMatchObject({
+      results: [],
+      reason: "no_results",
+      domain: "slack-support, discord-faq",
+    });
   });
 
   it("does not call getFaqChunksByIds when there are zero vector hits", async () => {
@@ -211,7 +215,11 @@ describe("knowledge tool search mode — FAQ metadata fetched by result id", () 
 
     const text = (result.content as Array<{ type: string; text: string }>)[0]
       .text;
-    expect(text).toBe("No FAQ results found.");
+    expect(JSON.parse(text)).toMatchObject({
+      results: [],
+      reason: "no_results",
+      domain: "slack-support, discord-faq",
+    });
     // No ids to look up — skip the round-trip entirely.
     expect(mockGetFaqChunksByIds).not.toHaveBeenCalled();
   });

--- a/src/__tests__/search-tool.test.ts
+++ b/src/__tests__/search-tool.test.ts
@@ -153,7 +153,7 @@ describe("search tool via MCP protocol (docs format)", () => {
     expect(mockSearchChunks).toHaveBeenCalledWith([0.1], 5, "docs", "v2.0");
   });
 
-  it('returns "No results found." when no results match', async () => {
+  it("returns the scope-hint payload when no results match", async () => {
     mockEmbed.mockResolvedValueOnce([0.1]);
     mockSearchChunks.mockResolvedValueOnce([]);
 
@@ -165,7 +165,11 @@ describe("search tool via MCP protocol (docs format)", () => {
     expect(result.isError).toBeFalsy();
     const text = (result.content as Array<{ type: string; text: string }>)[0]
       .text;
-    expect(text).toBe("No results found.");
+    expect(JSON.parse(text)).toMatchObject({
+      results: [],
+      reason: "no_results",
+      domain: "docs",
+    });
   });
 
   it("filters results by min_score when provided", async () => {

--- a/src/mcp/empty-result.ts
+++ b/src/mcp/empty-result.ts
@@ -1,0 +1,65 @@
+/**
+ * Empty-result scope hint.
+ *
+ * An empty result used to be the bare string "No results found." — which
+ * teaches the caller nothing. Two distinct audiences receive it:
+ *
+ *  1. Off-topic callers. Production analytics traced the off-topic volume on
+ *     mcp.copilotkit.ai to a single misconfigured agent that has this server
+ *     registered as a general-purpose search tool. It is teachable, not
+ *     evasive: telling it what this tool actually indexes is the cheap fix.
+ *  2. Real users hitting a genuine documentation gap — the MAJORITY of the
+ *     empty-result population. They deserve something actionable too.
+ *
+ * The hint is therefore UNCONDITIONAL on empty: no classification, no
+ * scoring, no branching on query content. That is the whole point — a
+ * classifier would need a threshold, and measured score distributions show
+ * no threshold separates the two populations, so any gate would mislabel
+ * legitimate users. An unconditional hint has zero false-positive surface.
+ *
+ * The payload mirrors the shape the abuse blocklist returns on its blocked
+ * path (`results` / `domain` / `hint`, serialized as a text chunk) so callers
+ * see one consistent structure. It deliberately does NOT set `blocked` —
+ * that flag keeps meaning "matched the regex blocklist". The discriminator
+ * here follows the existing `reason` convention instead.
+ */
+
+export const NO_RESULTS_REASON = "no_results";
+
+export type EmptyResultPayload = {
+  results: never[];
+  reason: typeof NO_RESULTS_REASON;
+  domain: string;
+  hint: string;
+};
+
+/**
+ * Build the empty-result payload for a tool.
+ *
+ * `sources` is the tool's configured source list (a search tool's single
+ * `source`, or a knowledge tool's `sources`), so the domain string is derived
+ * from config rather than hard-coded to any one deployment's subject matter.
+ */
+export function emptyResultPayload(sources: string[]): EmptyResultPayload {
+  const domain = sources.join(", ");
+  return {
+    results: [],
+    reason: NO_RESULTS_REASON,
+    domain,
+    hint:
+      `No indexed content matched. This tool only searches this server's indexed sources (${domain}) — ` +
+      `see the tool description for what they cover; it is not a general-purpose web search. ` +
+      `If your question is within that scope, try rephrasing it with different or more specific terms. ` +
+      `If it falls outside that scope, use a web search instead.`,
+  };
+}
+
+/**
+ * The serialized empty-result payload, ready to emit as an MCP `text` chunk.
+ * MCP tools return text content, so the JSON-shaped payload is stringified —
+ * the calling LLM still sees the structured fields. Same approach as the
+ * blocked path in src/mcp/tools/search.ts.
+ */
+export function formatEmptyResult(sources: string[]): string {
+  return JSON.stringify(emptyResultPayload(sources));
+}

--- a/src/mcp/tools/knowledge.ts
+++ b/src/mcp/tools/knowledge.ts
@@ -14,13 +14,22 @@ import {
 import { logQuery } from "../../db/analytics.js";
 import { getAnalyticsConfig } from "../../config.js";
 import { checkBlocklist } from "../abuse-blocklist.js";
+import { formatEmptyResult } from "../empty-result.js";
 import { oauthLog } from "../../oauth/observability.js";
 
 /**
  * Format FAQ results in the standard QUESTION/ANSWER/SOURCE/CONFIDENCE format.
+ *
+ * `sources` is the tool's configured source list, used ONLY to build the
+ * empty-result scope hint (see src/mcp/empty-result.ts). It applies to both
+ * browse mode (nothing above the confidence floor) and search mode (no
+ * qualifying hit) — an empty answer is equally uninformative either way.
  */
-export function formatFaqResults(results: FaqChunkResult[]): string {
-  if (results.length === 0) return "No FAQ results found.";
+export function formatFaqResults(
+  results: FaqChunkResult[],
+  sources: string[],
+): string {
+  if (results.length === 0) return formatEmptyResult(sources);
 
   return results
     .map((r, i) =>
@@ -201,7 +210,10 @@ export function registerKnowledgeTool(
 
           return {
             content: [
-              { type: "text" as const, text: formatFaqResults(chunks) },
+              {
+                type: "text" as const,
+                text: formatFaqResults(chunks, toolConfig.sources),
+              },
             ],
           };
         } else {
@@ -290,7 +302,10 @@ export function registerKnowledgeTool(
 
           return {
             content: [
-              { type: "text" as const, text: formatFaqResults(mergedResults) },
+              {
+                type: "text" as const,
+                text: formatFaqResults(mergedResults, toolConfig.sources),
+              },
             ],
           };
         }

--- a/src/mcp/tools/search.ts
+++ b/src/mcp/tools/search.ts
@@ -10,10 +10,11 @@ import {
 import { logQuery } from "../../db/analytics.js";
 import { getAnalyticsConfig } from "../../config.js";
 import { checkBlocklist } from "../abuse-blocklist.js";
+import { formatEmptyResult } from "../empty-result.js";
 import { oauthLog } from "../../oauth/observability.js";
 
-function formatDocsResults(results: ChunkResult[]): string {
-  if (results.length === 0) return "No results found.";
+function formatDocsResults(results: ChunkResult[], sources: string[]): string {
+  if (results.length === 0) return formatEmptyResult(sources);
   return results
     .map((r, i) =>
       [
@@ -27,8 +28,8 @@ function formatDocsResults(results: ChunkResult[]): string {
     .join("\n\n---\n\n");
 }
 
-function formatCodeResults(results: ChunkResult[]): string {
-  if (results.length === 0) return "No results found.";
+function formatCodeResults(results: ChunkResult[], sources: string[]): string {
+  if (results.length === 0) return formatEmptyResult(sources);
   return results
     .map((r, i) =>
       [
@@ -42,8 +43,8 @@ function formatCodeResults(results: ChunkResult[]): string {
     .join("\n\n---\n\n");
 }
 
-function formatRawResults(results: ChunkResult[]): string {
-  if (results.length === 0) return "No results found.";
+function formatRawResults(results: ChunkResult[], sources: string[]): string {
+  if (results.length === 0) return formatEmptyResult(sources);
   return results
     .map((r, i) =>
       [
@@ -56,14 +57,21 @@ function formatRawResults(results: ChunkResult[]): string {
     .join("\n\n---\n\n");
 }
 
-function formatResults(results: ChunkResult[], format: string): string {
+// `sources` is the tool's configured source list, used ONLY to build the
+// empty-result scope hint (see src/mcp/empty-result.ts). Non-empty results
+// are formatted exactly as before.
+function formatResults(
+  results: ChunkResult[],
+  format: string,
+  sources: string[],
+): string {
   switch (format) {
     case "docs":
-      return formatDocsResults(results);
+      return formatDocsResults(results, sources);
     case "code":
-      return formatCodeResults(results);
+      return formatCodeResults(results, sources);
     default:
-      return formatRawResults(results);
+      return formatRawResults(results, sources);
   }
 }
 
@@ -260,7 +268,9 @@ export function registerSearchTool(
           content: [
             {
               type: "text" as const,
-              text: formatResults(results, toolConfig.result_format),
+              text: formatResults(results, toolConfig.result_format, [
+                toolConfig.source,
+              ]),
             },
           ],
         };


### PR DESCRIPTION
Empty results returned the bare string `No results found.` (and `No FAQ results found.` on the knowledge path). That teaches the caller nothing, and two very different audiences receive it:

- **Off-topic callers.** The off-topic volume on this server traces to a *single* misconfigured caller (`Claude-User`, all IPs in `160.79.106.0/24`, 98.2% of requests on minute :10/:11/:40/:41 — a 30-minute cron). It is an agent that has this MCP server registered as a general-purpose search tool. Teachable, not evasive.
- **Real users.** 56% of the empty-result population (257 distinct queries) is legitimate traffic hitting genuine documentation gaps.

Every empty response now carries the same `results` / `domain` / `hint` payload shape the abuse blocklist already returns on its blocked path, with `domain` derived from the tool's configured source(s).

### Design constraints honored

- **Unconditional on empty.** No classification, no scoring, no threshold, no branching on query content, no new schema column. A cosine-threshold scope classifier was specced and rejected: the gate is a tautology at `threshold == min_score`, and full scoring showed abuse max (0.3216) now *exceeds* on-topic min (0.3001), so no threshold achieves both zero false positives and full recall. An unconditional hint has zero false-positive surface.
- **`blocked` is not reused.** That flag keeps meaning "matched the regex blocklist". The empty path uses the existing `reason` convention: `reason: "no_results"`. A test asserts the empty payload has no `blocked` property.
- **Domain comes from config**, not a hard-coded subject line, so the engine stays generic. Search tools pass `[toolConfig.source]`; knowledge tools pass `toolConfig.sources` (no `type: knowledge` tool is deployed in production, so that path is engine-generic).
- Knowledge **browse** mode gets the hint too — an empty listing is equally uninformative.

### Exact hint wording

```
No indexed content matched. This tool only searches this server's indexed sources (<domain>) — see the tool description for what they cover; it is not a general-purpose web search. If your question is within that scope, try rephrasing it with different or more specific terms. If it falls outside that scope, use a web search instead.
```

Chosen so it is useful to **both** audiences and accusatory toward neither: it never asserts the query was off-topic (most recipients are legitimate), it names what the tool actually covers (which is what the misconfigured caller needs), it gives an on-topic user an actionable next step (rephrase / narrow), and it gives an out-of-scope caller the correct alternative (web search). The wording is mode-neutral ("No indexed content matched") so it reads correctly for browse mode, which has no query.

---

## RED — before any source change

New test file `src/__tests__/empty-result-scope-hint.test.ts` (10 tests, driven through the real MCP protocol via `InMemoryTransport`), run against unmodified `search.ts` / `knowledge.ts`:

```
 RUN  v4.1.2 /Users/jpr5/proj/pathfinder

 ❯ src/__tests__/empty-result-scope-hint.test.ts (10 tests | 9 failed) 16ms
     × docs format: empty vector search returns the domain + hint payload 4ms
     × code format: empty vector search returns the domain + hint payload 1ms
     × raw format: empty vector search returns the domain + hint payload 0ms
     × keyword mode: empty results carry the hint too 0ms
     × hybrid mode: empty results carry the hint too 0ms
     × min_score filtering down to zero results also carries the hint 0ms
     × browse mode: empty FAQ listing returns the domain + hint payload 1ms
     × search mode: zero vector hits return the domain + hint payload 0ms
     × search mode: hits filtered out by confidence return the hint payload 0ms

⎯⎯⎯⎯⎯⎯⎯ Failed Tests 9 ⎯⎯⎯⎯⎯⎯⎯

 FAIL  src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > docs format: empty vector search returns the domain + hint payload
AssertionError: expected 'No results found.' not to be 'No results found.' // Object.is equality
 ❯ expectScopeHint src/__tests__/empty-result-scope-hint.test.ts:95:20
     93|  */
     94| function expectScopeHint(text: string, domain: string): EmptyPayload {
     95|   expect(text).not.toBe("No results found.");
       |                    ^
     96|   expect(text).not.toBe("No FAQ results found.");
     97|   const payload = JSON.parse(text) as EmptyPayload;
 ❯ src/__tests__/empty-result-scope-hint.test.ts:192:5

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[1/9]⎯

 FAIL  src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > code format: empty vector search returns the domain + hint payload
AssertionError: expected 'No results found.' not to be 'No results found.' // Object.is equality
 ❯ expectScopeHint src/__tests__/empty-result-scope-hint.test.ts:95:20
     93|  */
     94| function expectScopeHint(text: string, domain: string): EmptyPayload {
     95|   expect(text).not.toBe("No results found.");
       |                    ^
     96|   expect(text).not.toBe("No FAQ results found.");
     97|   const payload = JSON.parse(text) as EmptyPayload;
 ❯ src/__tests__/empty-result-scope-hint.test.ts:204:5

⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯⎯[2/9]⎯
```

(Full red log: 9 failed | 1 passed — the 1 pass is the guard test asserting non-empty results are unchanged.)

## GREEN — same tests, unchanged

```
 RUN  v4.1.2 /Users/jpr5/proj/pathfinder

 ✓ src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > docs format: empty vector search returns the domain + hint payload 3ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > code format: empty vector search returns the domain + hint payload 1ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > raw format: empty vector search returns the domain + hint payload 0ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > keyword mode: empty results carry the hint too 0ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > hybrid mode: empty results carry the hint too 0ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > min_score filtering down to zero results also carries the hint 0ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > search tool: empty results carry a scope hint > non-empty results are unchanged (no hint payload) 0ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > knowledge tool: empty results carry a scope hint > browse mode: empty FAQ listing returns the domain + hint payload 0ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > knowledge tool: empty results carry a scope hint > search mode: zero vector hits return the domain + hint payload 0ms
 ✓ src/__tests__/empty-result-scope-hint.test.ts > knowledge tool: empty results carry a scope hint > search mode: hits filtered out by confidence return the hint payload 0ms

 Test Files  1 passed (1)
      Tests  10 passed (10)
   Start at  09:56:12
   Duration  136ms (transform 28ms, setup 0ms, import 70ms, tests 13ms, environment 0ms)

```

Pre-existing suite, whole repo:

```

 Test Files  178 passed | 1 skipped (179)
      Tests  3600 passed | 1 skipped (3601)
   Start at  09:53:27
   Duration  10.61s (transform 4.14s, setup 0ms, import 17.13s, tests 60.38s, environment 8ms)

```

(Four pre-existing tests that asserted the old bare strings — in `search-tool.test.ts`, `knowledge-tool.test.ts`, `knowledge.test.ts`, `knowledge-mcp.test.ts` — were updated to assert the new payload. Nothing else in the suite moved.)

## Real-surface capture (not just unit tests)

Booted the actual server locally over the real Streamable-HTTP MCP transport — `tsx src/index.ts` with `DATABASE_URL=pglite://…` (a throwaway in-process PGlite DB, **not** production) and a local config using `search_mode: keyword` so the empty path is reached without an embedding round-trip. Index is empty, so every query returns zero rows. Probe = a real `@modelcontextprotocol/sdk` `Client` doing `initialize` + `tools/call` against `http://localhost:3999/mcp`.

**BEFORE** (`src/mcp/tools/{search,knowledge}.ts` checked out from `main`):

```
TOOLS: search-local-docs
RAW RESPONSE:
{
  "content": [
    {
      "type": "text",
      "text": "No results found."
    }
  ]
}
```

**AFTER** (this branch):

```
TOOLS: search-local-docs
RAW RESPONSE:
{
  "content": [
    {
      "type": "text",
      "text": "{\"results\":[],\"reason\":\"no_results\",\"domain\":\"local-docs\",\"hint\":\"No indexed content matched. This tool only searches this server's indexed sources (local-docs) — see the tool description for what they cover; it is not a general-purpose web search. If your question is within that scope, try rephrasing it with different or more specific terms. If it falls outside that scope, use a web search instead.\"}"
    }
  ]
}
```

## Local gate

- `npm run build` — clean
- `npx tsc --noEmit` — clean
- `npm test` — 3600 passed | 1 skipped
- `npx prettier --check` on touched files — clean (the ~11 unrelated pre-existing prettier-red files under `src/**` were left alone)

## Deliberately left out

- No classifier, threshold, score gate, or schema column.
- No CHANGELOG entry / version bump — the repo's comparable change (#156) did not carry one; the entry belongs to the release cut.
- The blocked path's hard-coded `domain: "CopilotKit + AG-UI documentation"` string was left as-is rather than migrated to the config-derived domain; that is a separate cleanup with its own blast radius.
