### PR TITLE
Bring the CopilotKit API reference into the docs search index

### DIFF
--- a/deploy/copilotkit-docs.yaml
+++ b/deploy/copilotkit-docs.yaml
@@ -14,15 +14,34 @@ sources:
   - name: docs
     type: markdown
     repo: https://github.com/CopilotKit/CopilotKit.git
-    path: showcase/shell-docs/src/content/docs/
+    # Walk from src/content/ rather than src/content/docs/ so the API
+    # reference tree is reachable. It is a SIBLING of the prose docs —
+    # src/content/reference/, rendered by src/app/reference/[...slug] —
+    # so a walk rooted at src/content/docs/ can never see it, which is why
+    # only the one stray reference page committed under the prose tree
+    # (docs/reference/v2/hooks/useCapabilities.mdx) was ever indexed.
+    path: showcase/shell-docs/src/content/
     base_url: https://docs.copilotkit.ai/
     url_derivation:
-      strip_prefix: "showcase/shell-docs/src/content/docs/"
+      # First match wins, so the longer docs/ prefix must precede the
+      # shorter content/ one. Prose pages live at the site root
+      # (docs/quickstart.mdx -> /quickstart); reference pages keep their
+      # directory (reference/hooks/useAgent.mdx -> /reference/hooks/useAgent,
+      # which the [...slug] route serves as the v2 root SDK).
+      strip_prefix:
+        - "showcase/shell-docs/src/content/docs/"
+        - "showcase/shell-docs/src/content/"
       strip_suffix: ".mdx"
       strip_route_groups: true
       strip_index: true
+    # Repo-root-relative, and now load-bearing: the wider walk root also
+    # exposes snippets/ (MDX partials), ag-ui/ (owned by the ag-ui-docs
+    # source) and framework-overviews/, none of which are standalone pages.
+    # These patterns are also what scopes the incremental webhook path,
+    # which filters changed files by pattern alone with no walk-root check.
     file_patterns:
-      - "**/*.mdx"
+      - "showcase/shell-docs/src/content/docs/**/*.mdx"
+      - "showcase/shell-docs/src/content/reference/**/*.mdx"
     chunk:
       target_tokens: 600
       overlap_tokens: 50

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -792,7 +792,16 @@
                 <strong>strip_prefix</strong> — Remove this prefix from the file
                 path before generating the URL. For example,
                 <code>"docs/"</code> turns <code>docs/guide/auth.mdx</code> into
-                <code>guide/auth.mdx</code>.
+                <code>guide/auth.mdx</code>. It also accepts a list of candidate
+                prefixes, of which the first one that matches the path is
+                stripped — useful when one source spans sibling content trees
+                that sit at different URL depths. Order matters: list a longer
+                prefix before any shorter prefix that would also match it. For
+                example <code>["content/docs/", "content/"]</code> turns
+                <code>content/docs/guide.mdx</code> into
+                <code>guide.mdx</code> while turning
+                <code>content/reference/useAgent.mdx</code> into
+                <code>reference/useAgent.mdx</code>.
               </li>
               <li>
                 <strong>strip_suffix</strong> — Remove the file extension. For

--- a/src/__tests__/bash-fs.test.ts
+++ b/src/__tests__/bash-fs.test.ts
@@ -1,4 +1,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { buildBashFilesMap } from "../mcp/tools/bash-fs.js";
 import type { SourceConfig } from "../types.js";
 
