### PR TITLE
Index the 96 AG-UI documentation pages hosted on docs.copilotkit.ai

### DIFF
--- a/deploy/copilotkit-docs.yaml
+++ b/deploy/copilotkit-docs.yaml
@@ -34,14 +34,27 @@ sources:
       strip_suffix: ".mdx"
       strip_route_groups: true
       strip_index: true
-    # Repo-root-relative, and now load-bearing: the wider walk root also
-    # exposes snippets/ (MDX partials), ag-ui/ (owned by the ag-ui-docs
-    # source) and framework-overviews/, none of which are standalone pages.
-    # These patterns are also what scopes the incremental webhook path,
-    # which filters changed files by pattern alone with no walk-root check.
+    # Repo-root-relative, and load-bearing: the wide walk root also exposes
+    # snippets/ (MDX partials) and framework-overviews/, neither of which is
+    # a standalone page. These patterns are also what scopes the incremental
+    # webhook path, which filters changed files by pattern alone with no
+    # walk-root check.
+    #
+    # ag-ui/ IS listed: those 96 files are live pages on THIS site,
+    # docs.copilotkit.ai/ag-ui/<slug>, served by src/app/ag-ui/[[...slug]],
+    # and all 96 are in the production sitemap. CopilotKit includes AG-UI, so
+    # they belong in the CopilotKit docs index. They are near-duplicates of
+    # the upstream ag-ui-protocol/ag-ui docs tree indexed by the `ag-ui-docs`
+    # source below, but that copy answers for docs.ag-ui.com and hands back
+    # docs.ag-ui.com links; this one hands back the copilotkit.ai links a
+    # CopilotKit user is reading. The ordered strip_prefix above needs no
+    # change for them — ag-ui/ is not under content/docs/, so it falls
+    # through to the content/ prefix and keeps its directory:
+    # content/ag-ui/concepts/agents.mdx -> /ag-ui/concepts/agents.
     file_patterns:
       - "showcase/shell-docs/src/content/docs/**/*.mdx"
       - "showcase/shell-docs/src/content/reference/**/*.mdx"
+      - "showcase/shell-docs/src/content/ag-ui/**/*.mdx"
     # Trees in this repo that hold .mdx but are CORRECTLY unclaimed, recorded
     # so the unclaimed-content audit (reindex-audit Check 4) stays quiet about
     # them. Pooled across every source reading CopilotKit/CopilotKit.
@@ -51,12 +64,9 @@ sources:
     #   examples/  — per-example READMEs for the demo apps, not on the site.
     #   showcase/integrations/ — per-integration setup notes that live with
     #                the integration app, not on docs.copilotkit.ai.
-    # NOT listed, deliberately: showcase/shell-docs/src/content/ag-ui/. Those
-    # 96 files ARE live pages (docs.copilotkit.ai/ag-ui/<slug>, all 96 in the
-    # sitemap) served by src/app/ag-ui/[[...slug]] — the same shape as the
-    # reference tree this check was built for. The audit should keep saying so
-    # until someone decides whether to index them here or leave them to
-    # docs.ag-ui.com.
+    # content/ag-ui/ is deliberately absent from this list and always will
+    # be: it is not exempt, it is CLAIMED by the file_patterns above. An
+    # exemption there would re-blind the audit to a tree of live pages.
     unclaimed_exempt_paths:
       - "showcase/shell-docs/src/content/snippets"
       - "examples"
@@ -177,7 +187,7 @@ sources:
 tools:
   - name: search-docs
     type: search
