### PR TITLE
Make a reindex actually pick up a change to a source's crawl configuration

### DIFF
--- a/src/__tests__/admin-ops-endpoints.test.ts
+++ b/src/__tests__/admin-ops-endpoints.test.ts
@@ -391,6 +391,12 @@ describe("admin ops control surface", () => {
         last_indexed: "2026-01-01T00:00:00.000Z",
         commit: "abcdef12",
         error: null,
+        // The row carries no config fingerprint (written before the column
+        // existed), so the next run cannot be proven current and will take a
+        // full walk. Surfacing the pending decision is the point: a reindex
+        // that would write zero rows is now visible BEFORE it runs.
+        next_acquire: "full",
+        next_acquire_reason: "no-stored-config-fingerprint",
       },
     ]);
   });

--- a/src/__tests__/index-state-config-fingerprint-sql.test.ts
+++ b/src/__tests__/index-state-config-fingerprint-sql.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// The orchestrator's config-change detection is only as good as the column
+// round-trip: if config_fingerprint is not SELECTed it always reads back
+// undefined (every run full-walks), and if it is not bound on the INSERT it is
+// never persisted (every run full-walks). Both failure modes are silent, so
+// pin the SQL and the binds.
+
+const mockQuery = vi.fn();
+vi.mock("../db/client.js", () => ({
+  getPool: () => ({ query: mockQuery }),
+}));
+
+vi.mock("pgvector", () => ({
+  default: { toSql: (v: unknown) => v },
+}));
+
+import { getIndexState, upsertIndexState } from "../db/queries.js";
+
+describe("index_state.config_fingerprint round-trip", () => {
+  beforeEach(() => {
+    mockQuery.mockReset();
+  });
+
+  it("SELECTs config_fingerprint and surfaces it on the state", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          source_type: "markdown",
+          source_key: "docs",
+          last_commit_sha: "abc",
+          config_fingerprint: "fp-1",
+          last_indexed_at: null,
+          status: "idle",
+          error_message: null,
+        },
+      ],
+    });
+
+    const state = await getIndexState("markdown", "docs");
+
+    expect(String(mockQuery.mock.calls[0][0])).toContain("config_fingerprint");
+    expect(state?.config_fingerprint).toBe("fp-1");
+  });
+
+  it("reads a pre-upgrade row (column absent) back as null, not undefined", async () => {
+    mockQuery.mockResolvedValueOnce({
+      rows: [
+        {
+          source_type: "markdown",
+          source_key: "docs",
+          last_commit_sha: "abc",
+          config_fingerprint: null,
+          last_indexed_at: null,
+          status: "idle",
+          error_message: null,
+        },
+      ],
+    });
+
+    const state = await getIndexState("markdown", "docs");
+    expect(state?.config_fingerprint).toBeNull();
+  });
+
+  it("persists config_fingerprint on INSERT and on CONFLICT UPDATE", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await upsertIndexState({
+      source_type: "markdown",
+      source_key: "docs",
+      last_commit_sha: "abc",
+      config_fingerprint: "fp-1",
+      status: "idle",
+    });
+
+    const [sql, binds] = mockQuery.mock.calls[0];
+    expect(String(sql)).toContain("config_fingerprint");
+    expect(String(sql)).toContain(
+      "config_fingerprint = EXCLUDED.config_fingerprint",
+    );
+    expect(binds).toContain("fp-1");
+  });
+
+  it("binds NULL rather than the string 'null' when there is no fingerprint", async () => {
+    mockQuery.mockResolvedValueOnce({ rows: [] });
+
+    await upsertIndexState({
+      source_type: "markdown",
+      source_key: "docs",
+      last_commit_sha: "abc",
+      status: "idle",
+    });
+
+    const binds = mockQuery.mock.calls[0][1] as unknown[];
+    expect(binds).toContain(null);
+    expect(binds).not.toContain("null");
+    expect(binds).not.toContain(undefined);
+  });
+});