@@ -98,6 +101,80 @@ describe("buildBashFilesMap", () => {
     ];
     const map = await buildBashFilesMap(sources);
     expect(Object.keys(map)).toHaveLength(0);
+  });
+
+  describe("git sources match file_patterns against repo-root-relative paths", () => {
+    // The indexer (FileDataProvider / walkSourceFiles) relativises against
+    // the REPO ROOT, so anchored patterns in a config are written that way.
+    // bash-fs must agree, or explore-* silently serves a different (here:
+    // empty) file set than search-* indexes.
+    let cloneDir: string;
+
+    beforeEach(() => {
+      cloneDir = fs.mkdtempSync(path.join(os.tmpdir(), "bash-fs-repo-"));
+      const deep = path.join(
+        cloneDir,
+        "myrepo",
+        "content",
+        "reference",
+        "hooks",
+      );
+      fs.mkdirSync(deep, { recursive: true });
+      fs.writeFileSync(path.join(deep, "useAgent.mdx"), "# useAgent\n");
+      fs.writeFileSync(
+        path.join(cloneDir, "myrepo", "content", "top.mdx"),
+        "# top\n",
+      );
+    });
+
+    afterEach(() => {
+      fs.rmSync(cloneDir, { recursive: true, force: true });
+    });
+
+    function source(filePatterns: string[]): SourceConfig[] {
+      return [
+        {
+          name: "docs",
+          type: "markdown",
+          repo: "https://github.com/example/myrepo.git",
+          path: "content/",
+          file_patterns: filePatterns,
+          chunk: { target_tokens: 600, overlap_tokens: 50 },
+        },
+      ];
+    }
+
+    it("includes files matched by a repo-root-anchored pattern", async () => {
+      const map = await buildBashFilesMap(
+        source(["content/reference/**/*.mdx"]),
+        {
+          cloneDir,
+        },
+      );
+      // Virtual paths stay relative to the source path, even though the
+      // pattern that selected them is repo-root-relative.
+      expect(Object.keys(map).sort()).toEqual([
+        "/reference/hooks/useAgent.mdx",
+      ]);
+    });
+
+    it("excludes files outside a repo-root-anchored pattern", async () => {
+      const map = await buildBashFilesMap(
+        source(["content/reference/**/*.mdx"]),
+        {
+          cloneDir,
+        },
+      );
+      expect(Object.keys(map)).not.toContain("/top.mdx");
+    });
+
+    it("still honours a catch-all pattern (pre-existing configs)", async () => {
+      const map = await buildBashFilesMap(source(["**/*.mdx"]), { cloneDir });
+      expect(Object.keys(map).sort()).toEqual([
+        "/reference/hooks/useAgent.mdx",
+        "/top.mdx",
+      ]);
+    });
   });
 
   describe("missing-path warnings", () => {

--- a/src/__tests__/url-derivation.test.ts
+++ b/src/__tests__/url-derivation.test.ts
@@ -92,6 +92,58 @@ describe("deriveUrl", () => {
     );
   });
 
+  // ── strip_prefix as an ordered candidate list ───────────────────────────
+
+  it("strips the first matching prefix from a candidate list", () => {
+    const config = makeConfig("https://example.com/", {
+      strip_prefix: ["content/docs/", "content/"],
+    });
+    expect(deriveUrl("content/docs/guide/intro.md", config)).toBe(
+      "https://example.com/guide/intro.md",
+    );
+  });
+
+  it("falls through to a later candidate when the first does not match", () => {
+    const config = makeConfig("https://example.com/", {
+      strip_prefix: ["content/docs/", "content/"],
+    });
+    expect(deriveUrl("content/reference/hooks/useAgent.md", config)).toBe(
+      "https://example.com/reference/hooks/useAgent.md",
+    );
+  });
+
+  it("stops at the first match rather than stripping every candidate", () => {
+    // "content/" also prefixes "content/docs/...". Without an early exit the
+    // second candidate would strip again and mangle the slug.
+    const config = makeConfig("https://example.com/", {
+      strip_prefix: ["content/", "docs/"],
+    });
+    expect(deriveUrl("content/docs/guide.md", config)).toBe(
+      "https://example.com/docs/guide.md",
+    );
+  });
+
+  it("leaves the path unchanged when no candidate matches", () => {
+    const config = makeConfig("https://example.com/", {
+      strip_prefix: ["src/", "lib/"],
+    });
+    expect(deriveUrl("docs/guide/intro.md", config)).toBe(
+      "https://example.com/docs/guide/intro.md",
+    );
+  });
+
+  it("treats a one-element list exactly like the plain string form", () => {
+    const asList = makeConfig("https://example.com/", {
+      strip_prefix: ["docs/"],
+    });
+    const asString = makeConfig("https://example.com/", {
+      strip_prefix: "docs/",
+    });
+    expect(deriveUrl("docs/guide/intro.md", asList)).toBe(
+      deriveUrl("docs/guide/intro.md", asString),
+    );
+  });
+
   // ── strip_suffix ────────────────────────────────────────────────────────
 
   it("strips a matching suffix", () => {

--- a/src/indexing/url-derivation.ts
+++ b/src/indexing/url-derivation.ts
@@ -15,8 +15,18 @@ export function deriveUrl(
   const d = sourceConfig.url_derivation;
   let slug = filePath;
 
-  if (d.strip_prefix && slug.startsWith(d.strip_prefix)) {
-    slug = slug.slice(d.strip_prefix.length);
+  if (d.strip_prefix) {
+    // Ordered candidates: the first prefix that matches wins, so a more
+    // specific prefix must be listed before a shorter one that also
+    // matches. A plain string behaves exactly as a one-element list.
+    const prefixes =
+      typeof d.strip_prefix === "string" ? [d.strip_prefix] : d.strip_prefix;
+    for (const prefix of prefixes) {
+      if (slug.startsWith(prefix)) {
+        slug = slug.slice(prefix.length);
+        break;
+      }
+    }
   }
   if (d.strip_suffix) {
     const re = new RegExp(escapeRegex(d.strip_suffix) + "$");

--- a/src/mcp/tools/bash-fs.ts
+++ b/src/mcp/tools/bash-fs.ts
@@ -56,15 +56,24 @@ export async function buildBashFilesMap(
   for (const source of sources) {
     if (!isFileSourceConfig(source)) continue; // Slack sources don't have filesystem paths
     let rootDir: string;
+    // `file_patterns` are matched against the path the indexer would see:
+    // repo-root-relative for a git source, rootDir-relative for a local one
+    // (see FileDataProvider and walkSourceFiles, which both relativise
+    // against the repo root). Matching against rootDir here instead would
+    // silently disagree with the index whenever `source.path` is a subtree
+    // and the patterns are anchored rather than catch-all.
+    let matchRoot: string;
     if (source.repo && options?.cloneDir) {
       // Git-based source: the orchestrator clones into cloneDir/<repoName>/
       const repoName = source.repo
         .replace(/\.git$/, "")
         .split("/")
         .pop()!;
-      rootDir = path.join(options.cloneDir, repoName, source.path);
+      matchRoot = path.join(options.cloneDir, repoName);
+      rootDir = path.join(matchRoot, source.path);
     } else {
       rootDir = path.resolve(source.path);
+      matchRoot = rootDir;
     }
     if (!fs.existsSync(rootDir)) {
       // Sources with a `repo` configured are populated asynchronously by the
@@ -90,7 +99,7 @@ export async function buildBashFilesMap(
 
     for (const absPath of allFiles) {
       const relPath = path.relative(rootDir, absPath);
-      if (!matchesPatterns(relPath, source)) continue;
+      if (!matchesPatterns(path.relative(matchRoot, absPath), source)) continue;
 
       let content: string;
       try {

--- a/src/types.ts
+++ b/src/types.ts
@@ -75,7 +75,12 @@ const AllowlistEntrySchema = z.string().superRefine((val, ctx) => {
 // ── Source configuration schemas ──────────────────────────────────────────────
 
 export const UrlDerivationConfigSchema = z.object({
-  strip_prefix: z.string().optional(),
+  // A single prefix, or an ordered list of candidates of which the FIRST
+  // one that matches the file path is stripped. A list is what lets one
+  // source span sibling content trees that sit at different URL depths —
+  // e.g. CopilotKit's prose docs live at the site root while its API
+  // reference keeps its directory in the URL.
+  strip_prefix: z.union([z.string(), z.array(z.string()).min(1)]).optional(),
   strip_suffix: z.string().optional(),
   strip_route_groups: z.boolean().optional(),
   strip_index: z.boolean().optional(),


### PR DESCRIPTION
## What

The entire CopilotKit API reference is published and live on `docs.copilotkit.ai`, and exactly **one** of its pages was in the search index. Per the gap analysis this accounts for **112 of 257 (44%)** of real user documentation-gap queries.

## Root cause — not a missing include, not an exclude rule

The reference `.mdx` files **are not under the configured crawl root at all**. They live in a *sibling* tree.

```
showcase/shell-docs/src/content/docs/        <- deploy/copilotkit-docs.yaml `path`
showcase/shell-docs/src/content/reference/   <- 184 .mdx files, never walked
```

* `deploy/copilotkit-docs.yaml:17` (pre-change) — `path: showcase/shell-docs/src/content/docs/`
* The reference tree is rendered by `showcase/shell-docs/src/app/reference/[...slug]/page.tsx` out of `REFERENCE_CONTENT_DIR = path.join(process.cwd(), "src/content/reference")` (`showcase/shell-docs/src/lib/reference-items.ts:17-20`). A walk rooted at `src/content/docs/` can never reach it.
* The one page that *was* indexed, `docs/reference/v2/hooks/useCapabilities.mdx`, is the single reference page committed under the prose tree by mistake — which is exactly why it, alone, retrieved.
* Corroboration that the scope was always meant to be wider: the webhook `path_triggers` for this source were already the **parent** `showcase/shell-docs/src/content/`. The trigger scope and the crawl scope disagreed.

Two things blocked the obvious one-line widening, and both are fixed here:

1. **`url_derivation.strip_prefix` accepted only one prefix** (`src/types.ts:78`, applied at `src/indexing/url-derivation.ts:18-20`). Prose pages need `.../content/docs/` stripped (→ `/quickstart`); reference pages need only `.../content/` stripped (→ `/reference/hooks/useAgent`). One string cannot do both, and using the shorter prefix alone would have rewritten **all 682** existing docs URLs into a wrong `/docs/...` form.
2. **`bash-fs` matched `file_patterns` against a different base than the indexer.** See "The trap" below.

## Changes

| File | Change |
|---|---|
| `src/types.ts` | `strip_prefix` accepts `string \| string[]` |
| `src/indexing/url-derivation.ts` | ordered candidates, first match wins, stops at first hit |
| `src/mcp/tools/bash-fs.ts` | match `file_patterns` repo-root-relative for git sources, matching the indexer |
| `deploy/copilotkit-docs.yaml` | widen walk root to `src/content/`, explicit `file_patterns`, ordered `strip_prefix` |
| `docs/config/index.html` | document the list form of `strip_prefix` |
| `src/__tests__/url-derivation.test.ts` | +5 tests |
| `src/__tests__/bash-fs.test.ts` | +3 tests |

## The trap this nearly shipped with

`file_patterns` are consumed by **two** code paths that disagreed on their base:

* indexer — `src/indexing/providers/file.ts:138` and `src/indexing/utils.ts:165`: relative to the **repo root**
* `explore-docs` virtual FS — `src/mcp/tools/bash-fs.ts:92`: relative to **`source.path`**

Nothing depended on the divergence, because every existing config uses catch-all patterns (`**/*.mdx`, `**/*.html`) that match under either base. The moment this config anchors its patterns, the two disagree — and `explore-docs` silently drops to **zero files**. Measured, with the new config and `bash-fs` reverted:

```
=== bash-fs WITHOUT its fix, but WITH the new anchored file_patterns ===
explore-docs virtual files for source "docs": 0
  reference pages: 0
  match "useHumanInTheLoop": 0
```

`bash-fs` now relativises against the repo root for git-backed sources (virtual paths still relative to `source.path`; local no-repo sources unaffected, both roots are the same directory). Proof the change is behaviour-preserving — **original** config, `bash-fs` before vs after:

```
=== ORIGINAL config + PRE-fix bash-fs ===      === ORIGINAL config + POST-fix bash-fs ===
explore-docs virtual files: 682                explore-docs virtual files: 682
  reference pages: 1                             reference pages: 1
  match "useHumanInTheLoop": 0                   match "useHumanInTheLoop": 0
diff => IDENTICAL
```

Note that this run also **reproduces the production symptom independently**: 682 files, 1 reference page, 0 hits for `useHumanInTheLoop` — the same "`ls -R /docs/reference` returns one file" that the gap analysis observed live.

## RED → GREEN

Real enumeration path (`walkSourceFiles`) + real URL derivation (`deriveUrl`), driven through `ServerConfigSchema`, against a local clone of `CopilotKit @ ce10479`. No database, no production, no reindex.

### RED — current config

```
config:                            deploy/copilotkit-docs.yaml
source.path:                       showcase/shell-docs/src/content/docs/
source.file_patterns:              ["**/*.mdx"]
url_derivation.strip_prefix:       "showcase/shell-docs/src/content/docs/"

TOTAL files enumerated:            682
  under content/docs/:             682
  under content/reference/:        0

Probe — API reference pages named in real user gap queries:
  [ ABSENT] .../content/reference/hooks/useAgent.mdx
  [ ABSENT] .../content/reference/hooks/useHumanInTheLoop.mdx
  [ ABSENT] .../content/reference/components/CopilotChatAssistantMessage.mdx
  [ ABSENT] .../content/reference/v1/hooks/useCopilotChat.mdx
  [ ABSENT] .../content/reference/vue/hooks/useAgent.mdx
  [INDEXED] .../content/docs/reference/v2/hooks/useCapabilities.mdx
              -> https://docs.copilotkit.ai/reference/v2/hooks/useCapabilities
  [INDEXED] .../content/docs/quickstart.mdx
              -> https://docs.copilotkit.ai/quickstart
```

### GREEN — identical command, fixed config

```
config:                            deploy/copilotkit-docs.yaml
source.path:                       showcase/shell-docs/src/content/
source.file_patterns:              ["showcase/shell-docs/src/content/docs/**/*.mdx",
                                    "showcase/shell-docs/src/content/reference/**/*.mdx"]
url_derivation.strip_prefix:       ["showcase/shell-docs/src/content/docs/",
                                    "showcase/shell-docs/src/content/"]

TOTAL files enumerated:            866
  under content/docs/:             682
  under content/reference/:        184
  other:                           0

Probe — API reference pages named in real user gap queries:
  [INDEXED] .../content/reference/hooks/useAgent.mdx
              -> https://docs.copilotkit.ai/reference/hooks/useAgent
  [INDEXED] .../content/reference/hooks/useHumanInTheLoop.mdx
              -> https://docs.copilotkit.ai/reference/hooks/useHumanInTheLoop
  [INDEXED] .../content/reference/components/CopilotChatAssistantMessage.mdx
              -> https://docs.copilotkit.ai/reference/components/CopilotChatAssistantMessage
  [INDEXED] .../content/reference/v1/hooks/useCopilotChat.mdx
              -> https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChat
  [INDEXED] .../content/reference/vue/hooks/useAgent.mdx
              -> https://docs.copilotkit.ai/reference/vue/hooks/useAgent
  [INDEXED] .../content/docs/reference/v2/hooks/useCapabilities.mdx
              -> https://docs.copilotkit.ai/reference/v2/hooks/useCapabilities
  [INDEXED] .../content/docs/quickstart.mdx
              -> https://docs.copilotkit.ai/quickstart
```

**Count delta: 682 → 866 files, +184 reference pages.**

`useHumanInTheLoop` and `useAgent` are directly what real gap queries were looking for — cluster C01 (23 queries, 20 hitting an unindexed reference page) and C18 (20 queries, 13 hitting one).

`explore-docs` matches the indexer exactly after the fix: **866** virtual files, 185 under `/reference/`.

### Live verification of every derived URL

All **184** derived reference URLs fetched:

```
checked=184 non200=1
NON-200 502  https://docs.copilotkit.ai/reference/v1/hooks/useCopilotChatHeadless_c
```

The single 502 is a transient upstream error, not a bad URL — re-fetched three times, `200 200 200`. **184/184 live.** Positive control (`/reference/hooks/useDefinitelyNotAHookXYZ`) returns **404**, so the 200s are real pages and the check is meaningful.

## URL stability — the non-negotiable

Derived URLs for the docs subtree, before vs after, path + URL:

```
docs rows RED:   682
docs rows GREEN: 682
--- diff (path TAB derived-url) ---
EMPTY DIFF: all 682 existing docs URLs unchanged
```

**Zero existing citation links change.** (682 is the count of `.mdx` files actually enumerated; the ~997 figure from the analysis was tree entries including directories and `meta.json`.)

## Deliberate, called-out consequence

`explore-docs` virtual paths for prose pages gain one segment: `/docs/quickstart.mdx` → `/docs/docs/quickstart.mdx`, alongside the new `/docs/reference/hooks/useAgent.mdx`. This affects only the bash exploration tool, whose paths are discovered at use time via `find`/`ls`/`INDEX.md` and are never a stable citation surface. The `base_url`-derived URLs that *are* cited are proven unchanged above.

## Tool description

`deploy/copilotkit-docs.yaml` `search-docs` advertises "guides, concepts, quickstarts, **API reference**, and how-tos". That promise was false and is now true. **No edit needed** — confirmed.

The webhook `path_triggers` already pointed at the parent `src/content/`, so they need no edit either.

## Sibling-config verdict — neither shares the defect

| Config | Verdict |
|---|---|
| `deploy/pathfinder-docs.yaml` | **Clean.** `type: html`, `path: docs/`. `docs/` *is* the published GitHub Pages site. All 11 local `docs/**/*.html` pages resolve live (200, or 301 trailing-slash). No repo-root sibling tree holds site content. |
| `deploy/aimock-docs.yaml` | **Clean.** `type: html`, `path: docs/`. Of 62 `.html` blobs in the repo, **62 are under `docs/` and 0 are outside it** — there is no sibling tree to miss. |

Neither is fixed here, because neither has the defect. (Unrelated minor note, not touched: aimock's `docs/og-image.html` is a social-card template rather than a page, and gets indexed as one. Different class of issue.)

## Gate

* `npx tsc --noEmit` — clean
* `npm run build` — clean
* `npm test` — **3608 passed**, 1 skipped, 179 files
* prettier — clean on all 7 touched files (pre-existing red on unrelated `src/**/*.ts` left alone)

New tests were each confirmed red before the fix and green after:

```
url-derivation.test.ts   pre-fix: 4 failed | 27 passed   post-fix: 31 passed
bash-fs.test.ts          pre-fix: 1 failed |  9 passed   post-fix: 10 passed
```