-    description: "Search the CopilotKit product documentation (https://docs.copilotkit.ai) — guides, concepts, quickstarts, API reference, and how-tos for building with CopilotKit. Use this for CopilotKit usage and configuration questions. NOT for AG-UI protocol docs (use search-ag-ui-docs) and NOT for source code (use search-code). This is a semantic search, so prefer performing multiple queries with different phrases instead of a single long query, until you find all the context you need."
+    description: "Search the CopilotKit product documentation (https://docs.copilotkit.ai) — guides, concepts, quickstarts, API reference, how-tos for building with CopilotKit, and the AG-UI protocol pages hosted on the CopilotKit docs site (docs.copilotkit.ai/ag-ui/...). Use this for CopilotKit usage and configuration questions. For the upstream AG-UI protocol documentation at docs.ag-ui.com use search-ag-ui-docs; for source code use search-code. This is a semantic search, so prefer performing multiple queries with different phrases instead of a single long query, until you find all the context you need."
     source: docs
     default_limit: 5
     max_limit: 20
@@ -197,7 +207,7 @@ tools:
 
   - name: search-ag-ui-docs
     type: search
-    description: "Search the AG-UI protocol documentation (https://docs.ag-ui.com) — the Agent-User Interaction protocol spec, event types, message schemas, and framework integration guides. Use this for protocol-level questions about AG-UI. NOT for CopilotKit product docs (use search-docs) and NOT for source code (use search-ag-ui-code). This is a semantic search, so prefer performing multiple queries with different phrases instead of a single long query, until you find all the context you need."
+    description: "Search the upstream AG-UI protocol documentation (https://docs.ag-ui.com) — the Agent-User Interaction protocol spec, event types, message schemas, and framework integration guides. Use this for protocol-level questions about AG-UI when you want the canonical ag-ui.com source; the CopilotKit docs site hosts its own near-identical copy of these pages, which search-docs returns with docs.copilotkit.ai links. NOT for CopilotKit product docs (use search-docs) and NOT for source code (use search-ag-ui-code). This is a semantic search, so prefer performing multiple queries with different phrases instead of a single long query, until you find all the context you need."
     source: ag-ui-docs
     default_limit: 5
     max_limit: 20

--- a/scripts/test-path-filter.ts
+++ b/scripts/test-path-filter.ts
@@ -63,9 +63,11 @@ const codeConfig = makeFileSourceConfig(
   ],
 );
 
-// Docs source config — mirrors the real `docs` source: only *.mdx, no excludes.
-// (The source path is showcase/shell-docs/src/content/docs/, so derived paths
-// live under that tree.)
+// Docs source config — a deliberately generic *.mdx matcher for the glob
+// logic itself. The real `docs` source walks showcase/shell-docs/src/content/
+// and names its three page subtrees (docs/, reference/, ag-ui/) explicitly;
+// that shipped config is asserted against directly in
+// src/__tests__/copilotkit-docs-config.test.ts.
 const docsConfig = makeFileSourceConfig(["**/*.mdx"]);
 
 console.log("=== Path Filter Tests ===\n");