--- a/src/__tests__/orchestrator-config-fingerprint.test.ts
+++ b/src/__tests__/orchestrator-config-fingerprint.test.ts
@@ -1,0 +1,273 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { execFileSync } from "node:child_process";
+
+// Regression: a change to a source's CRAWL CONFIGURATION (walk root,
+// file_patterns, url_derivation) must be picked up by a reindex.
+//
+// Before the fix, the acquisition branch keyed ONLY on "are there new
+// commits". Widening file_patterns leaves the commit sha untouched, so the
+// orchestrator took incrementalAcquire, which diffed HEAD against itself,
+// walked nothing, wrote zero rows — and still reported success. Observed in
+// production: PR #159 widened the docs crawl to include 184 reference .mdx
+// files; a source-scoped reindex returned 202, index_state.last_indexed
+// advanced, and zero rows were written.
+//
+// These tests drive the REAL FileDataProvider against a REAL git clone (a
+// local bare "origin" so no network is involved) through the REAL
+// orchestrator. Only the DB and the embedding/chunking pipeline are faked.
+
+const h = vi.hoisted(() => ({
+  // Mutable server config — tests swap `sources` between runs to simulate a
+  // config-only change (same commit, different crawl scope).
+  sources: [] as Record<string, unknown>[],
+  cloneDir: "",
+  repoUrl: "",
+  // In-memory index_state, keyed "type:key". Round-trips through the
+  // orchestrator exactly as the real table would.
+  indexStates: new Map<string, Record<string, unknown>>(),
+  // In-memory set of item ids currently "in the index", for stale detection.
+  indexed: new Set<string>(),
+  // Every item id handed to the pipeline, per run.
+  indexedThisRun: [] as string[],
+}));
+
+vi.mock("../config.js", () => ({
+  getConfig: () => ({
+    databaseUrl: "postgresql://test",
+    openaiApiKey: "test-key",
+    githubToken: "",
+    githubWebhookSecret: "",
+    port: 3001,
+    nodeEnv: "test",
+    logLevel: "info",
+    cloneDir: h.cloneDir,
+    slackBotToken: "",
+    slackSigningSecret: "",
+    discordBotToken: "",
+    notionToken: "",
+  }),
+  getServerConfig: () => ({
+    server: { name: "test", version: "1.0" },
+    sources: h.sources,
+    tools: [
+      {
+        name: "search",
+        type: "search",
+        description: "Search",
+        source: "docs",
+        default_limit: 5,
+        max_limit: 20,
+        result_format: "docs",
+      },
+    ],
+    embedding: {
+      provider: "openai",
+      model: "text-embedding-3-small",
+      dimensions: 1536,
+    },
+    indexing: {
+      auto_reindex: false,
+      reindex_hour_utc: 3,
+      stale_threshold_hours: 24,
+    },
+  }),
+  getIndexableSourceNames: () => new Set(["docs"]),
+  getAnalyticsConfig: () => undefined,
+}));
+
+vi.mock("../db/queries.js", () => ({
+  getIndexState: async (type: string, key: string) =>
+    h.indexStates.get(`${type}:${key}`) ?? null,
+  upsertIndexState: async (state: Record<string, unknown>) => {
+    h.indexStates.set(`${state.source_type}:${state.source_key}`, {
+      ...state,
+    });
+  },
+  getIndexedItemIds: async () => new Set(h.indexed),
+  cleanupOldWebhookDeliveries: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("../db/analytics.js", () => ({
+  cleanupOldQueryLogs: vi.fn().mockResolvedValue(0),
+}));
+
+vi.mock("../db/atlas.js", () => ({
+  markAtlasCachePagesStaleForSources: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("../indexing/embeddings.js", () => {
+  class MockEmbeddingProvider {
+    embed = vi.fn().mockResolvedValue([0.1, 0.2]);
+    embedBatch = vi.fn().mockResolvedValue([[0.1, 0.2]]);
+  }
+  return {
+    EmbeddingClient: MockEmbeddingProvider,
+    createEmbeddingProvider: () => new MockEmbeddingProvider(),
+  };
+});
+
+vi.mock("../indexing/pipeline.js", () => ({
+  IndexingPipeline: class MockIndexingPipeline {
+    async indexItems(items: { id: string }[]) {
+      for (const item of items) {
+        h.indexed.add(item.id);
+        h.indexedThisRun.push(item.id);
+      }
+      return { failedIds: [] };
+    }
+    async removeItems(ids: string[]) {
+      for (const id of ids) h.indexed.delete(id);
+      return { failedIds: [] };
+    }
+  },
+}));
+
+import { IndexingOrchestrator } from "../indexing/orchestrator.js";
+import { FileDataProvider } from "../indexing/providers/file.js";
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync(
+    "git",
+    ["-c", "user.email=t@t.test", "-c", "user.name=T", ...args],
+    { cwd, encoding: "utf8" },
+  );
+}
+
+/** Drive one source-reindex job to completion. */
+async function runSourceReindex(
+  orchestrator: IndexingOrchestrator,
+): Promise<void> {
+  h.indexedThisRun = [];
+  orchestrator.queueSourceReindex("docs");
+  for (let i = 0; i < 200; i++) {
+    await new Promise((r) => setTimeout(r, 25));
+    if (!orchestrator.isIndexing()) break;
+  }
+  await new Promise((r) => setTimeout(r, 25));
+}
+
+const MD_ONLY = ["**/*.md"];
+const MD_AND_MDX = ["**/*.md", "**/*.mdx"];
+
+function docsSource(filePatterns: string[]): Record<string, unknown> {
+  return {
+    name: "docs",
+    type: "markdown",
+    repo: h.repoUrl,
+    path: "content",
+    file_patterns: filePatterns,
+    chunk: {},
+  };
+}
+
+describe("reindex honors a source config change (same commit sha)", () => {
+  let tmp: string;
+  let orchestrator: IndexingOrchestrator;
+  let fullSpy: ReturnType<typeof vi.spyOn>;
+  let incSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    tmp = fs.mkdtempSync(path.join(os.tmpdir(), "pf-cfghash-"));
+    const originDir = path.join(tmp, "origin");
+    const workDir = path.join(tmp, "work");
+    h.cloneDir = path.join(tmp, "clones");
+    fs.mkdirSync(originDir, { recursive: true });
+    fs.mkdirSync(h.cloneDir, { recursive: true });
+
+    // Bare origin so `git pull` in ensureRepo succeeds with no network.
+    git(originDir, ["init", "--bare", "--initial-branch=main", "testrepo.git"]);
+    const originUrl = `file://${path.join(originDir, "testrepo.git")}`;
+    git(tmp, ["clone", originUrl, workDir]);
+    fs.mkdirSync(path.join(workDir, "content", "reference"), {
+      recursive: true,
+    });
+    fs.writeFileSync(
+      path.join(workDir, "content", "guide.md"),
+      "# Guide\n\nSome prose that is long enough to carry real semantic value for the chunker.\n",
+    );
+    fs.writeFileSync(
+      path.join(workDir, "content", "reference", "api.mdx"),
+      "# API Reference\n\nGenerated reference prose with enough substance to be indexed.\n",
+    );
+    git(workDir, ["add", "-A"]);
+    git(workDir, ["commit", "-m", "seed"]);
+    git(workDir, ["push", "origin", "HEAD:main"]);
+
+    h.repoUrl = originUrl;
+    h.sources = [docsSource(MD_ONLY)];
+    h.indexStates.clear();
+    h.indexed.clear();
+    h.indexedThisRun = [];
+
+    fullSpy = vi.spyOn(FileDataProvider.prototype, "fullAcquire");
+    incSpy = vi.spyOn(FileDataProvider.prototype, "incrementalAcquire");
+
+    orchestrator = new IndexingOrchestrator();
+  });
+
+  afterEach(() => {
+    fullSpy.mockRestore();
+    incSpy.mockRestore();
+    fs.rmSync(tmp, { recursive: true, force: true });
+  });
+
+  it("indexes newly-in-scope files after file_patterns widens", async () => {
+    // Run 1 — narrow scope. Establishes index_state at the current sha.
+    await runSourceReindex(orchestrator);
+    expect(h.indexedThisRun).toEqual(["content/guide.md"]);
+    const shaAfterFirstRun = h.indexStates.get("markdown:docs")
+      ?.last_commit_sha as string;
+    expect(shaAfterFirstRun).toBeTruthy();
+
+    // Config-only change: widen the crawl to include .mdx. NO new commits.
+    h.sources = [docsSource(MD_AND_MDX)];
+
+    // Run 2 — the reindex an operator would trigger after shipping the config.
+    await runSourceReindex(orchestrator);
+
+    expect(h.indexedThisRun).toContain("content/reference/api.mdx");
+    expect(h.indexed.has("content/reference/api.mdx")).toBe(true);
+    // The commit sha is unchanged — the walk was driven by the config change.
+    expect(h.indexStates.get("markdown:docs")?.last_commit_sha).toBe(
+      shaAfterFirstRun,
+    );
+  });
+
+  it("still takes the INCREMENTAL path when the config is unchanged", async () => {
+    await runSourceReindex(orchestrator);
+    expect(fullSpy).toHaveBeenCalledTimes(1); // first run: no prior state
+    fullSpy.mockClear();
+    incSpy.mockClear();
+
+    // Same config, same commit: must NOT full-walk.
+    await runSourceReindex(orchestrator);
+
+    expect(incSpy).toHaveBeenCalledTimes(1);
+    expect(fullSpy).not.toHaveBeenCalled();
+    expect(h.indexedThisRun).toEqual([]);
+  });
+
+  it("full-walks once when the stored fingerprint is absent, then goes incremental", async () => {
+    await runSourceReindex(orchestrator);
+    // Simulate a row written by a pre-upgrade deploy: sha present, fingerprint
+    // NULL. The first run after the upgrade must full-walk, and must persist a
+    // fingerprint so the run AFTER that goes incremental (no boot-storm).
+    const row = h.indexStates.get("markdown:docs")!;
+    delete row.config_fingerprint;
+    fullSpy.mockClear();
+    incSpy.mockClear();
+
+    await runSourceReindex(orchestrator);
+    expect(fullSpy).toHaveBeenCalledTimes(1);
+    expect(incSpy).not.toHaveBeenCalled();
+
+    fullSpy.mockClear();
+    incSpy.mockClear();
+    await runSourceReindex(orchestrator);
+    expect(incSpy).toHaveBeenCalledTimes(1);
+    expect(fullSpy).not.toHaveBeenCalled();
+  });
+});

--- a/src/__tests__/orchestrator-state-token-hold.test.ts
+++ b/src/__tests__/orchestrator-state-token-hold.test.ts
@@ -115,6 +115,21 @@ vi.mock("../indexing/providers/index.js", () => ({
 }));
 
 import { IndexingOrchestrator } from "../indexing/orchestrator.js";
+import { computeSourceConfigFingerprint } from "../indexing/source-fingerprint.js";
+import type { SourceConfig } from "../types.js";
+
+// The orchestrator now chooses full-vs-incremental on the commit sha AND the
+// source's crawl-config fingerprint, so a seeded state row must carry the
+// fingerprint of the source config the mocked getServerConfig returns —
+// otherwise these tests would silently drift onto the full-acquire path and
+// stop exercising the incremental token-hold behaviour they exist to pin.
+const DOCS_SOURCE_FINGERPRINT = computeSourceConfigFingerprint({
+  name: "docs",
+  type: "markdown",
+  path: "/tmp/docs",
+  file_patterns: ["**/*.md"],
+  chunk: {},
+} as SourceConfig);
 
 /** Drive a source-reindex job to completion and return when drain settles. */
 async function runSourceReindex(
@@ -151,6 +166,7 @@ describe("IndexingOrchestrator state-token hold on item failure (C1)", () => {
       source_type: "markdown",
       source_key: "docs",
       last_commit_sha: "old-token",
+      config_fingerprint: DOCS_SOURCE_FINGERPRINT,
       last_indexed_at: new Date(),
       status: "idle",
       error_message: null,

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -107,6 +107,7 @@ describe("generateSchema", () => {
         "source_type",
         "source_key",
         "last_commit_sha",
+        "config_fingerprint",
         "last_indexed_at",
         "status",
         "error_message",
@@ -169,6 +170,19 @@ describe("generatePostSchemaMigration", () => {
     const sql = generatePostSchemaMigration();
     expect(sql).toContain(
       "CREATE INDEX IF NOT EXISTS idx_chunks_version ON chunks (version)",
+    );
+  });
+
+  it("adds index_state.config_fingerprint idempotently", () => {
+    // Additive + nullable so installs whose index_state predates the column
+    // read back NULL; the orchestrator treats NULL as "unknown" and full-walks
+    // once rather than silently trusting a stale incremental.
+    const sql = generatePostSchemaMigration();
+    expect(sql).toContain(
+      "ALTER TABLE index_state ADD COLUMN IF NOT EXISTS config_fingerprint TEXT",
+    );
+    expect(sql).not.toContain(
+      "ALTER TABLE index_state ADD COLUMN IF NOT EXISTS config_fingerprint TEXT NOT NULL",
     );
   });
 

--- a/src/__tests__/schema.test.ts
+++ b/src/__tests__/schema.test.ts
@@ -186,6 +186,16 @@ describe("generatePostSchemaMigration", () => {
     );
   });
 
+  it("places index_state DDL BEFORE the query_log marker", () => {
+    // Several PGlite tests apply only the tail of this migration, sliced from
+    // the query_log marker. index_state DDL after that marker would run
+    // against a database with no index_state table and abort the whole slice.
+    const sql = generatePostSchemaMigration();
+    expect(sql.indexOf("ALTER TABLE index_state")).toBeLessThan(
+      sql.indexOf("-- Analytics: query_log table for tracking tool usage"),
+    );
+  });
+
   it("creates query_log table", () => {
     const sql = generatePostSchemaMigration();
     expect(sql).toContain("CREATE TABLE IF NOT EXISTS query_log");

--- a/src/__tests__/source-fingerprint.test.ts
+++ b/src/__tests__/source-fingerprint.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from "vitest";
+
+import {
+  computeSourceConfigFingerprint,
+  decideAcquisition,
+} from "../indexing/source-fingerprint.js";
+import { SourceConfigSchema } from "../types.js";
+import type { SourceConfig } from "../types.js";
+
+/** Parse through the real schema so defaults are applied as at runtime. */
+function source(overrides: Record<string, unknown>): SourceConfig {
+  return SourceConfigSchema.parse({
+    name: "docs",
+    type: "markdown",
+    path: "content",
+    file_patterns: ["**/*.md"],
+    ...overrides,
+  });
+}
+
+describe("computeSourceConfigFingerprint", () => {
+  it("is stable for an identical config", () => {
+    expect(computeSourceConfigFingerprint(source({}))).toBe(
+      computeSourceConfigFingerprint(source({})),
+    );
+  });
+
+  it("changes when file_patterns widens (the production regression)", () => {
+    expect(
+      computeSourceConfigFingerprint(
+        source({ file_patterns: ["**/*.md", "**/*.mdx"] }),
+      ),
+    ).not.toBe(computeSourceConfigFingerprint(source({})));
+  });
+
+  it("changes when the walk root moves", () => {
+    expect(computeSourceConfigFingerprint(source({ path: "docs" }))).not.toBe(
+      computeSourceConfigFingerprint(source({})),
+    );
+  });
+
+  it("changes when url_derivation.strip_prefix changes", () => {
+    expect(
+      computeSourceConfigFingerprint(
+        source({ url_derivation: { strip_prefix: "content/" } }),
+      ),
+    ).not.toBe(computeSourceConfigFingerprint(source({})));
+  });
+
+  it("is order-insensitive for set-valued fields", () => {
+    // Cosmetic reordering of a SET must not force a needless full walk.
+    expect(
+      computeSourceConfigFingerprint(
+        source({ file_patterns: ["**/*.mdx", "**/*.md"] }),
+      ),
+    ).toBe(
+      computeSourceConfigFingerprint(
+        source({ file_patterns: ["**/*.md", "**/*.mdx"] }),
+      ),
+    );
+    expect(
+      computeSourceConfigFingerprint(
+        source({ skip_dirs: ["b", "a"], exclude_patterns: ["y", "x"] }),
+      ),
+    ).toBe(
+      computeSourceConfigFingerprint(
+        source({ skip_dirs: ["a", "b"], exclude_patterns: ["x", "y"] }),
+      ),
+    );
+  });
+
+  it("IS order-sensitive for strip_prefix candidate lists", () => {
+    // The list is ordered — the FIRST matching candidate is the one stripped —
+    // so reordering genuinely changes the derived URLs.
+    expect(
+      computeSourceConfigFingerprint(
+        source({ url_derivation: { strip_prefix: ["a/", "a/b/"] } }),
+      ),
+    ).not.toBe(
+      computeSourceConfigFingerprint(
+        source({ url_derivation: { strip_prefix: ["a/b/", "a/"] } }),
+      ),
+    );
+  });
+
+  it("ignores fields that do not change what is enumerated", () => {
+    // chunk sizing / version / category only affect how already-enumerated
+    // content is rendered; they must not force a full re-walk of every source.
+    expect(
+      computeSourceConfigFingerprint(
+        source({ chunk: { target_tokens: 900 }, version: "2", name: "other" }),
+      ),
+    ).toBe(computeSourceConfigFingerprint(source({})));
+  });
+
+  it("covers non-file source types", () => {
+    const slack = (channels: string[]) =>
+      computeSourceConfigFingerprint(
+        SourceConfigSchema.parse({ name: "faq", type: "slack", channels }),
+      );
+    expect(slack(["C1", "C2"])).toBe(slack(["C2", "C1"]));
+    expect(slack(["C1"])).not.toBe(slack(["C1", "C2"]));
+
+    const notion = (roots: string[]) =>
+      computeSourceConfigFingerprint(
+        SourceConfigSchema.parse({
+          name: "wiki",
+          type: "notion",
+          root_pages: roots,
+        }),
+      );
+    expect(notion(["p1"])).not.toBe(notion(["p1", "p2"]));
+  });
+});
+
+describe("decideAcquisition", () => {
+  it("full-walks when there is no prior state", () => {
+    expect(decideAcquisition(null, null, "fp")).toEqual({
+      mode: "full",
+      reason: "no-prior-state",
+    });
+  });
+
+  it("full-walks ONCE when the stored fingerprint is NULL (pre-upgrade row)", () => {
+    // NULL is "unknown", not "unchanged": we cannot prove the indexed content
+    // matches the current config. The orchestrator persists the fingerprint on
+    // success, so this is a one-time cost per source, not a per-boot one.
+    expect(decideAcquisition("sha", null, "fp")).toEqual({
+      mode: "full",
+      reason: "no-stored-config-fingerprint",
+    });
+  });
+
+  it("full-walks when the config fingerprint differs", () => {
+    expect(decideAcquisition("sha", "old", "new")).toEqual({
+      mode: "full",
+      reason: "config-changed",
+    });
+  });
+
+  it("goes incremental when the sha exists AND the fingerprint matches", () => {
+    expect(decideAcquisition("sha", "fp", "fp")).toEqual({
+      mode: "incremental",
+      reason: "config-unchanged",
+    });
+  });
+});

--- a/src/__tests__/strip-nul-bytes-sweep.test.ts
+++ b/src/__tests__/strip-nul-bytes-sweep.test.ts
@@ -150,6 +150,7 @@ describe("upsertIndexState NUL sanitization", () => {
       source_type: `git${NUL}hub`,
       source_key: `repo${NUL}-key`,
       last_commit_sha: `sha${NUL}123`,
+      config_fingerprint: `fp${NUL}1`,
       last_indexed_at: new Date(0),
       status: "error",
       error_message: `invalid byte sequence for encoding "UTF8": 0x${NUL}00`,
@@ -158,17 +159,19 @@ describe("upsertIndexState NUL sanitization", () => {
     expect(poolQuery).toHaveBeenCalledTimes(1);
     const [sql, params] = poolQuery.mock.calls[0];
     expect(String(sql)).toContain("INSERT INTO index_state");
-    const [sourceType, sourceKey, sha, , status, errMsg] = params as unknown[];
+    const [sourceType, sourceKey, sha, fingerprint, , status, errMsg] =
+      params as unknown[];
     expect(sourceType).toBe("github");
     expect(sourceKey).toBe("repo-key");
     expect(sha).toBe("sha123");
+    expect(fingerprint).toBe("fp1");
     expect(status).toBe("error");
     expect(String(errMsg)).not.toContain(NUL);
     expect(String(errMsg)).toBe(
       'invalid byte sequence for encoding "UTF8": 0x00',
     );
 
-    for (const v of [sourceType, sourceKey, sha, status, errMsg]) {
+    for (const v of [sourceType, sourceKey, sha, fingerprint, status, errMsg]) {
       expect(String(v)).not.toContain(NUL);
     }
   });
@@ -184,8 +187,9 @@ describe("upsertIndexState NUL sanitization", () => {
     });
 
     const [, params] = poolQuery.mock.calls[0];
-    const [, , sha, lastAt, , err] = params as unknown[];
+    const [, , sha, fingerprint, lastAt, , err] = params as unknown[];
     expect(sha).toBeNull();
+    expect(fingerprint).toBeNull();
     expect(lastAt).toBeNull();
     expect(err).toBeNull();
   });
@@ -202,7 +206,7 @@ describe("upsertIndexState NUL sanitization", () => {
       error_message: null,
     });
     const [, params] = poolQuery.mock.calls[0];
-    expect((params as unknown[])[4]).toBe("idle");
+    expect((params as unknown[])[5]).toBe("idle");
   });
 });
 

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -884,7 +884,7 @@ export async function getIndexState(
 ): Promise<IndexState | null> {
   const pool = getPool();
   const sql = `
-        SELECT source_type, source_key, last_commit_sha, last_indexed_at, status, error_message
+        SELECT source_type, source_key, last_commit_sha, config_fingerprint, last_indexed_at, status, error_message
         FROM index_state
         WHERE source_type = $1 AND source_key = $2
     `;
@@ -903,6 +903,7 @@ export async function getIndexState(
     source_type: row.source_type,
     source_key: row.source_key,
     last_commit_sha: row.last_commit_sha,
+    config_fingerprint: row.config_fingerprint ?? null,
     last_indexed_at: row.last_indexed_at,
     status: row.status as IndexStatus,
     error_message: row.error_message,
@@ -916,14 +917,15 @@ export async function upsertIndexState(state: IndexState): Promise<void> {
   const pool = getPool();
   const sql = `
         INSERT INTO index_state
-            (source_type, source_key, last_commit_sha, last_indexed_at, status, error_message)
+            (source_type, source_key, last_commit_sha, config_fingerprint, last_indexed_at, status, error_message)
         VALUES
-            ($1, $2, $3, $4, $5, $6)
+            ($1, $2, $3, $4, $5, $6, $7)
         ON CONFLICT (source_type, source_key) DO UPDATE SET
-            last_commit_sha = EXCLUDED.last_commit_sha,
-            last_indexed_at = EXCLUDED.last_indexed_at,
-            status          = EXCLUDED.status,
-            error_message   = EXCLUDED.error_message
+            last_commit_sha    = EXCLUDED.last_commit_sha,
+            config_fingerprint = EXCLUDED.config_fingerprint,
+            last_indexed_at    = EXCLUDED.last_indexed_at,
+            status             = EXCLUDED.status,
+            error_message      = EXCLUDED.error_message
     `;
   // Sanitize every text-typed bind. The highest-risk column here is
   // error_message: it's populated with raw upstream errors, which in the
@@ -938,6 +940,9 @@ export async function upsertIndexState(state: IndexState): Promise<void> {
     stripNulBytes(state.source_type),
     stripNulBytes(state.source_key),
     state.last_commit_sha == null ? null : stripNulBytes(state.last_commit_sha),
+    state.config_fingerprint == null
+      ? null
+      : stripNulBytes(state.config_fingerprint),
     state.last_indexed_at ?? null,
     stripNulBytes(state.status ?? "idle"),
     state.error_message == null ? null : stripNulBytes(state.error_message),
@@ -1387,7 +1392,7 @@ export async function getIndexStats(): Promise<IndexStats> {
       "SELECT count(DISTINCT repo_url)::int AS count FROM chunks WHERE repo_url IS NOT NULL",
     ),
     pool.query(
-      "SELECT source_type, source_key, last_commit_sha, last_indexed_at, status, error_message FROM index_state ORDER BY source_type, source_key",
+      "SELECT source_type, source_key, last_commit_sha, config_fingerprint, last_indexed_at, status, error_message FROM index_state ORDER BY source_type, source_key",
     ),
   ]);
 
@@ -1407,6 +1412,7 @@ export async function getIndexStats(): Promise<IndexStats> {
       source_type: r.source_type as string,
       source_key: r.source_key as string,
       last_commit_sha: r.last_commit_sha as string | null,
+      config_fingerprint: (r.config_fingerprint as string | null) ?? null,
       last_indexed_at: r.last_indexed_at as Date | null,
       status: r.status as IndexStatus,
       error_message: r.error_message as string | null,

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -34,6 +34,7 @@ CREATE TABLE IF NOT EXISTS index_state (
     source_type     TEXT NOT NULL,
     source_key      TEXT NOT NULL,
     last_commit_sha TEXT,
+    config_fingerprint TEXT,
     last_indexed_at TIMESTAMPTZ,
     status          TEXT NOT NULL DEFAULT 'idle',
     error_message   TEXT,
@@ -156,6 +157,18 @@ CREATE INDEX IF NOT EXISTS idx_query_log_client_ip ON query_log (client_ip);
 -- score_kind = 'cosine', so legacy rows are EXCLUDED rather than misread. The
 -- score-based cards therefore start empty and refill as new traffic lands.
 ALTER TABLE query_log ADD COLUMN IF NOT EXISTS score_kind TEXT;
+
+-- index_state.config_fingerprint (v1.16.1). A stable hash of the fields of a
+-- source's config that decide WHAT gets walked and how paths/URLs map. The
+-- orchestrator previously chose incremental-vs-full acquisition on the commit
+-- sha alone, so a config-only scope change (widening file_patterns, moving
+-- path, changing url_derivation) diffed HEAD against itself and indexed
+-- nothing while reporting success. Additive and nullable, so installs whose
+-- index_state predates the column read back NULL; the orchestrator treats
+-- NULL as "unknown" and takes ONE full walk per source, which persists the
+-- fingerprint — a one-time cost, not a per-boot one. The CREATE TABLE above
+-- carries the column for fresh installs.
+ALTER TABLE index_state ADD COLUMN IF NOT EXISTS config_fingerprint TEXT;
 
 -- Webhook delivery tracking
 CREATE TABLE IF NOT EXISTS webhook_deliveries (

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -72,6 +72,11 @@ DROP TABLE IF EXISTS code_chunks CASCADE;
  * Returns ONLY core DDL that works on both PostgreSQL and PGlite:
  * - tsvector support for hybrid search (v1.8.0): the `tsv` column, a one-time
  *   populate of existing rows, and the GIN index.
+ * - The idempotent `index_state.config_fingerprint` ADD COLUMN. It sits
+ *   BEFORE the query_log section on purpose: several PGlite tests slice this
+ *   DDL from the query_log marker to the end of the string and apply only
+ *   that tail, so index_state DDL placed after the marker would run against a
+ *   database that has no index_state table.
  * - The analytics `query_log` table (+ its indexes and the idempotent
  *   `request_source` ADD COLUMN for back-compat).
  * - The `webhook_deliveries` table (+ its indexes).
@@ -93,6 +98,18 @@ UPDATE chunks SET tsv = to_tsvector('english', content) WHERE tsv IS NULL;
 
 -- GIN index for fast full-text search
 CREATE INDEX IF NOT EXISTS idx_chunks_tsv ON chunks USING GIN (tsv);
+
+-- index_state.config_fingerprint (v1.16.1). A stable hash of the fields of a
+-- source's config that decide WHAT gets walked and how paths/URLs map. The
+-- orchestrator previously chose incremental-vs-full acquisition on the commit
+-- sha alone, so a config-only scope change (widening file_patterns, moving
+-- path, changing url_derivation) diffed HEAD against itself and indexed
+-- nothing while reporting success. Additive and nullable, so installs whose
+-- index_state predates the column read back NULL; the orchestrator treats
+-- NULL as "unknown" and takes ONE full walk per source, which persists the
+-- fingerprint — a one-time cost, not a per-boot one. The CREATE TABLE above
+-- carries the column for fresh installs.
+ALTER TABLE index_state ADD COLUMN IF NOT EXISTS config_fingerprint TEXT;
 
 -- Analytics: query_log table for tracking tool usage
 --
@@ -157,18 +174,6 @@ CREATE INDEX IF NOT EXISTS idx_query_log_client_ip ON query_log (client_ip);
 -- score_kind = 'cosine', so legacy rows are EXCLUDED rather than misread. The
 -- score-based cards therefore start empty and refill as new traffic lands.
 ALTER TABLE query_log ADD COLUMN IF NOT EXISTS score_kind TEXT;
-
--- index_state.config_fingerprint (v1.16.1). A stable hash of the fields of a
--- source's config that decide WHAT gets walked and how paths/URLs map. The
--- orchestrator previously chose incremental-vs-full acquisition on the commit
--- sha alone, so a config-only scope change (widening file_patterns, moving
--- path, changing url_derivation) diffed HEAD against itself and indexed
--- nothing while reporting success. Additive and nullable, so installs whose
--- index_state predates the column read back NULL; the orchestrator treats
--- NULL as "unknown" and takes ONE full walk per source, which persists the
--- fingerprint — a one-time cost, not a per-boot one. The CREATE TABLE above
--- carries the column for fresh installs.
-ALTER TABLE index_state ADD COLUMN IF NOT EXISTS config_fingerprint TEXT;
 
 -- Webhook delivery tracking
 CREATE TABLE IF NOT EXISTS webhook_deliveries (

--- a/src/indexing/orchestrator.ts
+++ b/src/indexing/orchestrator.ts
@@ -15,6 +15,10 @@ import type { EmbeddingProvider } from "./embeddings.js";
 import { getProvider } from "./providers/index.js";
 import { IndexingPipeline } from "./pipeline.js";
 import {
+  computeSourceConfigFingerprint,
+  decideAcquisition,
+} from "./source-fingerprint.js";
+import {
   getIndexState,
   upsertIndexState,
   cleanupOldWebhookDeliveries,
@@ -184,11 +188,29 @@ export class IndexingOrchestrator {
         const currentToken = await this.getSourceStateToken(source);
         const state = await getIndexState(source.type, source.name);
 
-        if (currentToken === null || state?.last_commit_sha !== currentToken) {
+        // A KNOWN-but-different config fingerprint means the crawl scope
+        // changed since the last successful index, so "sha matches" is no
+        // longer sufficient evidence that the index is current. A NULL stored
+        // fingerprint deliberately does NOT queue here: on the first boot
+        // after this column ships every source would read NULL, and queuing
+        // them all would full-walk the whole fleet at startup. Those sources
+        // pick up their fingerprint on their next scheduled/triggered
+        // reindex, which full-walks once (see decideAcquisition).
+        const configChanged =
+          state?.config_fingerprint != null &&
+          state.config_fingerprint !== computeSourceConfigFingerprint(source);
+
+        if (
+          currentToken === null ||
+          state?.last_commit_sha !== currentToken ||
+          configChanged
+        ) {
           const reason =
             currentToken === null
               ? "source unavailable (clone missing?)"
-              : `remote ${currentToken.slice(0, 8)} differs from indexed`;
+              : configChanged
+                ? "crawl config changed since last index"
+                : `remote ${currentToken.slice(0, 8)} differs from indexed`;
           console.log(
             `[orchestrator] ${reason} for ${source.name} — queuing reindex`,
           );
@@ -756,14 +778,32 @@ export class IndexingOrchestrator {
           "indexing",
         );
 
+        const configFingerprint = computeSourceConfigFingerprint(sourceConfig);
+
         try {
           const state = await getIndexState(
             sourceConfig.type,
             sourceConfig.name,
           );
+          // The acquisition mode depends on the effective source CONFIG as
+          // well as the commit sha. Keying on the sha alone silently drops
+          // every config-scope change: widening file_patterns (or moving
+          // `path`, or changing url_derivation) leaves the sha untouched, so
+          // incrementalAcquire diffs HEAD against itself, walks nothing, and
+          // the job reports success having written zero rows.
+          const decision = decideAcquisition(
+            state?.last_commit_sha,
+            state?.config_fingerprint,
+            configFingerprint,
+          );
+          // Log the mode AND why. A no-op that reports success is exactly the
+          // failure this fix addresses, so the reason is worth one line.
+          console.log(
+            `[orchestrator] ${sourceConfig.name}: ${decision.mode} acquire (${decision.reason})`,
+          );
           let result;
-          if (state?.last_commit_sha) {
-            result = await provider.incrementalAcquire(state.last_commit_sha);
+          if (decision.mode === "incremental") {
+            result = await provider.incrementalAcquire(state!.last_commit_sha!);
           } else {
             result = await provider.fullAcquire();
           }
@@ -814,6 +854,12 @@ export class IndexingOrchestrator {
             source_type: sourceConfig.type,
             source_key: sourceConfig.name,
             last_commit_sha: result.stateToken,
+            // Persist the config fingerprint ONLY on a fully successful run,
+            // symmetric with last_commit_sha. A held/errored run leaves the
+            // prior (possibly NULL) fingerprint in place, so the next run
+            // re-evaluates and full-walks again rather than recording a
+            // config as "applied" that was never fully walked.
+            config_fingerprint: configFingerprint,
             last_indexed_at: new Date(),
             status: "idle",
           });
@@ -883,6 +929,10 @@ export class IndexingOrchestrator {
       source_type: sourceType,
       source_key: sourceKey,
       last_commit_sha: existing?.last_commit_sha ?? null,
+      // Preserve, never advance: a status write is not evidence that the
+      // current config was successfully walked. Same discipline as the state
+      // token above.
+      config_fingerprint: existing?.config_fingerprint ?? null,
       last_indexed_at: existing?.last_indexed_at ?? null,
       status,
       error_message: errorMessage ?? null,

--- a/src/indexing/source-fingerprint.ts
+++ b/src/indexing/source-fingerprint.ts
@@ -1,0 +1,170 @@
+// Fingerprint of a source's effective CRAWL configuration.
+//
+// The orchestrator's acquisition branch used to key only on "are there new
+// commits". That silently loses every config-scope change: widening
+// `file_patterns`, moving `path`, or changing `url_derivation` leaves the
+// commit sha untouched, so the incremental path diffs HEAD against itself,
+// walks nothing, writes zero rows — and reports success. Persisting this
+// fingerprint alongside `last_commit_sha` lets the orchestrator notice that
+// the *question* changed even when the *answer's inputs* (the commits) did
+// not, and take a full walk.
+//
+// Scope: the fields folded in here are exactly those that determine WHICH
+// items get enumerated and HOW their paths/URLs are derived. Fields that only
+// affect how already-enumerated content is rendered downstream — `chunk`
+// sizing, `version`, `category`, `distiller_model` — are deliberately
+// EXCLUDED: changing them does not make a previously-invisible item visible,
+// so they must not force a full re-walk of every source.
+
+import { createHash } from "node:crypto";
+
+import type { SourceConfig } from "../types.js";
+
+/**
+ * Bump when the *definition* of the fingerprint changes (a field is added to
+ * or removed from the covered set). A bump makes every stored fingerprint
+ * mismatch, which costs one full walk per source — the same cost as the
+ * NULL-fingerprint path, and for the same reason: we can no longer prove the
+ * stored value answers the current question.
+ */
+const FINGERPRINT_VERSION = 1;
+
+/**
+ * Order-insensitive normalization for fields that are semantically a SET, so
+ * cosmetic reordering in the YAML does not force a needless full walk.
+ */
+function asSet(values: readonly string[] | undefined): string[] | undefined {
+  return values === undefined ? undefined : [...values].sort();
+}
+
+/**
+ * Fields covered per source type. Everything listed changes enumeration or
+ * path/URL output.
+ */
+function fingerprintPayload(config: SourceConfig): Record<string, unknown> {
+  switch (config.type) {
+    case "markdown":
+    case "code":
+    case "raw-text":
+    case "html":
+    case "document":
+      return {
+        type: config.type,
+        repo: config.repo ?? null,
+        branch: config.branch ?? null,
+        path: config.path,
+        base_url: config.base_url ?? null,
+        // url_derivation.strip_prefix may be a LIST, and that list is ORDERED
+        // — the first candidate that matches is the one stripped — so it is
+        // NOT sorted. Reordering it genuinely changes the derived URLs.
+        url_derivation: config.url_derivation
+          ? {
+              strip_prefix: config.url_derivation.strip_prefix ?? null,
+              strip_suffix: config.url_derivation.strip_suffix ?? null,
+              strip_route_groups:
+                config.url_derivation.strip_route_groups ?? null,
+              strip_index: config.url_derivation.strip_index ?? null,
+            }
+          : null,
+        file_patterns: asSet(config.file_patterns),
+        exclude_patterns: asSet(config.exclude_patterns) ?? null,
+        skip_dirs: asSet(config.skip_dirs) ?? null,
+        max_file_size: config.max_file_size ?? null,
+      };
+    case "slack":
+      return {
+        type: config.type,
+        channels: asSet(config.channels),
+        trigger_emoji: config.trigger_emoji,
+        min_thread_replies: config.min_thread_replies,
+        confidence_threshold: config.confidence_threshold,
+      };
+    case "discord":
+      return {
+        type: config.type,
+        guild_id: config.guild_id,
+        channels: [...config.channels]
+          .map((c) => `${c.id}:${c.type}`)
+          .sort(),
+        min_thread_replies: config.min_thread_replies,
+        confidence_threshold: config.confidence_threshold,
+      };
+    case "notion":
+      return {
+        type: config.type,
+        root_pages: asSet(config.root_pages),
+        databases: asSet(config.databases),
+        max_depth: config.max_depth,
+        include_properties: config.include_properties,
+      };
+    case "atlas":
+      return {
+        type: config.type,
+        seed_path: config.seed_path ?? null,
+        cache_namespace: config.cache_namespace ?? null,
+        repositories: (config.repositories ?? [])
+          .map((r) =>
+            JSON.stringify({
+              repo_url: r.repo_url,
+              refs: asSet(r.refs) ?? null,
+              subsystems: asSet(r.subsystems) ?? null,
+            }),
+          )
+          .sort(),
+      };
+  }
+}
+
+/**
+ * Stable hex fingerprint of a source's effective crawl configuration.
+ *
+ * Stable across process restarts and across cosmetic reordering of set-valued
+ * fields; changes whenever a covered field changes.
+ */
+export function computeSourceConfigFingerprint(config: SourceConfig): string {
+  const payload = fingerprintPayload(config);
+  // Sort keys so the serialization does not depend on object literal order.
+  const canonical = JSON.stringify(
+    payload,
+    Object.keys(payload).sort(),
+  );
+  return createHash("sha256")
+    .update(`v${FINGERPRINT_VERSION}:${canonical}`)
+    .digest("hex")
+    .slice(0, 32);
+}
+
+/** Why the orchestrator chose full vs incremental acquisition. */
+export type AcquisitionReason =
+  | "no-prior-state"
+  | "no-stored-config-fingerprint"
+  | "config-changed"
+  | "config-unchanged";
+
+export interface AcquisitionDecision {
+  mode: "full" | "incremental";
+  reason: AcquisitionReason;
+}
+
+/**
+ * Decide how to acquire, given the persisted state and the current config
+ * fingerprint.
+ *
+ * A NULL/missing stored fingerprint means "unknown" — we cannot prove the
+ * indexed content matches the current config, so we take ONE full walk and
+ * persist the fingerprint. It is a one-time cost per source on the first run
+ * after this ships, not a per-boot cost: the fingerprint is written on
+ * success, so the next run compares equal and goes incremental.
+ */
+export function decideAcquisition(
+  storedSha: string | null | undefined,
+  storedFingerprint: string | null | undefined,
+  currentFingerprint: string,
+): AcquisitionDecision {
+  if (!storedSha) return { mode: "full", reason: "no-prior-state" };
+  if (!storedFingerprint)
+    return { mode: "full", reason: "no-stored-config-fingerprint" };
+  if (storedFingerprint !== currentFingerprint)
+    return { mode: "full", reason: "config-changed" };
+  return { mode: "incremental", reason: "config-unchanged" };
+}

--- a/src/indexing/source-fingerprint.ts
+++ b/src/indexing/source-fingerprint.ts
@@ -83,9 +83,7 @@ function fingerprintPayload(config: SourceConfig): Record<string, unknown> {
       return {
         type: config.type,
         guild_id: config.guild_id,
-        channels: [...config.channels]
-          .map((c) => `${c.id}:${c.type}`)
-          .sort(),
+        channels: [...config.channels].map((c) => `${c.id}:${c.type}`).sort(),
         min_thread_replies: config.min_thread_replies,
         confidence_threshold: config.confidence_threshold,
       };

--- a/src/indexing/source-fingerprint.ts
+++ b/src/indexing/source-fingerprint.ts
@@ -116,18 +116,34 @@ function fingerprintPayload(config: SourceConfig): Record<string, unknown> {
 }
 
 /**
+ * Deterministic JSON: object keys sorted at EVERY depth, arrays left in order.
+ *
+ * Not `JSON.stringify(value, sortedKeys)` — passing a key array as the
+ * replacer filters keys at every level against that ONE list, which silently
+ * drops nested objects' contents (url_derivation would serialize as `{}`,
+ * making a strip_prefix change invisible to the fingerprint).
+ */
+function canonicalJson(value: unknown): string {
+  if (Array.isArray(value)) {
+    return `[${value.map(canonicalJson).join(",")}]`;
+  }
+  if (value !== null && typeof value === "object") {
+    const entries = Object.entries(value as Record<string, unknown>)
+      .sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0))
+      .map(([k, v]) => `${JSON.stringify(k)}:${canonicalJson(v)}`);
+    return `{${entries.join(",")}}`;
+  }
+  return JSON.stringify(value) ?? "null";
+}
+
+/**
  * Stable hex fingerprint of a source's effective crawl configuration.
  *
  * Stable across process restarts and across cosmetic reordering of set-valued
  * fields; changes whenever a covered field changes.
  */
 export function computeSourceConfigFingerprint(config: SourceConfig): string {
-  const payload = fingerprintPayload(config);
-  // Sort keys so the serialization does not depend on object literal order.
-  const canonical = JSON.stringify(
-    payload,
-    Object.keys(payload).sort(),
-  );
+  const canonical = canonicalJson(fingerprintPayload(config));
   return createHash("sha256")
     .update(`v${FINGERPRINT_VERSION}:${canonical}`)
     .digest("hex")

--- a/src/server.ts
+++ b/src/server.ts
@@ -38,10 +38,16 @@ import {
   isDiscordSourceConfig,
   isFileSourceConfig,
   type FaqChunkResult,
+  type IndexState,
+  type IndexStatus,
   type ServerConfig,
 } from "./types.js";
 import { IndexingOrchestrator } from "./indexing/orchestrator.js";
 import { runReindexAudit } from "./indexing/reindex-audit.js";
+import {
+  computeSourceConfigFingerprint,
+  decideAcquisition,
+} from "./indexing/source-fingerprint.js";
 
 import {
   createWebhookHandler,
@@ -2087,6 +2093,50 @@ app.post("/messages", ...sseHandlers.postHandler);
 // Health check
 // ---------------------------------------------------------------------------
 
+/**
+ * Operator-facing projection of one index_state row, shared by /health and the
+ * admin `index-stats` op so the two shapes stay in sync.
+ *
+ * `next_acquire` / `next_acquire_reason` answer the question that cost us a
+ * silent no-op in production: will the next run for this source actually walk
+ * anything? A reindex that reported success while writing zero rows was
+ * indistinguishable from a real one; now the pending decision (and WHY) is
+ * visible before the run rather than inferred afterwards from row counts.
+ */
+export function projectIndexStateForOperators(s: IndexState): {
+  type: string;
+  key: string;
+  status: IndexStatus | undefined;
+  last_indexed: Date | null | undefined;
+  commit: string | null;
+  error: string | null;
+  next_acquire: "full" | "incremental" | null;
+  next_acquire_reason: string | null;
+} {
+  // The source may have been removed from the config while its index_state
+  // row survives; there is then no current config to compare against.
+  const sourceConfig = getServerConfig().sources.find(
+    (candidate) => candidate.name === s.source_key,
+  );
+  const decision = sourceConfig
+    ? decideAcquisition(
+        s.last_commit_sha,
+        s.config_fingerprint,
+        computeSourceConfigFingerprint(sourceConfig),
+      )
+    : null;
+  return {
+    type: s.source_type,
+    key: s.source_key,
+    status: s.status,
+    last_indexed: s.last_indexed_at,
+    commit: s.last_commit_sha?.slice(0, 8) ?? null,
+    error: s.error_message ?? null,
+    next_acquire: decision?.mode ?? null,
+    next_acquire_reason: decision?.reason ?? null,
+  };
+}
+
 export interface HealthRouteDeps {
   getIndexStats?: typeof getIndexStats;
   getWebhookDeliveryStats?: typeof getWebhookDeliveryStats;
@@ -2143,14 +2193,7 @@ export function registerHealthRoute(
           total_chunks: stats.totalChunks,
           by_source: stats.bySource,
           indexed_repos: stats.indexedRepos,
-          sources: stats.indexStates.map((s) => ({
-            type: s.source_type,
-            key: s.source_key,
-            status: s.status,
-            last_indexed: s.last_indexed_at,
-            commit: s.last_commit_sha?.slice(0, 8) ?? null,
-            error: s.error_message ?? null,
-          })),
+          sources: stats.indexStates.map(projectIndexStateForOperators),
         },
         ...(deliveryStats ? { webhook_deliveries: deliveryStats } : {}),
       });
@@ -3892,14 +3935,7 @@ function buildAdminOpRegistry(
             total_chunks: stats.totalChunks,
             by_source: stats.bySource,
             indexed_repos: stats.indexedRepos,
-            sources: stats.indexStates.map((s) => ({
-              type: s.source_type,
-              key: s.source_key,
-              status: s.status,
-              last_indexed: s.last_indexed_at,
-              commit: s.last_commit_sha?.slice(0, 8) ?? null,
-              error: s.error_message ?? null,
-            })),
+            sources: stats.indexStates.map(projectIndexStateForOperators),
           },
         };
       } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -635,6 +635,13 @@ export interface IndexState {
   source_type: string;
   source_key: string;
   last_commit_sha?: string | null;
+  /**
+   * Hash of the source's effective crawl configuration at the time of the
+   * last successful index (see indexing/source-fingerprint.ts). NULL means
+   * "unknown" — written before the column existed, or never indexed — and the
+   * orchestrator responds by taking a full walk.
+   */
+  config_fingerprint?: string | null;
   last_indexed_at?: Date | null;
   status?: IndexStatus;
   error_message?: string | null;


### PR DESCRIPTION
## What was broken

`indexSourceWithState` chose its acquisition mode on the commit sha alone:

```ts
if (state?.last_commit_sha) {
  result = await provider.incrementalAcquire(state.last_commit_sha);
} else {
  result = await provider.fullAcquire();
}
```

When a source's **config** changes — walk root, `file_patterns`,
`url_derivation`/`strip_prefix` — the commit sha is unchanged. So
`incrementalAcquire` diffed HEAD against itself, walked nothing, and exited.
`runFullReindex` calls the same helper, so `{"scope":"full"}` was a no-op too.
There was no reindex operation that could apply a config-scope change, and the
job reported success while writing zero rows.

**Production evidence.** PR #159 widened the docs crawl to include 184
reference `.mdx` files. A source-scoped reindex returned 202,
`index_state.last_indexed` advanced, and zero rows were written — docs stayed
at 552 files / 3437 chunks, with 0 files under `content/reference/`.

## The fix

The acquisition decision now depends on the **effective source configuration**
as well as the sha.

- `src/indexing/source-fingerprint.ts` derives a stable sha256 fingerprint of
  the fields that decide *what gets walked and how paths map*. For file
  sources: `type`, `repo`, `branch`, `path`, `base_url`, `url_derivation`
  (all four sub-fields), `file_patterns`, `exclude_patterns`, `skip_dirs`,
  `max_file_size`. Slack/Discord/Notion/Atlas have their own equivalent field
  sets. Set-valued fields are sorted so cosmetic reordering does not force a
  needless full walk; `url_derivation.strip_prefix` is deliberately **not**
  sorted, because that list is ordered (first match wins) and reordering it
  genuinely changes the derived URLs. Fields that only affect how
  already-enumerated content is rendered — `chunk`, `version`, `category`,
  `distiller_model` — are excluded, so changing them does not full-walk the
  fleet.
- Persisted as `index_state.config_fingerprint`, an additive nullable column
  following the `query_log` `ADD COLUMN IF NOT EXISTS` convention. Written only
  on a fully successful run, symmetric with `last_commit_sha`; a held/errored
  run preserves the prior value rather than recording a config as "applied"
  that was never fully walked.
- Full acquire when the fingerprint is absent or differs; incremental only when
  the sha exists **and** the fingerprint matches.

## Migration / first-deploy behaviour for operators

- The `ALTER TABLE index_state ADD COLUMN IF NOT EXISTS config_fingerprint
  TEXT` runs automatically as part of the post-schema migration. It is additive
  and nullable, so existing rows read back NULL.
- **NULL is treated as "unknown", not "unchanged".** The first indexing run per
  source after this deploys takes one full walk and persists the fingerprint;
  every run after that compares equal and goes incremental. It is a one-time
  cost per source, not a per-boot cost.
- **No boot storm.** The startup `checkAndIndex` path queues a reindex on a
  *known-but-different* fingerprint only. A NULL fingerprint deliberately does
  not queue at startup — otherwise every source would full-walk on the first
  boot after this ships. Those sources pick up their fingerprint on their next
  scheduled or triggered reindex.
- **For the docs regression specifically:** after deploy, a source-scoped
  reindex of `docs` will take a full walk (reason
  `no-stored-config-fingerprint`) and pick up the 184 reference `.mdx` files.

## Surfacing full-vs-incremental

Yes — a silent no-op reporting success is what this cost us, so the reason is
now visible in two places:

- One log line per run: `[orchestrator] docs: full acquire (config-changed)`,
  with reasons `no-prior-state` / `no-stored-config-fingerprint` /
  `config-changed` / `config-unchanged`.
- `/health` and the admin `index-stats` op carry `next_acquire` and
  `next_acquire_reason` per source, so a reindex that would write nothing is
  visible **before** it runs rather than inferred afterwards from row counts.
  The reindex endpoint itself only enqueues, so it cannot report the mode.

## Red-green proof

`src/__tests__/orchestrator-config-fingerprint.test.ts` drives the **real**
`FileDataProvider` against a **real** git clone (a local bare origin, no
network) through the **real** orchestrator; only the DB and the
embedding/chunking pipeline are faked. Run 1 indexes with
`file_patterns: ["**/*.md"]`; the config is then widened to include `**/*.mdx`
with no new commits; run 2 must index the newly-in-scope file.

**RED** (unmodified code):

```
[file-provider:docs] Pulling latest changes for testrepo
[file-provider:docs] No new commits, skipping
[orchestrator] Indexing complete for docs

 FAIL  ... > indexes newly-in-scope files after file_patterns widens
AssertionError: expected [] to include 'content/reference/api.mdx'

 FAIL  ... > full-walks once when the stored fingerprint is absent, then goes incremental
AssertionError: expected "fullAcquire" to be called 1 times, but got 0 times

 Test Files  1 failed (1)
      Tests  2 failed | 1 passed (3)
```

It fails by indexing **zero** files while the job logs `Indexing complete` —
the exact production symptom, not an error.

**GREEN** (same test, unchanged):

```
[orchestrator] docs: full acquire (no-prior-state)
[file-provider:docs] Found 1 files for full acquire (1 excluded by patterns)
[orchestrator] docs: full acquire (config-changed)
 ✓ indexes newly-in-scope files after file_patterns widens 356ms

[orchestrator] docs: full acquire (no-prior-state)
[orchestrator] docs: incremental acquire (config-unchanged)
 ✓ still takes the INCREMENTAL path when the config is unchanged 318ms

[orchestrator] docs: full acquire (no-prior-state)
[orchestrator] docs: full acquire (no-stored-config-fingerprint)
[orchestrator] docs: incremental acquire (config-unchanged)
 ✓ full-walks once when the stored fingerprint is absent, then goes incremental 457ms

      Tests  15 passed (15)
```

**The negative assertion matters as much as the positive one.** The second test
asserts that an unchanged config with an unchanged sha still takes
`incrementalAcquire` and never calls `fullAcquire` — spied on the real
`FileDataProvider.prototype`. That test **passes on unmodified code too**: it
is the guard against "fixing" this by making everything always full-reindex,
which would be a performance regression rather than a fix. The third test pins
that a NULL fingerprint full-walks exactly **once** and then settles back to
incremental.

One implementation bug was caught by these tests before it shipped: the first
canonicalization used `JSON.stringify(payload, sortedKeys)`, whose key-array
replacer filters keys at *every* depth — so `url_derivation` serialized as `{}`
and a `strip_prefix` reorder was invisible to the fingerprint. Replaced with a
recursive canonical serializer.

## Full local gate

- `npm run build` — clean
- `npx tsc --noEmit` — clean
- `npm test` — `184 passed | 1 skipped`, `3684 passed`. The only failures are
  the 4 pre-existing `src/__tests__/cli.test.ts` cases, proven pre-existing by
  a positive control: checking out bare `origin/main` (`0874baf`) in the same
  worktree reproduces the identical 4 failures and nothing else.
- `npx prettier --check` on every touched file — clean

One incidental fix: the new `ALTER TABLE index_state` is placed **before** the
`-- Analytics: query_log` marker in `generatePostSchemaMigration()`. Several
PGlite tests slice that DDL from the marker to the end of the string and apply
only the tail; index_state DDL after the marker runs against a database with no
`index_state` table and aborts the whole slice. A guard test in
`schema.test.ts` pins the ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErcmeS9SFqc9ggEz5Rjpwp