@@ -187,7 +189,7 @@ assert(
 assert(matchesPatterns("src/index.ts", codeConfig), "root src file included");
 
 // --- docs (*.mdx only) ---
-// Paths reflect the current docs source tree: showcase/shell-docs/src/content/docs/
+// Paths reflect the prose subtree of the docs source: content/docs/.
 console.log("\n--- docs (*.mdx only) ---");
 assert(
   matchesPatterns(

--- a/src/__tests__/copilotkit-docs-config.test.ts
+++ b/src/__tests__/copilotkit-docs-config.test.ts
@@ -51,9 +51,9 @@ describe("deploy/copilotkit-docs.yaml — docs source coverage", () => {
   });
 
   it("does not claim MDX partials, which are inlined into pages", () => {
-    expect(matchesPatterns(CONTENT + "snippets/installation.mdx", docsSource)).toBe(
-      false,
-    );
+    expect(
+      matchesPatterns(CONTENT + "snippets/installation.mdx", docsSource),
+    ).toBe(false);
   });
 
   it("leaves the ag-ui tree out of the unclaimed-audit exemptions now that it is claimed", () => {
@@ -65,7 +65,10 @@ describe("deploy/copilotkit-docs.yaml — docs source coverage", () => {
 describe("deploy/copilotkit-docs.yaml — derived URLs match the live routes", () => {
   it.each([
     // src/app/ag-ui/[[...slug]] serves the ag-ui tree UNDER /ag-ui/.
-    ["ag-ui/concepts/agents.mdx", "https://docs.copilotkit.ai/ag-ui/concepts/agents"],
+    [
+      "ag-ui/concepts/agents.mdx",
+      "https://docs.copilotkit.ai/ag-ui/concepts/agents",
+    ],
     [
       "ag-ui/sdk/js/core/events.mdx",
       "https://docs.copilotkit.ai/ag-ui/sdk/js/core/events",

--- a/src/__tests__/copilotkit-docs-config.test.ts
+++ b/src/__tests__/copilotkit-docs-config.test.ts
@@ -1,0 +1,85 @@
+// Guards the SHIPPED production config, deploy/copilotkit-docs.yaml, on the
+// two properties that decide whether a live documentation page is findable and
+// whether the link a search result hands back actually resolves:
+//
+//   1. which repository files the `docs` source claims, and
+//   2. the URL each claimed file derives.
+//
+// Both were silently wrong before. The API reference — 184 pages under
+// src/content/reference/ — went unindexed for months because the walk root was
+// its sibling, and the ag-ui tree's 96 live pages went unindexed because
+// file_patterns never named it. Neither failure was visible from any unit test
+// over synthetic configs, because the defect lived in the YAML that ships.
+//
+// The derivation half matters just as much in the other direction: the ordered
+// strip_prefix list is first-match-wins, so reordering or widening it mints
+// plausible URLs that 404 — a search result that lies, which is worse than a
+// missing one. These assertions pin one page per subtree.
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { parse as parseYaml } from "yaml";
+import { ServerConfigSchema, isFileSourceConfig } from "../types.js";
+import { matchesPatterns } from "../indexing/utils.js";
+import { deriveUrl } from "../indexing/url-derivation.js";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const CONFIG_PATH = resolve(REPO_ROOT, "deploy/copilotkit-docs.yaml");
+
+const config = ServerConfigSchema.parse(
+  parseYaml(readFileSync(CONFIG_PATH, "utf8")),
+);
+const docsSource = config.sources.find((s) => s.name === "docs");
+if (!docsSource || !isFileSourceConfig(docsSource)) {
+  throw new Error("deploy/copilotkit-docs.yaml has no file source named docs");
+}
+
+const CONTENT = "showcase/shell-docs/src/content/";
+
+describe("deploy/copilotkit-docs.yaml — docs source coverage", () => {
+  it.each([
+    ["ag-ui/concepts/agents.mdx"],
+    ["ag-ui/concepts/architecture.mdx"],
+    ["ag-ui/agentic-protocols.mdx"],
+    ["ag-ui/sdk/js/core/events.mdx"],
+    ["docs/quickstart.mdx"],
+    ["reference/hooks/useAgent.mdx"],
+  ])("claims %s", (rel) => {
+    expect(matchesPatterns(CONTENT + rel, docsSource)).toBe(true);
+  });
+
+  it("does not claim MDX partials, which are inlined into pages", () => {
+    expect(matchesPatterns(CONTENT + "snippets/installation.mdx", docsSource)).toBe(
+      false,
+    );
+  });
+
+  it("leaves the ag-ui tree out of the unclaimed-audit exemptions now that it is claimed", () => {
+    const exempt = docsSource.unclaimed_exempt_paths ?? [];
+    expect(exempt.some((p) => p.includes("content/ag-ui"))).toBe(false);
+  });
+});
+
+describe("deploy/copilotkit-docs.yaml — derived URLs match the live routes", () => {
+  it.each([
+    // src/app/ag-ui/[[...slug]] serves the ag-ui tree UNDER /ag-ui/.
+    ["ag-ui/concepts/agents.mdx", "https://docs.copilotkit.ai/ag-ui/concepts/agents"],
+    [
+      "ag-ui/sdk/js/core/events.mdx",
+      "https://docs.copilotkit.ai/ag-ui/sdk/js/core/events",
+    ],
+    ["ag-ui/introduction.mdx", "https://docs.copilotkit.ai/ag-ui/introduction"],
+    // Prose pages live at the site ROOT — the longer content/docs/ prefix
+    // must keep winning over the shorter content/ one.
+    ["docs/quickstart.mdx", "https://docs.copilotkit.ai/quickstart"],
+    // Reference pages keep their directory.
+    [
+      "reference/hooks/useAgent.mdx",
+      "https://docs.copilotkit.ai/reference/hooks/useAgent",
+    ],
+  ])("derives %s -> %s", (rel, expected) => {
+    expect(deriveUrl(CONTENT + rel, docsSource)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## What is wrong

`showcase/shell-docs/src/content/ag-ui/` in CopilotKit/CopilotKit is **96 `.mdx` files that are live documentation pages** — served at `https://docs.copilotkit.ai/ag-ui/<slug>` by `src/app/ag-ui/[[...slug]]`, and all 96 are in the production sitemap. **No configured source claimed a single one of them.** The `docs` source already walked their parent directory (`src/content/`, widened in #159), but its `file_patterns` named only the `docs/` and `reference/` subtrees.

#163's new `unclaimed_content` check found this on its first real run and deliberately left it unexempted, pending a decision. The decision: **index them here — CopilotKit includes AG-UI.**

## Extend the existing source, not a new one

A `type: search` tool takes exactly **one** `source`, so a separate `copilotkit-ag-ui-docs` source could not feed `search-docs` — it would need a *third* docs tool, sitting between two that already confuse each other (`search-docs` and `search-ag-ui-docs`). That is the opposite of "CopilotKit includes AG-UI". The tree also needs no different walk root, no different `base_url`, no different derivation, and the webhook `path_triggers` for `docs` already cover `src/content/`. One more `file_patterns` entry is the whole change.

Honest note on overlap: 94 of these 96 files also exist in `ag-ui-protocol/ag-ui`'s `docs/` tree, which the `ag-ui-docs` source already indexes — mostly the same prose, drifted in formatting. They are indexed twice on purpose, because the two copies hand back **different links**: `ag-ui-docs` answers with `docs.ag-ui.com/...`, this one with the `docs.copilotkit.ai/ag-ui/...` page a CopilotKit reader is actually on. Both tool descriptions now say so, so an agent can route deliberately instead of guessing.

## No change to `url_derivation` — and proof that none was needed

The ordered `strip_prefix` list is first-match-wins, and getting it wrong here would mint plausible URLs that 404 — a search result that lies, which is worse than no result. `ag-ui/` is not under `content/docs/`, so it falls through to the `content/` prefix and keeps its directory. Verified against the real route, not by reading the YAML.

## Red → green (real enumeration + real URL derivation, fresh checkout `7a36707ab`, no DB, no production)

Harness calls the shipped `walkSourceFiles()` and `deriveUrl()` over the real config.

**RED** (config as on `main`):

```
TOTAL enumerated: 866
  content/docs/:      682
  content/reference/: 184
  content/ag-ui/:     0
  [ ABSENT] .../content/ag-ui/concepts/agents.mdx
  [ ABSENT] .../content/ag-ui/concepts/architecture.mdx
  [ ABSENT] .../content/ag-ui/agentic-protocols.mdx
  [ ABSENT] .../content/ag-ui/sdk/js/core/events.mdx
```

**GREEN** (this branch):

```
TOTAL enumerated: 962
  content/docs/:      682
  content/reference/: 184
  content/ag-ui/:     96
  [PRESENT] .../ag-ui/concepts/agents.mdx     -> https://docs.copilotkit.ai/ag-ui/concepts/agents
  [PRESENT] .../ag-ui/concepts/architecture.mdx -> https://docs.copilotkit.ai/ag-ui/concepts/architecture
  [PRESENT] .../ag-ui/agentic-protocols.mdx   -> https://docs.copilotkit.ai/ag-ui/agentic-protocols
  [PRESENT] .../ag-ui/sdk/js/core/events.mdx  -> https://docs.copilotkit.ai/ag-ui/sdk/js/core/events
```

## URL correctness: 96/96

Every one of the 96 derived URLs was checked against the production sitemap (`curl -s https://docs.copilotkit.ai/sitemap.xml`, 3791 locs):

- **96 / 96 derived URLs appear in the sitemap.** Zero misses in either direction — the sitemap's only extra `/ag-ui` entry is `/ag-ui` itself, the overview page with no backing file (its body is rendered inline by `OverviewContent`), correctly not derived.
- Live fetch of all 96 with a genuine 404 positive control (`/ag-ui/concepts/agents-definitely-not-a-page` → **404**): **88 return HTTP 200**, 8 return **HTTP 500**.

The 8 are `development/updates`, `sdk/dart/client/overview`, and six `sdk/rust/*` pages. They are **not** a derivation error: an invented slug on the same route returns a clean 404, these return 500 *after* the route matched, they are in the sitemap, and they 500 identically before and after this change (nothing here touches the docs site). That is a pre-existing render fault on docs.copilotkit.ai and worth a separate issue on CopilotKit/CopilotKit. Indexing them is still right — the content is real and the links become good the moment the site is fixed.

## No regression: the existing 866 URLs are byte-identical

Full `path → URL` manifests for the `docs/` and `reference/` subtrees, before and after, diffed:

```
red rows: 866   green rows (excluding ag-ui): 866
diff exit=0, 0 lines            cmp: BYTE-IDENTICAL
```

`docs/quickstart.mdx → /quickstart` and `reference/hooks/useAgent.mdx → /reference/hooks/useAgent` both unchanged.

## The `unclaimed_content` finding clears

#163's check, run against the updated config over the same checkouts:

| | before | after |
|---|---|---|
| CopilotKit/CopilotKit | `showcase/shell-docs/src/content/ag-ui  .mdx x96` | **no unclaimed clusters** |
| ag-ui-protocol/ag-ui | `middlewares  .ts x34` | `middlewares  .ts x34` (unchanged, unrelated) |

The audit that found this goes quiet, and **no new cluster appears**.

## Regression guard

`src/__tests__/copilotkit-docs-config.test.ts` is new and reads the **shipped** `deploy/copilotkit-docs.yaml`, asserting through the real `matchesPatterns` and `deriveUrl` which files the `docs` source claims and what URL each derives. Both of this config's silent failures — the reference tree, and now ag-ui — were invisible to every existing unit test precisely because they lived in the YAML rather than in a fixture. Committed red (4 failing coverage cases), green after the config change.

## Deploying this: a reindex is needed, and it should fire by itself

Indexing the pages requires a full walk of the `docs` source — merging the config does not move content on its own. #160's `config_fingerprint` should force that automatically, because `file_patterns` is one of the fields folded into the fingerprint. Measured on the two configs:

```
2bf63ca62d74ba10ad4698363f3c5f7b   docs source @ origin/main
8274a4799a6d331b97b48a4a74a74cc5   docs source @ this branch
```

The stored fingerprint no longer matches, so the orchestrator's acquisition branch takes the full-walk path instead of diffing HEAD against itself.

**How an operator confirms it landed**, after deploy and the next reindex:

1. `/health` — the `docs` source's document count moves from ~866 toward ~962.
2. The reindex audit reports no unclaimed cluster for CopilotKit/CopilotKit.
3. `search-docs` for something only these pages say (e.g. "AG-UI RunAgentInput", "AG-UI Rust SDK subscriber") returns results with `docs.copilotkit.ai/ag-ui/...` URLs.

If the count does not move, the fingerprint path did not fire and a manual full reindex of the `docs` source is the fallback.

## Local gate

`npm run build` ✅ · `npx tsc --noEmit` ✅ · `npm test` **191 files / 3730 tests passed, 0 failed** ✅ · `node scripts/check-test-shapes.mjs` ✅ · `npx prettier --check` on all three touched files ✅
