### PR TITLE
Exclude machine-relay traffic from the operator-facing analytics surfaces

### DIFF
--- a/deploy/copilotkit-docs.yaml
+++ b/deploy/copilotkit-docs.yaml
@@ -278,6 +278,31 @@ indexing:
 
 analytics:
   enabled: true
+  # Machines that forward somebody else's text into the tools verbatim. Their
+  # traffic is real but it is NOT a user query, so it is excluded from Top
+  # Queries, the weekly search report, the gap analysis and the unique-IP /
+  # session counts. The dashboard's "Excluded Machine-Relay Traffic" panel
+  # enumerates what each rule removed; `?request_source=relay` on any
+  # analytics endpoint reads the excluded rows back.
+  #
+  # Measured 2026-09-12 over a 7-day window: this relay produced 46 of 1,318
+  # rows from ONE IP (152.55.178.126, inside Railway's 152.55.176.0/20) with
+  # User-Agent `node`, against a legitimate control of 130 IPs across 58 UAs.
+  # It had forwarded 23 SEO-spam GitHub issues into search-docs/search-code
+  # within seconds of each being filed, and those bodies — 3.3 KB of
+  # marketing copy carrying live backlinks — ranked in Top Queries and were
+  # on course to be published verbatim into Notion.
+  #
+  # DELETE THIS RULE once the relay sends `X-Pathfinder-Source: github-triage`
+  # at MCP session init: that header tags its rows `relay` and the exclusion
+  # holds without any fingerprint. The rule is the bridge, not the fix.
+  machine_relays:
+    - name: github-issue-triage
+      reason: >-
+        CopilotKit GitHub-issue triage relay (Railway) — forwards every new
+        issue body verbatim into search-docs/search-code
+      user_agent: node
+      client_ip_cidr: 152.55.176.0/20
 
 webhook:
   repo_sources:

--- a/docs/analytics.html
+++ b/docs/analytics.html
@@ -537,6 +537,41 @@
       <tbody></tbody>
     </table>
 
+    <h2 id="relayExclusionsTitle" style="margin-bottom: 4px">
+      Excluded Machine-Relay Traffic &#x1F501;
+    </h2>
+    <p
+      id="relayExclusionsSubtitle"
+      style="
+        color: var(--text-secondary, #6b7280);
+        margin-top: 0;
+        margin-bottom: 12px;
+        font-size: 14px;
+      "
+    >
+      Machines that forward somebody else's text into the tools verbatim (our
+      GitHub-issue triage relay, for one). Real traffic, but not user queries —
+      so these rows are excluded from every panel above and from the weekly and
+      gap-analysis reports. <em>Tag</em> means the client declared itself with
+      the <code>X-Pathfinder-Source</code> header; <em>fingerprint</em> means
+      this server recognized it from an
+      <code>analytics.machine_relays</code> rule. Nothing is hidden: append
+      <code>?request_source=relay</code> to any analytics endpoint to read the
+      excluded rows.
+    </p>
+    <table id="relayExclusionsTable">
+      <thead>
+        <tr>
+          <th>Rule</th>
+          <th>How</th>
+          <th>Rows Excluded</th>
+          <th>Last Seen</th>
+          <th>Why</th>
+        </tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+
     <div
       id="login"
       style="
@@ -762,6 +797,24 @@
               source_name: "code",
               count: 7,
               last_seen: new Date(Date.now() - 3600 * 1000 * 8).toISOString(),
+            },
+          ],
+          "/api/analytics/relay-exclusions": [
+            {
+              name: "x-pathfinder-source",
+              reason:
+                "Client declared itself a machine relay via the X-Pathfinder-Source header",
+              kind: "tag",
+              count: 18,
+              last_seen: new Date(Date.now() - 900 * 1000).toISOString(),
+            },
+            {
+              name: "github-issue-triage",
+              reason:
+                "GitHub-issue triage relay forwards issue bodies verbatim into search",
+              kind: "fingerprint",
+              count: 46,
+              last_seen: new Date(Date.now() - 3600 * 1000 * 5).toISOString(),
             },
           ],
           "/api/analytics/blocked-queries": [
@@ -1811,6 +1864,10 @@
             if (m) daysParam = "?days=" + m[1];
           }
           var blockedUrl = "/api/analytics/blocked-queries" + daysParam;
+          // Relay-exclusions panel takes the same window as everything else.
+          // It deliberately ignores the audience filter: its whole job is to
+          // report what the audience filter REMOVED.
+          var relayUrl = "/api/analytics/relay-exclusions" + daysParam;
           // Same '?' / leading-'&' handling as summary above.
           var toolCountsUrl =
             "/api/analytics/tool-counts" +
@@ -1830,6 +1887,7 @@
             fetchJson(emptyUrl, gen),
             fetchJson(toolCountsUrl, gen),
             fetchJson(blockedUrl, gen),
+            fetchJson(relayUrl, gen),
           ]);
           if (gen !== loadGeneration) return; // stale response — abort
 
@@ -1867,6 +1925,11 @@
           var blockedQueries = settledValueOr(
             settled[4],
             "blocked queries",
+            [],
+          );
+          var relayExclusions = settledValueOr(
+            settled[5],
+            "relay exclusions",
             [],
           );
 
@@ -2302,6 +2365,44 @@
                 })
                 .join("") ||
               '<tr><td colspan="4">No blocked queries in this window.</td></tr>';
+          }
+
+          // Relay-exclusions title tracks the same window label.
+          var relayTitle = document.getElementById("relayExclusionsTitle");
+          if (relayTitle) {
+            relayTitle.textContent =
+              "Excluded Machine-Relay Traffic (" + winLabel + ") ";
+            var loop = document.createElement("span");
+            loop.textContent = "🔁";
+            relayTitle.appendChild(loop);
+          }
+
+          // One row per rule, INCLUDING rules that matched nothing — a
+          // declared rule with a zero count is how an operator learns a
+          // stale exclusion can be deleted.
+          var relayBody = document.querySelector("#relayExclusionsTable tbody");
+          if (relayBody) {
+            relayBody.innerHTML =
+              asArray(relayExclusions)
+                .map(function (r) {
+                  return (
+                    "<tr><td>" +
+                    esc(String(r.name)) +
+                    "</td><td>" +
+                    esc(r.kind === "tag" ? "tag" : "fingerprint") +
+                    "</td><td>" +
+                    esc(safeNumber(r.count).toLocaleString()) +
+                    "</td><td>" +
+                    esc(
+                      r.last_seen ? formatAnalyticsTimestamp(r.last_seen) : "—",
+                    ) +
+                    "</td><td>" +
+                    esc(r.reason ? String(r.reason) : "—") +
+                    "</td></tr>"
+                  );
+                })
+                .join("") ||
+              '<tr><td colspan="5">No machine-relay exclusions configured.</td></tr>';
           }
         } catch (err) {
           // Stale-response guard also applies to failures: a slow old

--- a/docs/config/index.html
+++ b/docs/config/index.html
@@ -1615,6 +1615,23 @@
             <strong>retention_days</strong> — How long to keep analytics data
             before automatic cleanup. Default 90 days.
           </li>
+          <li>
+            <strong>machine_relays</strong> — Machines that forward somebody
+            else&rsquo;s text into your tools verbatim (an issue-triage bot, a
+            mirroring service). Their traffic is real, but it is not a user
+            query, so matching rows are excluded from Top Queries, the
+            empty-result panel, the unique-IP and session counts, and the
+            scheduled reports. Each rule takes a <code>name</code>, an optional
+            <code>reason</code>, and the predicates
+            <code>user_agent</code> (exact, case-insensitive) and
+            <code>client_ip_cidr</code> (IPv4 CIDR); a rule matches when every
+            predicate it declares matches. Nothing is hidden: the dashboard
+            lists every rule and what it removed, and
+            <code>?request_source=relay</code> on any analytics endpoint reads
+            the excluded rows back. Prefer having the relay send
+            <code>X-Pathfinder-Source</code> at MCP session init instead — a
+            self-declaring relay needs no rule here.
+          </li>
         </ul>
 
         <p>
@@ -1622,7 +1639,8 @@
           and latency metrics. API endpoints:
           <code>/api/analytics/summary</code>,
           <code>/api/analytics/queries</code>,
-          <code>/api/analytics/empty-queries</code>.
+          <code>/api/analytics/empty-queries</code>,
+          <code>/api/analytics/relay-exclusions</code>.
         </p>
 
         <h2 id="authentication">Authentication</h2>

--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -173,3 +173,18 @@ indexing:
 #   enabled: true
 #   log_queries: true
 #   retention_days: 90
+#   # Machines that forward somebody else's text into the tools verbatim (an
+#   # issue-triage bot, a mirroring service). Real traffic, but not user
+#   # queries — matching rows are excluded from Top Queries, the weekly search
+#   # report, the gap analysis and the unique-IP/session counts, and are
+#   # enumerated in the dashboard's "Excluded Machine-Relay Traffic" panel.
+#   # A rule matches when EVERY predicate it declares matches.
+#   #
+#   # Prefer having the relay send `X-Pathfinder-Source: github-triage` at MCP
+#   # session init — that tags its rows directly and needs no rule here. These
+#   # fingerprints are for relays you do not control.
+#   machine_relays:
+#     - name: github-issue-triage
+#       reason: Forwards GitHub issue bodies verbatim into search
+#       user_agent: node
+#       client_ip_cidr: 152.55.176.0/20

--- a/scripts/weekly-search-report/relay-exclusion.test.ts
+++ b/scripts/weekly-search-report/relay-exclusion.test.ts
@@ -30,7 +30,7 @@ import {
 } from "../../src/db/analytics.js";
 import type { MachineRelayRule } from "../../src/types.js";
 import { generatePostSchemaMigration } from "../../src/db/schema.js";
-import { renderMarkdown } from "./weekly-search-report.js";
+import { fetchBundle, renderMarkdown } from "./weekly-search-report.js";
 import type {
   AnalyticsBundle,
   AnalyticsSummary as ReportSummary,
@@ -177,14 +177,22 @@ describe("published reports exclude machine-relay traffic", () => {
   });
 
   it("renders no relayed body into the weekly Notion report", async () => {
-    const md = renderMarkdown(await bundle(), new Date("2026-09-13T09:07:00Z"), 7);
+    const md = renderMarkdown(
+      await bundle(),
+      new Date("2026-09-13T09:07:00Z"),
+      7,
+    );
     expect(md).not.toContain("1rank.app");
     expect(md).not.toContain("SEO Growth Stack");
   });
 
   it("still renders the 7,548-char legitimate query in the weekly report", async () => {
     expect(LONG_LEGIT_QUERY.length).toBeGreaterThanOrEqual(7500);
-    const md = renderMarkdown(await bundle(), new Date("2026-09-13T09:07:00Z"), 7);
+    const md = renderMarkdown(
+      await bundle(),
+      new Date("2026-09-13T09:07:00Z"),
+      7,
+    );
     expect(md).toContain("GraphQLError on streaming");
     expect(md).toContain("how do I install copilotkit");
   });
@@ -211,5 +219,135 @@ describe("published reports exclude machine-relay traffic", () => {
     );
     expect(prompt).not.toContain("1rank.app");
     expect(prompt).toContain("GraphQLError on streaming");
+  });
+});
+
+describe("weekly report provenance line", () => {
+  const base = {
+    summary: {
+      total_queries_window: 10,
+      unique_ip_count_window: 4,
+      unique_session_count_window: 5,
+      empty_result_count_window: 1,
+      empty_result_rate_window: 0.1,
+      low_confidence_count_window: 0,
+      low_confidence_rate_window: 0,
+      avg_latency_ms_window: 20,
+      p95_latency_ms_window: 40,
+      queries_by_source: [],
+      queries_per_day_window: [],
+      earliest_query_day: "2026-09-06",
+    } as ReportSummary,
+    queries: [] as ReportTopQuery[],
+    emptyQueries: [] as ReportEmptyQuery[],
+    toolBreakdown: [] as ToolBreakdownRow[],
+  };
+
+  it("states what was excluded and under which rule", () => {
+    const md = renderMarkdown(
+      {
+        ...base,
+        relayExclusions: [
+          {
+            name: "github-issue-triage",
+            reason: "relay",
+            kind: "fingerprint",
+            count: 46,
+            last_seen: null,
+          },
+          {
+            name: "x-pathfinder-source",
+            reason: null,
+            kind: "tag",
+            count: 4,
+            last_seen: null,
+          },
+        ],
+      },
+      new Date("2026-09-13T09:07:00Z"),
+      7,
+    );
+    expect(md).toContain("Excluded as machine-relay traffic: 50");
+    expect(md).toContain("github-issue-triage: 46");
+  });
+
+  it("omits the line entirely when nothing was excluded", () => {
+    const md = renderMarkdown(
+      {
+        ...base,
+        relayExclusions: [
+          {
+            name: "github-issue-triage",
+            reason: "relay",
+            kind: "fingerprint",
+            count: 0,
+            last_seen: null,
+          },
+        ],
+      },
+      new Date("2026-09-13T09:07:00Z"),
+      7,
+    );
+    expect(md).not.toContain("Excluded as machine-relay traffic");
+  });
+
+  it("still renders when the exclusions endpoint is absent", () => {
+    const md = renderMarkdown(base, new Date("2026-09-13T09:07:00Z"), 7);
+    expect(md).toContain("Header metrics");
+    expect(md).not.toContain("Excluded as machine-relay traffic");
+  });
+});
+
+describe("fetchBundle tolerance for the exclusions endpoint", () => {
+  const summary = {
+    total_queries_window: 1,
+    unique_ip_count_window: 1,
+    unique_session_count_window: 1,
+    empty_result_count_window: 0,
+    empty_result_rate_window: 0,
+    low_confidence_count_window: 0,
+    low_confidence_rate_window: 0,
+    avg_latency_ms_window: 1,
+    p95_latency_ms_window: 1,
+    queries_by_source: [],
+    queries_per_day_window: [],
+  };
+
+  it("still returns a bundle when /relay-exclusions 404s", async () => {
+    const fetchJson = async <T>(path: string): Promise<T> => {
+      if (path.startsWith("/api/analytics/relay-exclusions")) {
+        throw new Error("404 Not Found");
+      }
+      if (path.startsWith("/api/analytics/summary")) {
+        return summary as unknown as T;
+      }
+      return [] as unknown as T;
+    };
+    const b = await fetchBundle({ fetchJson }, 7);
+    expect(b.relayExclusions).toBeUndefined();
+    expect(b.summary.total_queries_window).toBe(1);
+  });
+
+  it("carries the exclusion rows through when the endpoint answers", async () => {
+    const rows = [
+      {
+        name: "github-issue-triage",
+        reason: "relay",
+        kind: "fingerprint",
+        count: 46,
+        last_seen: null,
+      },
+    ];
+    const fetchJson = async <T>(path: string): Promise<T> => {
+      if (path.startsWith("/api/analytics/relay-exclusions")) {
+        return rows as unknown as T;
+      }
+      if (path.startsWith("/api/analytics/summary")) {
+        return summary as unknown as T;
+      }
+      return [] as unknown as T;
+    };
+    const b = await fetchBundle({ fetchJson }, 7);
+    expect(b.relayExclusions).toEqual(rows);
   });
 });

--- a/scripts/weekly-search-report/relay-exclusion.test.ts
+++ b/scripts/weekly-search-report/relay-exclusion.test.ts
@@ -1,0 +1,215 @@
+/**
+ * End-to-end proof that machine-relay traffic cannot reach the two PUBLISHED
+ * surfaces: the weekly Notion search report and the bi-weekly gap-analysis LLM
+ * prompt.
+ *
+ * Both scripts read the analytics JSON API with its DEFAULT audience, so the
+ * exclusion lives one layer down in src/db/analytics.ts. This suite wires the
+ * real readers (against PGlite) to the real renderers, because "the DB layer
+ * filters it" is a claim about a different file than the one that publishes
+ * the spam.
+ *
+ * The concrete incident: 23 SEO-spam GitHub issues were forwarded verbatim
+ * into search-docs/search-code by our own triage relay, ranked in Top Queries,
+ * and were on course to be rendered as full `query_text` into a Notion table
+ * (weekly report, cron `7 9 * * 0`) and fed un-truncated into an LLM prompt
+ * whose output is also published (gap analysis, cron `0 4 1,15 * *`).
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+import {
+  __setPoolForTesting,
+  __resetPoolForTesting,
+} from "../../src/db/client.js";
+import {
+  getAnalyticsSummary,
+  getEmptyQueries,
+  getToolBreakdown,
+  getTopQueries,
+  __setMachineRelayRulesForTesting,
+} from "../../src/db/analytics.js";
+import type { MachineRelayRule } from "../../src/types.js";
+import { generatePostSchemaMigration } from "../../src/db/schema.js";
+import { renderMarkdown } from "./weekly-search-report.js";
+import type {
+  AnalyticsBundle,
+  AnalyticsSummary as ReportSummary,
+  EmptyQuery as ReportEmptyQuery,
+  TopQuery as ReportTopQuery,
+  ToolBreakdownRow,
+} from "./weekly-search-report.js";
+import { buildLlmPrompt } from "../gap-analysis/monthly-gap-analysis.js";
+import { clusterQueries, filterSynthetic } from "../gap-analysis/cluster.js";
+
+const QUERY_LOG_DDL_MARKER =
+  "-- Analytics: query_log table for tracking tool usage";
+
+function extractAnalyticsDdl(): string {
+  const full = generatePostSchemaMigration();
+  const idx = full.indexOf(QUERY_LOG_DDL_MARKER);
+  if (idx < 0) {
+    throw new Error(`Could not locate "${QUERY_LOG_DDL_MARKER}" in schema`);
+  }
+  return full.slice(idx);
+}
+
+function poolFromPglite(db: PGlite) {
+  return {
+    query: (text: string, params?: unknown[]) => db.query(text, params),
+    connect: async () => ({
+      query: (text: string, params?: unknown[]) => db.query(text, params),
+      release: () => {},
+    }),
+    end: async () => db.close(),
+  };
+}
+
+const RELAY_RULE: MachineRelayRule = {
+  name: "github-issue-triage",
+  reason: "CopilotKit GitHub-issue triage relay (Railway) — forwards bodies",
+  user_agent: "node",
+  client_ip_cidr: "152.55.176.0/20",
+};
+
+/** The shipped shape: ~3.3 KB of marketing copy carrying 13 live backlinks. */
+const SPAM_BODY =
+  "Why 1Rank.app Belongs in Your SEO Growth Stack. " +
+  Array.from(
+    { length: 13 },
+    (_, i) => `Read more at https://1rank.app/blog/post-${i} and grow faster. `,
+  ).join("") +
+  "x".repeat(3300);
+
+/** 7,548 chars, two links: the measured production maximum for a REAL query. */
+const LONG_LEGIT_QUERY =
+  "CopilotKit runtime throws GraphQLError on streaming, see https://github.com/CopilotKit/CopilotKit/issues/1 and https://docs.copilotkit.ai/troubleshooting — full trace: " +
+  "at Runtime.handleRequest (dist/index.js:1:1) ".repeat(164);
+
+async function insertRow(
+  db: PGlite,
+  row: {
+    tool: string;
+    text: string;
+    results: number;
+    session: string;
+    ip: string;
+    ua: string;
+  },
+): Promise<void> {
+  await db.query(
+    `INSERT INTO query_log
+       (tool_name, query_text, result_count, top_score, score_kind, latency_ms,
+        source_name, session_id, request_source, client_ip, user_agent)
+     VALUES ($1,$2,$3,$4,$5,25,'docs',$6,'user',$7,$8)`,
+    [
+      row.tool,
+      row.text,
+      row.results,
+      row.results > 0 ? 0.4 : null,
+      row.results > 0 ? "cosine" : null,
+      row.session,
+      row.ip,
+      row.ua,
+    ],
+  );
+}
+
+async function bundle(): Promise<AnalyticsBundle> {
+  return {
+    summary: (await getAnalyticsSummary({}, 7)) as unknown as ReportSummary,
+    queries: (await getTopQueries(7, 200)) as unknown as ReportTopQuery[],
+    emptyQueries: (await getEmptyQueries(
+      7,
+      200,
+    )) as unknown as ReportEmptyQuery[],
+    toolBreakdown: (await getToolBreakdown(
+      7,
+      {},
+    )) as unknown as ToolBreakdownRow[],
+  };
+}
+
+describe("published reports exclude machine-relay traffic", () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await db.exec(extractAnalyticsDdl());
+    __setPoolForTesting(poolFromPglite(db));
+  });
+
+  afterAll(async () => {
+    __resetPoolForTesting();
+    __setMachineRelayRulesForTesting(null);
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await db.query("DELETE FROM query_log");
+    __setMachineRelayRulesForTesting([RELAY_RULE]);
+    await insertRow(db, {
+      tool: "search-docs",
+      text: "how do I install copilotkit",
+      results: 5,
+      session: "legit-1",
+      ip: "3.4.5.6",
+      ua: "Claude-User",
+    });
+    await insertRow(db, {
+      tool: "search-docs",
+      text: LONG_LEGIT_QUERY,
+      results: 4,
+      session: "legit-2",
+      ip: "9.9.9.9",
+      ua: "Claude-User",
+    });
+    for (let i = 0; i < 3; i++) {
+      await insertRow(db, {
+        tool: "search-docs",
+        text: SPAM_BODY,
+        results: 4,
+        session: `relay-${i}`,
+        ip: "152.55.178.126",
+        ua: "node",
+      });
+    }
+  });
+
+  it("renders no relayed body into the weekly Notion report", async () => {
+    const md = renderMarkdown(await bundle(), new Date("2026-09-13T09:07:00Z"), 7);
+    expect(md).not.toContain("1rank.app");
+    expect(md).not.toContain("SEO Growth Stack");
+  });
+
+  it("still renders the 7,548-char legitimate query in the weekly report", async () => {
+    expect(LONG_LEGIT_QUERY.length).toBeGreaterThanOrEqual(7500);
+    const md = renderMarkdown(await bundle(), new Date("2026-09-13T09:07:00Z"), 7);
+    expect(md).toContain("GraphQLError on streaming");
+    expect(md).toContain("how do I install copilotkit");
+  });
+
+  it("puts no relayed body into the gap-analysis LLM prompt", async () => {
+    const b = await bundle();
+    const rows = filterSynthetic(b.queries).map((q) => ({
+      query_text: q.query_text,
+      tool_name: q.tool_name,
+      count: q.count,
+    }));
+    const prompt = buildLlmPrompt(
+      {
+        total_queries_window: b.summary.total_queries_window,
+        empty_result_count_window: b.summary.empty_result_count_window,
+        empty_result_rate_window: b.summary.empty_result_rate_window,
+        queries_by_source: b.summary.queries_by_source,
+      } as never,
+      {
+        topClusters: clusterQueries(rows),
+        emptyClusters: [],
+        syntheticDropped: 0,
+      },
+    );
+    expect(prompt).not.toContain("1rank.app");
+    expect(prompt).toContain("GraphQLError on streaming");
+  });
+});

--- a/scripts/weekly-search-report/weekly-search-report.ts
+++ b/scripts/weekly-search-report/weekly-search-report.ts
@@ -103,11 +103,31 @@ export interface ToolBreakdownRow {
   count: number;
 }
 
+/**
+ * `/relay-exclusions` row — one per machine-relay rule the server applied.
+ * See RelayExclusion in src/db/analytics.ts.
+ */
+export interface RelayExclusionRow {
+  name: string;
+  reason: string | null;
+  kind: string;
+  count: number;
+  last_seen: string | null;
+}
+
 export interface AnalyticsBundle {
   summary: AnalyticsSummary;
   queries: TopQuery[];
   emptyQueries: EmptyQuery[];
   toolBreakdown: ToolBreakdownRow[];
+  /**
+   * What the server excluded as machine-relay traffic. OPTIONAL, and a fetch
+   * failure degrades to `undefined` rather than failing the run: this is a
+   * provenance footnote on a report whose data is already correct without it,
+   * and the endpoint may not exist yet on an older deployment. Every other
+   * endpoint stays fail-loud.
+   */
+  relayExclusions?: RelayExclusionRow[];
 }
 
 // ── Keyword categorization taxonomy (deterministic, NO LLM) ───────────────────
@@ -531,6 +551,20 @@ export function renderMarkdown(
       `(${(summary.empty_result_rate_window * 100).toFixed(1)}%)`,
   );
   lines.push(`- p95 latency: ${summary.p95_latency_ms_window} ms`);
+  // Provenance, not decoration. Every number above is computed over REAL USER
+  // traffic with machine-relay rows removed; saying so — and by how much —
+  // is what stops the next reader from wondering why the dashboard and the
+  // report disagree with a raw row count.
+  const excluded = (bundle.relayExclusions ?? []).filter((r) => r.count > 0);
+  if (excluded.length > 0) {
+    const total = excluded.reduce((a, r) => a + r.count, 0);
+    lines.push(
+      `- Excluded as machine-relay traffic: ${total} ` +
+        `(${excluded
+          .map((r) => `${sanitizeCell(r.name)}: ${r.count}`)
+          .join(", ")})`,
+    );
+  }
   lines.push("");
 
   // 2. Activity by day
@@ -1115,7 +1149,23 @@ export async function fetchBundle(
     assertToolBreakdownRow("/tool-breakdown", r, i),
   );
 
-  return { summary, queries, emptyQueries, toolBreakdown };
+  // Tolerant by design — see AnalyticsBundle.relayExclusions. A 404 from an
+  // older deployment, or any other failure here, must not cost us the report.
+  let relayExclusions: RelayExclusionRow[] | undefined;
+  try {
+    const rows = await deps.fetchJson<RelayExclusionRow[]>(
+      `/api/analytics/relay-exclusions?days=${days}`,
+    );
+    if (Array.isArray(rows)) relayExclusions = rows;
+  } catch (err) {
+    console.warn(
+      `[weekly-report] relay-exclusions unavailable (report continues): ${String(
+        err instanceof Error ? err.message : err,
+      )}`,
+    );
+  }
+
+  return { summary, queries, emptyQueries, toolBreakdown, relayExclusions };
 }
 
 /**

--- a/src/__tests__/analytics-auth-length-check.test.ts
+++ b/src/__tests__/analytics-auth-length-check.test.ts
@@ -20,6 +20,7 @@ vi.mock("../db/analytics.js", () => ({
   getTopQueries: vi.fn(),
   getEmptyQueries: vi.fn(),
   getBlockedQueries: vi.fn(),
+  getRelayExclusions: vi.fn(),
   getToolCounts: vi.fn(),
   getToolBreakdown: vi.fn(),
 }));
@@ -82,6 +83,7 @@ describe("analyticsAuth length-check early return (R4-18)", () => {
       getTopQueries: async () => [],
       getEmptyQueries: async () => [],
       getBlockedQueries: async () => [],
+      getRelayExclusions: async () => [],
       getToolCounts: async () => [],
     });
     server = http.createServer(app);

--- a/src/__tests__/analytics-error-log-ip.test.ts
+++ b/src/__tests__/analytics-error-log-ip.test.ts
@@ -14,6 +14,7 @@ vi.mock("../db/analytics.js", () => ({
   getTopQueries: vi.fn(),
   getEmptyQueries: vi.fn(),
   getBlockedQueries: vi.fn(),
+  getRelayExclusions: vi.fn(),
   getToolCounts: vi.fn(),
   getToolBreakdown: vi.fn(),
 }));

--- a/src/__tests__/analytics-relay-exclusion.test.ts
+++ b/src/__tests__/analytics-relay-exclusion.test.ts
@@ -1,0 +1,354 @@
+/**
+ * Machine-relay traffic must not reach the operator-facing analytics
+ * surfaces.
+ *
+ * BACKGROUND (measured on production query_log, 7-day window ending
+ * 2026-09-12). A CopilotKit-owned Railway triage service forwards every new
+ * GitHub issue body VERBATIM into `search-docs` + `search-code` within ~4s of
+ * the issue being filed. Twenty-three SEO-spam issues were therefore amplified
+ * into the MCP by our own automation: 46 of 1,318 rows, all from one IP
+ * (152.55.178.126, inside Railway's 152.55.176.0/20) with User-Agent `node`.
+ * Those blobs retrieve real content (cosine 0.33-0.43, 4 results), so nothing
+ * in the empty-result path or the abuse blocklist ever saw them — they ranked
+ * in Top Queries, and from there into the weekly Notion report (full
+ * `query_text` rendered into a table cell) and the bi-weekly gap analysis
+ * (un-truncated into an LLM prompt whose output is published).
+ *
+ * The rule under test is IDENTITY-shaped (User-Agent + source CIDR), never
+ * content-shaped. The longest LEGITIMATE query in that same production window
+ * was 7,520 characters — a length threshold would delete real operator signal,
+ * which is why this suite pins a 7,520-char legitimate query as a NEGATIVE
+ * assertion on every surface.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+import { __setPoolForTesting, __resetPoolForTesting } from "../db/client.js";
+import {
+  getAnalyticsSummary,
+  getAtlasRetrievalMetrics,
+  getEmptyQueries,
+  getToolBreakdown,
+  getToolCounts,
+  getTopQueries,
+  __setMachineRelayRulesForTesting,
+} from "../db/analytics.js";
+import type { MachineRelayRule } from "../types.js";
+import { generatePostSchemaMigration } from "../db/schema.js";
+import { renderMarkdown } from "../../scripts/weekly-search-report/weekly-search-report.js";
+import type {
+  AnalyticsBundle,
+  AnalyticsSummary as ReportSummary,
+  EmptyQuery as ReportEmptyQuery,
+  TopQuery as ReportTopQuery,
+  ToolBreakdownRow,
+} from "../../scripts/weekly-search-report/weekly-search-report.js";
+
+const QUERY_LOG_DDL_MARKER =
+  "-- Analytics: query_log table for tracking tool usage";
+
+function extractAnalyticsDdl(): string {
+  const full = generatePostSchemaMigration();
+  const idx = full.indexOf(QUERY_LOG_DDL_MARKER);
+  if (idx < 0) {
+    throw new Error(`Could not locate "${QUERY_LOG_DDL_MARKER}" in schema`);
+  }
+  return full.slice(idx);
+}
+
+function poolFromPglite(db: PGlite) {
+  return {
+    query: (text: string, params?: unknown[]) => db.query(text, params),
+    connect: async () => ({
+      query: (text: string, params?: unknown[]) => db.query(text, params),
+      release: () => {},
+    }),
+    end: async () => db.close(),
+  };
+}
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+/** The production relay: Railway's 152.55.176.0/20, User-Agent `node`. */
+const RELAY_IP = "152.55.178.126";
+const RELAY_RULE: MachineRelayRule = {
+  name: "github-issue-triage",
+  reason:
+    "CopilotKit GitHub-issue triage relay (Railway) forwards issue bodies verbatim",
+  user_agent: "node",
+  client_ip_cidr: "152.55.176.0/20",
+};
+
+/** SEO-spam body, ~3.3 KB with 13 live backlinks — the shape that shipped. */
+const SPAM_BODY =
+  "Why 1Rank.app Belongs in Your SEO Growth Stack. " +
+  "Ranking on search engines is harder than ever. " +
+  Array.from(
+    { length: 13 },
+    (_, i) => `Read more at https://1rank.app/blog/post-${i} and grow faster. `,
+  ).join("") +
+  "x".repeat(3300);
+
+/**
+ * The 7,520-char LEGITIMATE query: an operator pasting a long stack trace /
+ * config dump into the docs search. Two links, not thirteen. This is the
+ * measured production maximum and the decisive negative assertion — if a
+ * future exclusion rule ever goes content-shaped, this row disappears from
+ * the dashboard and this suite fails.
+ */
+const LONG_LEGIT_QUERY =
+  "CopilotKit runtime throws GraphQLError on streaming, see https://github.com/CopilotKit/CopilotKit/issues/1 and https://docs.copilotkit.ai/troubleshooting — full trace: " +
+  "at Runtime.handleRequest (dist/index.js:1:1) ".repeat(164);
+
+/** A long legitimate PASTE with few links — the second content-shape control. */
+const LONG_LEGIT_PASTE = "useCoAgent state sync issue: " + "y".repeat(3400);
+
+const SHORT_LEGIT = "how do I install copilotkit";
+
+interface Row {
+  toolName: string;
+  queryText: string;
+  resultCount: number;
+  sourceName: string | null;
+  sessionId: string | null;
+  clientIp: string | null;
+  userAgent: string | null;
+  requestSource?: string | null;
+}
+
+async function insertRow(db: PGlite, row: Row): Promise<void> {
+  await db.query(
+    `INSERT INTO query_log
+      (tool_name, query_text, result_count, top_score, score_kind, latency_ms,
+       source_name, session_id, request_source, client_ip, user_agent)
+     VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11)`,
+    [
+      row.toolName,
+      row.queryText,
+      row.resultCount,
+      row.resultCount > 0 ? 0.4 : null,
+      row.resultCount > 0 ? "cosine" : null,
+      25,
+      row.sourceName,
+      row.sessionId,
+      row.requestSource === undefined ? "user" : row.requestSource,
+      row.clientIp,
+      row.userAgent,
+    ],
+  );
+}
+
+async function seed(db: PGlite): Promise<void> {
+  // ── Legitimate traffic: 4 distinct clients, 4 IPs, 4 sessions ────────────
+  for (let i = 0; i < 3; i++) {
+    await insertRow(db, {
+      toolName: "search-docs",
+      queryText: SHORT_LEGIT,
+      resultCount: 5,
+      sourceName: "docs",
+      sessionId: "legit-short",
+      clientIp: "3.4.5.6",
+      userAgent: "Claude-User",
+    });
+  }
+  await insertRow(db, {
+    toolName: "search-docs",
+    queryText: LONG_LEGIT_QUERY,
+    resultCount: 4,
+    sourceName: "docs",
+    sessionId: "legit-long",
+    clientIp: "9.9.9.9",
+    userAgent: "Claude-User",
+  });
+  await insertRow(db, {
+    toolName: "search-code",
+    queryText: LONG_LEGIT_PASTE,
+    resultCount: 2,
+    sourceName: "code",
+    sessionId: "legit-paste",
+    clientIp: "8.8.8.8",
+    userAgent: "curl/8.4.0",
+  });
+  // `node` User-Agent, but OUTSIDE the declared relay CIDR: the rule is
+  // UA *and* network, not UA alone.
+  await insertRow(db, {
+    toolName: "search-docs",
+    queryText: "node sdk streaming example",
+    resultCount: 3,
+    sourceName: "docs",
+    sessionId: "legit-node-elsewhere",
+    clientIp: "54.176.234.134",
+    userAgent: "node",
+  });
+  await insertRow(db, {
+    toolName: "search-docs",
+    queryText: "no hits for this one",
+    resultCount: 0,
+    sourceName: "docs",
+    sessionId: "legit-empty",
+    clientIp: "3.4.5.6",
+    userAgent: "Claude-User",
+  });
+
+  // ── Relay traffic: one IP, UA `node`, a fresh session per issue ──────────
+  for (let i = 0; i < 3; i++) {
+    for (const tool of ["search-docs", "search-code"]) {
+      await insertRow(db, {
+        toolName: tool,
+        queryText: SPAM_BODY,
+        resultCount: 4,
+        sourceName: tool === "search-docs" ? "docs" : "code",
+        sessionId: `relay-issue-${i}`,
+        clientIp: RELAY_IP,
+        userAgent: "node",
+      });
+    }
+  }
+  // A relayed issue body that is NOT spam. Still not a user query.
+  await insertRow(db, {
+    toolName: "search-docs",
+    queryText: "Bug: useCopilotAction does not fire on first render",
+    resultCount: 4,
+    sourceName: "docs",
+    sessionId: "relay-issue-legit",
+    clientIp: RELAY_IP,
+    userAgent: "node",
+  });
+  // A relayed body that retrieved nothing — pollutes the empty-result panel.
+  await insertRow(db, {
+    toolName: "search-code",
+    queryText: SPAM_BODY + " zagfro.com",
+    resultCount: 0,
+    sourceName: "code",
+    sessionId: "relay-issue-empty",
+    clientIp: RELAY_IP,
+    userAgent: "node",
+  });
+
+  // ── Convergence row: the relay AFTER it starts sending the header ────────
+  // `X-Pathfinder-Source: github-triage` normalizes to request_source
+  // 'relay'. Different IP and User-Agent on purpose: once the relay declares
+  // itself, the fingerprint rule is no longer what excludes it.
+  await insertRow(db, {
+    toolName: "search-docs",
+    queryText: "Relayed issue body from a self-declaring relay",
+    resultCount: 4,
+    sourceName: "docs",
+    sessionId: "relay-tagged",
+    clientIp: "10.20.30.40",
+    userAgent: "undici",
+    requestSource: "relay",
+  });
+}
+
+function texts(rows: Array<{ query_text: string }>): string[] {
+  return rows.map((r) => r.query_text);
+}
+
+describe("machine-relay exclusion from operator-facing analytics", () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await db.exec(extractAnalyticsDdl());
+    __setPoolForTesting(poolFromPglite(db));
+  });
+
+  afterAll(async () => {
+    __resetPoolForTesting();
+    __setMachineRelayRulesForTesting(null);
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await db.query("DELETE FROM query_log");
+    __setMachineRelayRulesForTesting([RELAY_RULE]);
+    await seed(db);
+  });
+
+  // ── The pollution ────────────────────────────────────────────────────────
+
+  it("keeps relayed bodies out of Top Queries", async () => {
+    const top = await getTopQueries(7, 200);
+    expect(texts(top)).not.toContain(SPAM_BODY);
+    expect(
+      texts(top).some((t) => t.includes("useCopilotAction does not fire")),
+    ).toBe(false);
+  });
+
+  it("keeps relayed bodies out of the Empty-Result panel", async () => {
+    const empty = await getEmptyQueries(7, 200);
+    expect(texts(empty).some((t) => t.includes("zagfro.com"))).toBe(false);
+    expect(texts(empty)).toContain("no hits for this one");
+  });
+
+  it("keeps relay rows out of the weekly search report payload", async () => {
+    const bundle: AnalyticsBundle = {
+      summary: (await getAnalyticsSummary({}, 7)) as unknown as ReportSummary,
+      queries: (await getTopQueries(7, 200)) as unknown as ReportTopQuery[],
+      emptyQueries: (await getEmptyQueries(
+        7,
+        200,
+      )) as unknown as ReportEmptyQuery[],
+      toolBreakdown: (await getToolBreakdown(
+        7,
+        {},
+      )) as unknown as ToolBreakdownRow[],
+    };
+    const markdown = renderMarkdown(bundle, new Date("2026-09-13T09:07:00Z"), 7);
+    expect(markdown).not.toContain("1rank.app");
+    expect(markdown).not.toContain("zagfro.com");
+  });
+
+  it("keeps relay rows out of the summary counts", async () => {
+    const s = await getAnalyticsSummary({}, 7);
+    // 4 legitimate IPs: 3.4.5.6, 9.9.9.9, 8.8.8.8, 54.176.234.134.
+    expect(s.unique_ip_count_window).toBe(4);
+    // 5 legitimate sessions; the relay's per-issue sessions are the largest
+    // single-actor session inflation in the production window.
+    expect(s.unique_session_count_window).toBe(5);
+    expect(s.total_queries_window).toBe(7);
+  });
+
+  it("keeps relay rows out of the tool counts and breakdown", async () => {
+    const counts = await getToolCounts(7, {});
+    const total = counts.reduce((a, c) => a + c.count, 0);
+    expect(total).toBe(7);
+    const breakdown = await getToolBreakdown(7, {});
+    expect(breakdown.reduce((a, c) => a + c.count, 0)).toBe(7);
+  });
+
+  it("keeps relay rows out of the Atlas user-query denominator", async () => {
+    const m = await getAtlasRetrievalMetrics(7, {});
+    expect(m.total_user_queries_window).toBe(7);
+  });
+
+  // ── Negative assertions: legitimate traffic SURVIVES ─────────────────────
+
+  it("does NOT exclude the 7,520-char legitimate query", async () => {
+    expect(LONG_LEGIT_QUERY.length).toBeGreaterThanOrEqual(7500);
+    const top = await getTopQueries(7, 200);
+    expect(texts(top)).toContain(LONG_LEGIT_QUERY);
+  });
+
+  it("does NOT exclude a long legitimate paste with few links", async () => {
+    const top = await getTopQueries(7, 200);
+    expect(texts(top)).toContain(LONG_LEGIT_PASTE);
+  });
+
+  it("does NOT exclude ordinary short legitimate queries", async () => {
+    const top = await getTopQueries(7, 200);
+    expect(texts(top)).toContain(SHORT_LEGIT);
+  });
+
+  it("does NOT exclude a `node` client outside the declared relay CIDR", async () => {
+    const top = await getTopQueries(7, 200);
+    expect(texts(top)).toContain("node sdk streaming example");
+  });
+
+  it("excludes NOTHING when no relay rules are declared", async () => {
+    __setMachineRelayRulesForTesting([]);
+    const top = await getTopQueries(7, 200);
+    expect(texts(top)).toContain(SPAM_BODY);
+  });
+});

--- a/src/__tests__/analytics-relay-exclusion.test.ts
+++ b/src/__tests__/analytics-relay-exclusion.test.ts
@@ -30,6 +30,9 @@ import {
   getToolBreakdown,
   getToolCounts,
   getTopQueries,
+  getRelayExclusions,
+  normalizeRequestSource,
+  RELAY_TAG_EXCLUSION_NAME,
   __setMachineRelayRulesForTesting,
 } from "../db/analytics.js";
 import type { MachineRelayRule } from "../types.js";
@@ -318,6 +321,67 @@ describe("machine-relay exclusion from operator-facing analytics", () => {
   it("does NOT exclude a `node` client outside the declared relay CIDR", async () => {
     const top = await getTopQueries(7, 200);
     expect(texts(top)).toContain("node sdk streaming example");
+  });
+
+  // ── Operator visibility ─────────────────────────────────────────────────
+
+  it("reports what was excluded, and why, one row per rule", async () => {
+    const rows = await getRelayExclusions(7, {});
+    const byName = Object.fromEntries(rows.map((r) => [r.name, r]));
+
+    const fingerprint = byName["github-issue-triage"];
+    expect(fingerprint.kind).toBe("fingerprint");
+    // 6 spam + 1 relayed non-spam body + 1 relayed body with no results.
+    expect(fingerprint.count).toBe(8);
+    expect(fingerprint.reason).toContain("triage relay");
+    expect(fingerprint.last_seen).toBeTruthy();
+
+    const tagged = byName[RELAY_TAG_EXCLUSION_NAME];
+    expect(tagged.kind).toBe("tag");
+    expect(tagged.count).toBe(1);
+  });
+
+  it("still lists a declared rule that matched nothing", async () => {
+    __setMachineRelayRulesForTesting([
+      { name: "stale-rule", user_agent: "some-retired-relay" },
+    ]);
+    const rows = await getRelayExclusions(7, {});
+    const stale = rows.find((r) => r.name === "stale-rule");
+    expect(stale?.count).toBe(0);
+  });
+
+  it("lets an operator read the excluded rows back via request_source=relay", async () => {
+    const relayOnly = await getTopQueries(7, 200, {
+      request_source: "relay",
+    });
+    // Both halves of the audience: fingerprinted AND self-declared.
+    expect(texts(relayOnly)).toContain(SPAM_BODY);
+    expect(
+      texts(relayOnly).some((t) => t.includes("self-declaring relay")),
+    ).toBe(true);
+    // And nothing legitimate leaks into the inspection view.
+    expect(texts(relayOnly)).not.toContain(SHORT_LEGIT);
+    expect(texts(relayOnly)).not.toContain(LONG_LEGIT_QUERY);
+  });
+
+  // ── Convergence on the header ────────────────────────────────────────────
+
+  it("maps the relay's X-Pathfinder-Source value onto the relay audience", () => {
+    expect(normalizeRequestSource("github-triage")).toBe("relay");
+    expect(normalizeRequestSource(" GitHub-Triage ")).toBe("relay");
+    expect(normalizeRequestSource("relay")).toBe("relay");
+    // Still conservative for anything unrecognized.
+    expect(normalizeRequestSource("something-else")).toBe("user");
+  });
+
+  it("excludes a self-declared relay even with NO fingerprint rule declared", async () => {
+    __setMachineRelayRulesForTesting([]);
+    const top = await getTopQueries(7, 200);
+    expect(texts(top).some((t) => t.includes("self-declaring relay"))).toBe(
+      false,
+    );
+    // This is the convergence contract: once the relay sends the header the
+    // fingerprint rule can be deleted from config and the exclusion holds.
   });
 
   it("excludes NOTHING when no relay rules are declared", async () => {

--- a/src/__tests__/analytics-relay-exclusion.test.ts
+++ b/src/__tests__/analytics-relay-exclusion.test.ts
@@ -34,14 +34,6 @@ import {
 } from "../db/analytics.js";
 import type { MachineRelayRule } from "../types.js";
 import { generatePostSchemaMigration } from "../db/schema.js";
-import { renderMarkdown } from "../../scripts/weekly-search-report/weekly-search-report.js";
-import type {
-  AnalyticsBundle,
-  AnalyticsSummary as ReportSummary,
-  EmptyQuery as ReportEmptyQuery,
-  TopQuery as ReportTopQuery,
-  ToolBreakdownRow,
-} from "../../scripts/weekly-search-report/weekly-search-report.js";
 
 const QUERY_LOG_DDL_MARKER =
   "-- Analytics: query_log table for tracking tool usage";
@@ -280,24 +272,6 @@ describe("machine-relay exclusion from operator-facing analytics", () => {
     const empty = await getEmptyQueries(7, 200);
     expect(texts(empty).some((t) => t.includes("zagfro.com"))).toBe(false);
     expect(texts(empty)).toContain("no hits for this one");
-  });
-
-  it("keeps relay rows out of the weekly search report payload", async () => {
-    const bundle: AnalyticsBundle = {
-      summary: (await getAnalyticsSummary({}, 7)) as unknown as ReportSummary,
-      queries: (await getTopQueries(7, 200)) as unknown as ReportTopQuery[],
-      emptyQueries: (await getEmptyQueries(
-        7,
-        200,
-      )) as unknown as ReportEmptyQuery[],
-      toolBreakdown: (await getToolBreakdown(
-        7,
-        {},
-      )) as unknown as ToolBreakdownRow[],
-    };
-    const markdown = renderMarkdown(bundle, new Date("2026-09-13T09:07:00Z"), 7);
-    expect(markdown).not.toContain("1rank.app");
-    expect(markdown).not.toContain("zagfro.com");
   });
 
   it("keeps relay rows out of the summary counts", async () => {

--- a/src/__tests__/analytics-sendfile-correlation.test.ts
+++ b/src/__tests__/analytics-sendfile-correlation.test.ts
@@ -18,6 +18,7 @@ vi.mock("../db/analytics.js", () => ({
   getTopQueries: vi.fn(),
   getEmptyQueries: vi.fn(),
   getBlockedQueries: vi.fn(),
+  getRelayExclusions: vi.fn(),
   getToolCounts: vi.fn(),
   getToolBreakdown: vi.fn(),
 }));

--- a/src/__tests__/analytics-server.test.ts
+++ b/src/__tests__/analytics-server.test.ts
@@ -9,12 +9,14 @@ const mockGetEmptyQueries = vi.fn();
 const mockGetBlockedQueries = vi.fn();
 const mockGetToolCounts = vi.fn();
 const mockGetToolBreakdown = vi.fn();
+const mockGetRelayExclusions = vi.fn();
 
 vi.mock("../db/analytics.js", () => ({
   getAnalyticsSummary: (...args: unknown[]) => mockGetAnalyticsSummary(...args),
   getTopQueries: (...args: unknown[]) => mockGetTopQueries(...args),
   getEmptyQueries: (...args: unknown[]) => mockGetEmptyQueries(...args),
   getBlockedQueries: (...args: unknown[]) => mockGetBlockedQueries(...args),
+  getRelayExclusions: (...args: unknown[]) => mockGetRelayExclusions(...args),
   getToolCounts: (...args: unknown[]) => mockGetToolCounts(...args),
   getToolBreakdown: (...args: unknown[]) => mockGetToolBreakdown(...args),
 }));
@@ -92,6 +94,8 @@ function buildTestApp() {
       mockGetToolCounts(...args),
     getToolBreakdown: (...args: Parameters<typeof mockGetToolBreakdown>) =>
       mockGetToolBreakdown(...args),
+    getRelayExclusions: (...args: Parameters<typeof mockGetRelayExclusions>) =>
+      mockGetRelayExclusions(...args),
     analyticsHtmlPath,
   });
 
@@ -451,6 +455,88 @@ describe("Analytics server routes (HTTP-level)", () => {
       const body = JSON.parse(res.body);
       expect(body.error).toBe("Failed to fetch blocked queries");
       consoleErrSpy.mockRestore();
+    });
+  });
+
+  // ---- /api/analytics/relay-exclusions -------------------------------------
+
+  describe("GET /api/analytics/relay-exclusions", () => {
+    const rows = [
+      {
+        name: "x-pathfinder-source",
+        reason: "Client declared itself a machine relay",
+        kind: "tag",
+        count: 4,
+        last_seen: "2026-09-12T05:00:00.000Z",
+      },
+      {
+        name: "github-issue-triage",
+        reason: "Triage relay forwards issue bodies verbatim",
+        kind: "fingerprint",
+        count: 46,
+        last_seen: "2026-09-11T18:56:09.000Z",
+      },
+    ];
+
+    it("returns the exclusion rows with a valid token and forwards days", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "secret",
+      });
+      mockGetRelayExclusions.mockResolvedValue(rows);
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/relay-exclusions?days=14",
+        { Authorization: "Bearer secret" },
+      );
+
+      expect(res.status).toBe(200);
+      expect(JSON.parse(res.body)).toEqual(rows);
+      expect(mockGetRelayExclusions).toHaveBeenCalledWith(14, {});
+    });
+
+    it("returns 401 without a token", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "secret",
+      });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/relay-exclusions",
+      );
+
+      expect(res.status).toBe(401);
+      expect(mockGetRelayExclusions).not.toHaveBeenCalled();
+    });
+
+    it("rejects days=abc with 400", async () => {
+      mockGetAnalyticsConfigFn.mockReturnValue({
+        enabled: true,
+        log_queries: true,
+        retention_days: 90,
+        token: "secret",
+      });
+
+      await startApp();
+      const res = await request(
+        server,
+        "GET",
+        "/api/analytics/relay-exclusions?days=abc",
+        { Authorization: "Bearer secret" },
+      );
+
+      expect(res.status).toBe(400);
+      expect(mockGetRelayExclusions).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/analytics-ui.test.ts
+++ b/src/__tests__/analytics-ui.test.ts
@@ -929,6 +929,78 @@ describe("analytics dashboard UI — Pacific timestamps (v1.15.3)", () => {
   });
 });
 
+describe("analytics dashboard UI — Excluded Machine-Relay Traffic panel", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("fetches /api/analytics/relay-exclusions and renders one row per rule", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 0).summary,
+      "/api/analytics/tool-counts": () => [],
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
+      "/api/analytics/relay-exclusions": () => [
+        {
+          name: "x-pathfinder-source",
+          reason: "Client declared itself a machine relay",
+          kind: "tag",
+          count: 4,
+          last_seen: "2026-09-12T05:00:00.000Z",
+        },
+        {
+          name: "github-issue-triage",
+          reason: "Triage relay forwards issue bodies verbatim",
+          kind: "fingerprint",
+          count: 46,
+          last_seen: "2026-09-11T18:56:09.000Z",
+        },
+      ],
+    };
+
+    const { dom, calls } = await loadDashboard(endpoints);
+
+    expect(
+      calls.some((u) => u.startsWith("/api/analytics/relay-exclusions")),
+    ).toBe(true);
+
+    const rows = Array.from(
+      dom.window.document.querySelectorAll("#relayExclusionsTable tbody tr"),
+    );
+    expect(rows.length).toBe(2);
+    const cells = Array.from(rows[1].querySelectorAll("td")).map(
+      (c) => c.textContent ?? "",
+    );
+    expect(cells[0]).toBe("github-issue-triage");
+    expect(cells[1]).toBe("fingerprint");
+    expect(cells[2]).toBe("46");
+    // The WHY column is the point of the panel: an exclusion an operator
+    // cannot read the reason for is still a silent exclusion.
+    expect(cells[4]).toContain("forwards issue bodies verbatim");
+  });
+
+  it("renders an explicit empty state when nothing is excluded", async () => {
+    const endpoints = {
+      "/api/analytics/auth-mode": () => ({ dev: true }),
+      "/api/analytics/summary": () => canned(7, 0).summary,
+      "/api/analytics/tool-counts": () => [],
+      "/api/analytics/queries": () => [],
+      "/api/analytics/empty-queries": () => [],
+      "/api/analytics/blocked-queries": () => [],
+      "/api/analytics/relay-exclusions": () => [],
+    };
+    const { dom } = await loadDashboard(endpoints);
+    const body = dom.window.document.querySelector(
+      "#relayExclusionsTable tbody",
+    );
+    expect(body?.textContent ?? "").toContain(
+      "No machine-relay exclusions configured",
+    );
+  });
+});
+
 describe("analytics dashboard UI — Blocked Queries panel (v1.15.3)", () => {
   afterEach(() => {
     vi.restoreAllMocks();

--- a/src/__tests__/copilotkit-docs-config.test.ts
+++ b/src/__tests__/copilotkit-docs-config.test.ts
@@ -86,3 +86,24 @@ describe("deploy/copilotkit-docs.yaml — derived URLs match the live routes", (
     expect(deriveUrl(CONTENT + rel, docsSource)).toBe(expected);
   });
 });
+
+// The shipped exclusion for the GitHub-issue triage relay. It is pinned here
+// rather than left to the YAML alone because the rule is what keeps relayed
+// issue bodies — SEO spam included — out of the weekly Notion search report
+// and the gap-analysis LLM prompt until the relay starts declaring itself with
+// `X-Pathfinder-Source: github-triage`.
+describe("deploy/copilotkit-docs.yaml — machine-relay exclusion", () => {
+  const relays =
+    (config as unknown as { analytics?: { machine_relays?: unknown[] } })
+      .analytics?.machine_relays ?? [];
+
+  it("declares the GitHub-issue triage relay by identity, not by content shape", () => {
+    expect(relays).toHaveLength(1);
+    const rule = relays[0] as Record<string, unknown>;
+    expect(rule.name).toBe("github-issue-triage");
+    expect(rule.user_agent).toBe("node");
+    expect(rule.client_ip_cidr).toBe("152.55.176.0/20");
+    // An operator reading the dashboard panel must be able to see WHY.
+    expect(String(rule.reason)).toContain("triage relay");
+  });
+});

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -390,6 +390,30 @@ export interface TopQuery {
   avg_top_score: number | null;
 }
 
+/**
+ * One row of the operator-facing "excluded machine-relay traffic" panel — the
+ * answer to "what did the dashboard just stop showing me, and why".
+ *
+ * A silently filtered category is how the original blindness happened, so
+ * every exclusion this server applies is enumerable: one row per declared
+ * fingerprint rule, plus one row for traffic that TAGGED itself via
+ * `X-Pathfinder-Source`. Counts only, deliberately — the excluded text is
+ * still reachable on demand through `?request_source=relay` on any analytics
+ * endpoint, but it is never rendered into a panel or a published report.
+ */
+export interface RelayExclusion {
+  /** Rule name, or {@link RELAY_TAG_EXCLUSION_NAME} for self-declared rows. */
+  name: string;
+  /** Operator-written explanation from config; null for the tag row. */
+  reason: string | null;
+  /** How the row was identified: it said so, or we recognized it. */
+  kind: "tag" | "fingerprint";
+  /** Rows excluded in the window. */
+  count: number;
+  /** Most recent excluded row in the window, or null if none. */
+  last_seen: string | null;
+}
+
 export interface EmptyQuery {
   query_text: string;
   tool_name: string;
@@ -1475,6 +1499,88 @@ export async function getEmptyQueries(
     count: r.count as number,
     last_seen: r.last_seen as string,
   }));
+}
+
+/**
+ * Name used for the exclusion row that covers traffic which DECLARED itself a
+ * relay via `X-Pathfinder-Source` (any value that normalizes to the `relay`
+ * request source). Distinct from a config rule name because it is not
+ * operator-declared — the client asserted it.
+ */
+export const RELAY_TAG_EXCLUSION_NAME = "x-pathfinder-source";
+
+/**
+ * Enumerate what the machine-relay exclusion removed from the operator-facing
+ * surfaces in this window, one row per rule, so the exclusion is visible
+ * rather than silent. See {@link RelayExclusion}.
+ *
+ * The population matches the windowed aggregates (date window, backfilled
+ * rows excluded) MINUS the request-source clause — the whole point is to
+ * count rows the audience filter drops. Rules with a zero count are still
+ * returned: "this rule is declared and matched nothing" is the reading that
+ * tells an operator a stale rule can be deleted.
+ */
+export async function getRelayExclusions(
+  days: number = 7,
+  filter: AnalyticsFilter = {},
+  rules: readonly MachineRelayRule[] = getMachineRelayRules(),
+): Promise<RelayExclusion[]> {
+  const pool = getPool();
+
+  const { clauses: fc, params: fp, nextIdx } = buildFilterClauses(filter);
+  const dw = buildDateWindow(filter, days, nextIdx);
+  const where = whereAnd([...dw.clauses, "latency_ms >= 0"], fc);
+
+  // One aggregate per rule (plus the tag) in a single pass, so the panel
+  // costs one query regardless of how many rules are declared.
+  const selects: string[] = [
+    `count(*) FILTER (WHERE ${RELAY_TAG_SQL})::int AS c_tag`,
+    `max(created_at) FILTER (WHERE ${RELAY_TAG_SQL})::text AS t_tag`,
+  ];
+  const params: unknown[] = [...fp, ...dw.params];
+  let idx = dw.nextIdx;
+  const usable: MachineRelayRule[] = [];
+  for (const rule of rules) {
+    const fpRule = buildMachineRelayPredicate([rule], idx);
+    if (!fpRule.sql) continue;
+    const i = usable.length;
+    selects.push(`count(*) FILTER (WHERE ${fpRule.sql})::int AS c_${i}`);
+    selects.push(
+      `max(created_at) FILTER (WHERE ${fpRule.sql})::text AS t_${i}`,
+    );
+    // The predicate is spliced twice but its params are bound once: the
+    // second splice reuses the SAME placeholders, so push the params once.
+    params.push(...fpRule.params);
+    idx = fpRule.nextIdx;
+    usable.push(rule);
+  }
+
+  const { rows } = await pool.query(
+    `SELECT ${selects.join(", ")} FROM query_log ${where}`,
+    params,
+  );
+  const row = (rows[0] ?? {}) as Record<string, unknown>;
+
+  const out: RelayExclusion[] = [
+    {
+      name: RELAY_TAG_EXCLUSION_NAME,
+      reason:
+        "Client declared itself a machine relay via the X-Pathfinder-Source header",
+      kind: "tag",
+      count: (row.c_tag as number | undefined) ?? 0,
+      last_seen: (row.t_tag as string | null | undefined) ?? null,
+    },
+  ];
+  usable.forEach((rule, i) => {
+    out.push({
+      name: rule.name,
+      reason: rule.reason ?? null,
+      kind: "fingerprint",
+      count: (row[`c_${i}`] as number | undefined) ?? 0,
+      last_seen: (row[`t_${i}`] as string | null | undefined) ?? null,
+    });
+  });
+  return out;
 }
 
 /**

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -1,4 +1,6 @@
 import { getPool } from "./client.js";
+import { getAnalyticsConfig } from "../config.js";
+import type { MachineRelayRule } from "../types.js";
 import {
   COSINE_SCORE_KIND,
   COSINE_SCORE_MAX,
@@ -135,6 +137,50 @@ export const DEFAULT_REQUEST_SOURCE: RequestSource = "user";
  * all-sources view (see {@link AnalyticsFilter.request_source}).
  */
 export const REAL_USER_REQUEST_SOURCES: readonly RequestSource[] = ["user"];
+
+// ---------------------------------------------------------------------------
+// Machine relays
+// ---------------------------------------------------------------------------
+
+/**
+ * Operator-declared fingerprints for MACHINE RELAYS — see
+ * {@link MachineRelayRuleSchema} in src/types.ts for the full rationale.
+ * Re-exported here because every consumer of the exclusion (the readers, the
+ * routes, the dashboard) reaches for it through the analytics module.
+ */
+export type { MachineRelayRule };
+
+/**
+ * Test/opt-in override for {@link getMachineRelayRules}. `null` (the default)
+ * means "read the live server config". Set to an array to pin the rules
+ * without a config file; pass `null` to restore.
+ */
+let machineRelayRulesOverride: MachineRelayRule[] | null = null;
+
+/** @internal — test seam for {@link getMachineRelayRules}. */
+export function __setMachineRelayRulesForTesting(
+  rules: MachineRelayRule[] | null,
+): void {
+  machineRelayRulesOverride = rules;
+}
+
+/**
+ * The machine-relay rules in force, from `analytics.machine_relays` in the
+ * server YAML. Defaults to NO rules: an install that has not declared a relay
+ * never gets a hidden exclusion.
+ *
+ * Config loading is wrapped because the analytics readers are also exercised
+ * in contexts with no YAML on disk (unit tests, ad-hoc scripts); a missing
+ * config must degrade to "no relay rules", never throw inside a reader.
+ */
+export function getMachineRelayRules(): MachineRelayRule[] {
+  if (machineRelayRulesOverride !== null) return machineRelayRulesOverride;
+  try {
+    return getAnalyticsConfig()?.machine_relays ?? [];
+  } catch {
+    return [];
+  }
+}
 
 /**
  * Normalize an arbitrary `X-Pathfinder-Source` header value to a known

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -105,12 +105,22 @@ export {
 
 /**
  * Canonical request-origin tags persisted on `query_log.request_source`.
+ *
+ * `relay` is MACHINE-RELAY traffic: a service that forwards somebody else's
+ * text into the tools verbatim (see {@link MachineRelayRule}). It is real
+ * traffic but it is NOT a user query, so it is excluded from the default
+ * real-user population the same way `synthetic`/`analysis` are.
  * Sourced from the `X-Pathfinder-Source` request header on the MCP init
  * request. Anything outside this set (including a missing header) is coerced
  * to {@link DEFAULT_REQUEST_SOURCE} at the edge so the column only ever holds
  * a known value going forward.
  */
-export const REQUEST_SOURCE_VALUES = ["user", "synthetic", "analysis"] as const;
+export const REQUEST_SOURCE_VALUES = [
+  "user",
+  "synthetic",
+  "analysis",
+  "relay",
+] as const;
 export type RequestSource = (typeof REQUEST_SOURCE_VALUES)[number];
 
 /**
@@ -188,14 +198,29 @@ export function getMachineRelayRules(): MachineRelayRule[] {
  * {@link DEFAULT_REQUEST_SOURCE}. Case-insensitive and whitespace-trimmed so
  * `"Synthetic"` / `" analysis "` still tag correctly.
  */
+/**
+ * Non-canonical `X-Pathfinder-Source` values that map onto a canonical
+ * {@link RequestSource}. This is how a relay declares itself with a name that
+ * says WHICH relay it is ("github-triage") while the analytics layer keeps a
+ * single `relay` audience: the relay does not need to know our taxonomy, and
+ * we do not need a new audience per relay.
+ *
+ * Keys are lower-cased; {@link normalizeRequestSource} trims and lower-cases
+ * before the lookup.
+ */
+export const REQUEST_SOURCE_ALIASES: Readonly<Record<string, RequestSource>> = {
+  "github-triage": "relay",
+};
+
 export function normalizeRequestSource(
   value: string | null | undefined,
 ): RequestSource {
   if (typeof value !== "string") return DEFAULT_REQUEST_SOURCE;
   const v = value.trim().toLowerCase();
-  return (REQUEST_SOURCE_VALUES as readonly string[]).includes(v)
-    ? (v as RequestSource)
-    : DEFAULT_REQUEST_SOURCE;
+  if ((REQUEST_SOURCE_VALUES as readonly string[]).includes(v)) {
+    return v as RequestSource;
+  }
+  return REQUEST_SOURCE_ALIASES[v] ?? DEFAULT_REQUEST_SOURCE;
 }
 
 // ---------------------------------------------------------------------------
@@ -626,9 +651,71 @@ function whereAnd(baseClauses: string[], filterClauses: string[]): string {
  * Returns `{ clauses, params, nextIdx }` shaped like {@link buildFilterClauses}
  * so callers can splice it into their base clauses + param list uniformly.
  */
+/**
+ * Build the SQL predicate that is TRUE for a row emitted by one of the
+ * declared machine relays (see {@link MachineRelayRule}).
+ *
+ * Each rule ANDs the predicates it declares; the rules OR together. Returns
+ * `null` when no usable rule is declared, which every caller reads as "no
+ * relay exclusion at all" — an install that declared nothing must behave
+ * exactly as it did before this feature existed.
+ *
+ * NULL-safety matters here because the predicate is also used NEGATED
+ * (`NOT (...)`). `user_agent`/`client_ip` are nullable, and in SQL's
+ * three-valued logic `NOT (NULL)` is NULL, which a WHERE clause drops — so an
+ * untagged row with no User-Agent would silently vanish from the dashboard.
+ * Every leg is therefore total: the UA compare goes through COALESCE, and the
+ * IP compare sits inside a CASE whose ELSE is `false`. The CASE also guards
+ * the `::inet` cast — `client_ip` is TEXT and can hold a non-address value
+ * (an IPv6 form, a proxy artefact), which would raise a cast error rather
+ * than simply not matching.
+ */
+function buildMachineRelayPredicate(
+  rules: readonly MachineRelayRule[],
+  startIdx: number,
+): { sql: string | null; params: unknown[]; nextIdx: number } {
+  const params: unknown[] = [];
+  const legs: string[] = [];
+  let idx = startIdx;
+
+  for (const rule of rules) {
+    const preds: string[] = [];
+    if (rule.user_agent) {
+      preds.push(`COALESCE(lower(user_agent), '') = $${idx}`);
+      params.push(rule.user_agent.toLowerCase());
+      idx++;
+    }
+    if (rule.client_ip_cidr) {
+      preds.push(
+        `CASE WHEN client_ip ~ '^[0-9]{1,3}(\\.[0-9]{1,3}){3}$' ` +
+          `THEN client_ip::inet <<= $${idx}::inet ELSE false END`,
+      );
+      params.push(rule.client_ip_cidr);
+      idx++;
+    }
+    // A rule with no predicate would match every row. The config schema
+    // rejects that shape, but a hand-rolled caller could still produce one —
+    // skip it rather than emptying the dashboard.
+    if (preds.length === 0) continue;
+    legs.push(`(${preds.join(" AND ")})`);
+  }
+
+  if (legs.length === 0) return { sql: null, params: [], nextIdx: startIdx };
+  return { sql: `(${legs.join(" OR ")})`, params, nextIdx: idx };
+}
+
+/**
+ * SQL that is TRUE for a row the relay TAGGED itself with, i.e. one that
+ * arrived with `X-Pathfinder-Source: github-triage` (normalized to the
+ * `relay` request source). Kept as a named constant so the fingerprint path
+ * and the tag path read as the same concept in every query.
+ */
+const RELAY_TAG_SQL = "request_source = 'relay'";
+
 function buildRequestSourceClause(
   filter: AnalyticsFilter,
   startIdx: number,
+  rules: readonly MachineRelayRule[] = getMachineRelayRules(),
 ): { clauses: string[]; params: unknown[]; nextIdx: number } {
   const rs = filter.request_source;
 
@@ -636,13 +723,41 @@ function buildRequestSourceClause(
     return { clauses: [], params: [], nextIdx: startIdx };
   }
 
+  // The relay AUDIENCE: everything this server considers machine-relay
+  // traffic, whether it declared itself via X-Pathfinder-Source or was
+  // fingerprinted. This is the operator's "show me what was excluded" view
+  // (`?request_source=relay` on every analytics endpoint).
+  if (rs === "relay") {
+    const fp = buildMachineRelayPredicate(rules, startIdx);
+    return {
+      clauses: [
+        fp.sql ? `(${RELAY_TAG_SQL} OR ${fp.sql})` : `(${RELAY_TAG_SQL})`,
+      ],
+      params: fp.params,
+      nextIdx: fp.nextIdx,
+    };
+  }
+
+  // Every other audience excludes relay traffic. The TAG half needs no
+  // clause — a row tagged 'relay' already fails `request_source = 'user'` and
+  // the exact-match branch below — so the only thing to add is the
+  // FINGERPRINT half, which catches relays that do not yet send the header.
+  // Once a relay starts tagging itself, its rows are excluded by the tag and
+  // the fingerprint rule can be deleted from the config with no behavior
+  // change.
+  const fp = buildMachineRelayPredicate(rules, startIdx + 1);
+  const relayExclusion = fp.sql ? [`NOT ${fp.sql}`] : [];
+
   // Default (undefined) and explicit "user" both mean real users, which
   // includes the untagged historical rows (request_source IS NULL).
   if (rs === undefined || rs === "user") {
     return {
-      clauses: [`(request_source = $${startIdx} OR request_source IS NULL)`],
-      params: ["user"],
-      nextIdx: startIdx + 1,
+      clauses: [
+        `(request_source = $${startIdx} OR request_source IS NULL)`,
+        ...relayExclusion,
+      ],
+      params: ["user", ...fp.params],
+      nextIdx: fp.nextIdx,
     };
   }
 
@@ -650,9 +765,38 @@ function buildRequestSourceClause(
   // not synthetic/analysis, so the bare equality (which is NULL-rejecting in
   // SQL three-valued logic) correctly excludes them.
   return {
-    clauses: [`request_source = $${startIdx}`],
-    params: [rs],
-    nextIdx: startIdx + 1,
+    clauses: [`request_source = $${startIdx}`, ...relayExclusion],
+    params: [rs, ...fp.params],
+    nextIdx: fp.nextIdx,
+  };
+}
+
+/**
+ * Standalone machine-relay exclusion, for the one reader that does NOT go
+ * through {@link buildRequestSourceClause}.
+ *
+ * {@link getAtlasRetrievalMetrics} deliberately has no request-source clause
+ * (its window is "all retrieval traffic", not "the real-user audience"), but
+ * its `total_user_queries_window` IS a user-facing denominator and must not
+ * count a relay. Both halves apply: the TAG (`request_source = 'relay'`, set
+ * when the relay sends `X-Pathfinder-Source: github-triage`) and the
+ * FINGERPRINT (User-Agent + CIDR, for a relay that does not yet send it).
+ *
+ * `IS DISTINCT FROM` rather than `<>` so the NULL request_source of a
+ * historical row reads as "not a relay" instead of dropping the row.
+ */
+function buildRelayExclusionClause(
+  startIdx: number,
+  rules: readonly MachineRelayRule[] = getMachineRelayRules(),
+): { clauses: string[]; params: unknown[]; nextIdx: number } {
+  const fp = buildMachineRelayPredicate(rules, startIdx);
+  return {
+    clauses: [
+      "request_source IS DISTINCT FROM 'relay'",
+      ...(fp.sql ? [`NOT ${fp.sql}`] : []),
+    ],
+    params: fp.params,
+    nextIdx: fp.nextIdx,
   };
 }
 
@@ -1556,13 +1700,15 @@ export async function getAtlasRetrievalMetrics(
 
   const { clauses: fc, params: fp, nextIdx } = buildFilterClauses(filter);
   const dw = buildDateWindow(filter, days, nextIdx);
-  const redactedIdx = dw.nextIdx;
+  const relay = buildRelayExclusionClause(dw.nextIdx);
+  const redactedIdx = relay.nextIdx;
   const baseClauses = [
     ...dw.clauses,
+    ...relay.clauses,
     "latency_ms >= 0",
     `query_text != $${redactedIdx}`,
   ];
-  const params = [...fp, ...dw.params, REDACTED_QUERY_TEXT];
+  const params = [...fp, ...dw.params, ...relay.params, REDACTED_QUERY_TEXT];
   const userWhere = whereAnd(baseClauses, fc);
   const atlasWhere = whereAnd(
     [

--- a/src/server.ts
+++ b/src/server.ts
@@ -92,6 +92,7 @@ import {
   getTopQueries,
   getEmptyQueries,
   getBlockedQueries,
+  getRelayExclusions,
   getToolCounts,
   getToolBreakdown,
   normalizeRequestSource,
@@ -3101,6 +3102,7 @@ export interface AnalyticsRouteDeps {
   getTopQueries?: typeof getTopQueries;
   getEmptyQueries?: typeof getEmptyQueries;
   getBlockedQueries?: typeof getBlockedQueries;
+  getRelayExclusions?: typeof getRelayExclusions;
   getToolCounts?: typeof getToolCounts;
   getToolBreakdown?: typeof getToolBreakdown;
   analyticsHtmlPath?: string;
@@ -3119,6 +3121,7 @@ export function registerAnalyticsRoutes(
   const _getTopQueries = deps.getTopQueries ?? getTopQueries;
   const _getEmptyQueries = deps.getEmptyQueries ?? getEmptyQueries;
   const _getBlockedQueries = deps.getBlockedQueries ?? getBlockedQueries;
+  const _getRelayExclusions = deps.getRelayExclusions ?? getRelayExclusions;
   const _getToolCounts = deps.getToolCounts ?? getToolCounts;
   const _getToolBreakdown = deps.getToolBreakdown ?? getToolBreakdown;
   const _analyticsHtmlPath =
@@ -3254,6 +3257,39 @@ export function registerAnalyticsRoutes(
           err,
         );
         res.status(500).json({ error: "Failed to fetch blocked queries" });
+      }
+    },
+  );
+
+  // What the machine-relay exclusion removed from every other panel in this
+  // window, one row per rule. The exclusion is deliberately enumerable: a
+  // silently filtered category is how relayed SEO spam reached the published
+  // reports unnoticed in the first place. Counts only — the excluded TEXT
+  // stays reachable on demand via `?request_source=relay` on the sibling
+  // endpoints, so it is never rendered into a panel or a report by default.
+  app.get(
+    "/api/analytics/relay-exclusions",
+    analyticsAuth,
+    async (req: Request, res: Response) => {
+      const parsed = parseAnalyticsFilter(req);
+      if (!parsed.ok) {
+        res.status(parsed.status).json(parsed.body);
+        return;
+      }
+      const daysParsed = parseDaysOrError(req);
+      if (!daysParsed.ok) {
+        res.status(daysParsed.status).json(daysParsed.body);
+        return;
+      }
+      try {
+        const rows = await _getRelayExclusions(daysParsed.value, parsed.filter);
+        res.json(rows);
+      } catch (err) {
+        console.error(
+          `[analytics] Relay exclusions failed (days=${daysParsed.value} ip=${clientIp(req, trustProxy)}):`,
+          err,
+        );
+        res.status(500).json({ error: "Failed to fetch relay exclusions" });
       }
     },
   );

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,11 +352,67 @@ export const WebhookConfigSchema = z.object({
 
 // ── Analytics configuration schemas ──────────────────────────────────────────
 
+/**
+ * One operator-declared MACHINE-RELAY fingerprint.
+ *
+ * A relay is a machine that forwards somebody else's text into the MCP tools
+ * verbatim (our GitHub-issue triage service is the motivating case: it posts
+ * every new issue body into `search-docs`/`search-code` within seconds of the
+ * issue being filed). Its traffic is legitimate TRAFFIC but it is not a USER
+ * QUERY, so counting it in Top Queries, the weekly search report, the
+ * bi-weekly gap analysis and the unique-IP/session KPIs renders whatever a
+ * stranger typed into a GitHub issue — SEO spam included — into
+ * operator-facing reports and into an LLM prompt whose output we publish.
+ *
+ * The durable fix is for the relay to declare itself with
+ * `X-Pathfinder-Source: github-triage` at MCP session init (that header value
+ * normalizes to the `relay` request source, which the analytics readers
+ * already exclude from the real-user population). This config is the bridge
+ * for relays that do NOT yet send the header: it identifies them by the
+ * properties we can observe today — User-Agent and source IP range.
+ *
+ * A rule matches a row when EVERY predicate it declares matches; a rule that
+ * declares no predicate at all would match everything and is rejected here
+ * rather than silently emptying the dashboard.
+ *
+ * Deliberately NOT content-shaped: "long" and "link-dense" describe one spam
+ * campaign, not a source. The longest LEGITIMATE query observed in a
+ * production week is 7,520 characters, so a length rule would delete real
+ * operator signal. Identity, not shape.
+ */
+export const MachineRelayRuleSchema = z
+  .object({
+    /** Stable operator-facing id, surfaced in the "excluded" panel. */
+    name: z.string().min(1),
+    /** Why this source is a relay. Rendered next to the excluded count. */
+    reason: z.string().min(1).optional(),
+    /** Exact User-Agent match, case-insensitive (e.g. "node"). */
+    user_agent: z.string().min(1).optional(),
+    /** IPv4 CIDR the client IP must sit inside (e.g. "152.55.176.0/20"). */
+    client_ip_cidr: z
+      .string()
+      .regex(
+        /^\d{1,3}(\.\d{1,3}){3}\/\d{1,2}$/,
+        "client_ip_cidr must be an IPv4 CIDR like 152.55.176.0/20",
+      )
+      .optional(),
+  })
+  .refine((r) => Boolean(r.user_agent || r.client_ip_cidr), {
+    message:
+      "machine_relays rule must declare at least one of user_agent / client_ip_cidr (a rule with no predicate would match all traffic)",
+  });
+
 export const AnalyticsConfigSchema = z.object({
   enabled: z.boolean().default(false),
   log_queries: z.boolean().default(true),
   token: z.string().min(1).optional(),
   retention_days: z.number().int().positive().default(90),
+  /**
+   * Machine relays to exclude from the operator-facing analytics surfaces.
+   * See {@link MachineRelayRuleSchema}. Optional and absent by default — no
+   * install gets a hidden exclusion it did not declare.
+   */
+  machine_relays: z.array(MachineRelayRuleSchema).optional(),
 });
 
 // ── Top-level server configuration schema ─────────────────────────────────────
@@ -519,6 +575,7 @@ export type LocalEmbeddingConfig = z.infer<typeof LocalEmbeddingConfigSchema>;
 export type IndexingConfig = z.infer<typeof IndexingConfigSchema>;
 export type WebhookConfig = z.infer<typeof WebhookConfigSchema>;
 export type AnalyticsConfig = z.infer<typeof AnalyticsConfigSchema>;
+export type MachineRelayRule = z.infer<typeof MachineRelayRuleSchema>;
 export type ServerConfig = z.infer<typeof ServerConfigSchema>;
 export type BashCacheConfig = z.infer<typeof BashCacheConfigSchema>;
 export type BashOptions = z.infer<typeof BashOptionsSchema>;

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -2,7 +2,7 @@ import { defineConfig, configDefaults } from "vitest/config";
 
 export default defineConfig({
   test: {
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "scripts/**/*.test.ts"],
     exclude: [...configDefaults.exclude, "dist/**", "**/.claude/**"],
 
     // Pin the suite's timezone. Unpinned, four tests that reason about UTC-day


### PR DESCRIPTION
## The deadline

The weekly search report cron fires **Sunday 09:07 UTC**. It renders full `query_text` into a Notion table. As things stand it will publish SEO spam bodies with live backlinks. The bi-weekly gap analysis (`0 4 1,15 * *`) fires 09-15 with the same rows still in window and feeds those blobs **un-truncated into an LLM prompt** whose output is also published to Notion.

## What happened

A CopilotKit-owned Railway triage service forwards every new GitHub issue body **verbatim** into `search-docs` and `search-code` within ~4s of issue creation. Twenty-three SEO-spam issues (`1rank.app` / `zagfro.com`, two throwaway accounts, now closed) were therefore amplified into `query_log` by our own automation.

Measured over a 7-day production window (2026-09-05 → 2026-09-12):

| | rows | distinct UA | distinct IP | distinct /16 |
|---|---|---|---|---|
| legitimate | 1,272 | 58 | 130 | 106 |
| relay spam | 46 | 1 (`node`) | 1 (`152.55.178.126`) | 1 |

The queries retrieve real content (cosine 0.33–0.43, 4 results), so nothing in the empty-result path or the abuse blocklist ever saw them. They ranked in Top Queries, and from there into both published reports.

## What this changes

Relay traffic is excluded from the operator-facing surfaces two ways, both funnelled through **one** predicate builder so a reader cannot be fixed in one place and missed in another:

- **TAG** — `request_source = 'relay'`, set when a client sends `X-Pathfinder-Source`. `github-triage` is added as an alias onto the `relay` audience, so the relay can name itself without knowing our taxonomy. A parallel change is adding that header at the relay's MCP session init; **this PR does not depend on it landing.**
- **FINGERPRINT** — `analytics.machine_relays` in the server YAML: operator-declared User-Agent + IPv4 CIDR, for a relay that does not yet send the header.

Once the relay starts sending the header, its rows are excluded by the tag and the fingerprint rule can be deleted from config with no behaviour change. The shipped rule in `deploy/copilotkit-docs.yaml` says exactly that in a comment.

**Deliberately identity-shaped, never content-shaped.** The longest *legitimate* query in that production window is **7,520 characters** — longer than every spam row — so a length rule would delete real operator signal. (`length >= 3000 AND urls >= 6` does separate the two populations, but it describes one campaign, not a source.)

### Surfaces now filtered — every consumer checked

| Consumer | How |
|---|---|
| `getTopQueries` | via `buildRequestSourceClause` |
| `getEmptyQueries` | via `buildRequestSourceClause` |
| `getAnalyticsSummary` — incl. `unique_ip_count_window`, `unique_session_count_window`, per-day, by-source, latency | via `buildRequestSourceClause` |
| `getToolCounts`, `getToolBreakdown` | via `buildRequestSourceClause` |
| `getAtlasRetrievalMetrics` (`total_user_queries_window`) | explicit `buildRelayExclusionClause` — this reader has no request-source clause by design |
| `/api/analytics/{summary,queries,empty-queries,tool-counts,tool-breakdown}` | inherited from the readers |
| `scripts/weekly-search-report/` | reads those endpoints with the default audience |
| `scripts/gap-analysis/` | same — the spam never reaches `buildLlmPrompt` |
| `docs/analytics.html` | inherited, plus a new panel |

`getBlockedQueries` is intentionally untouched: it surfaces rows the abuse blocklist short-circuited *before* retrieval and has no audience wiring at all; no relay row is blocked.

### How an operator sees what was excluded

A silently filtered category is how the original blindness happened, so:

- `GET /api/analytics/relay-exclusions` returns one row per rule — name, `kind` (`tag` / `fingerprint`), count, last-seen, and the operator-written **reason**. Rules that matched nothing are still listed, so a stale rule is visible as deletable.
- A new **"Excluded Machine-Relay Traffic"** dashboard panel renders those rows.
- `?request_source=relay` on any analytics endpoint reads the excluded rows back in full.
- The weekly Notion report prints `- Excluded as machine-relay traffic: N (github-issue-triage: 46, …)` under Header metrics. That one fetch is tolerant: an older deployment without the endpoint loses the footnote, not the report. Every other endpoint stays fail-loud.

## Red → green

Fixtures (PGlite, never production): ordinary short legitimate queries; a **7,548-char legitimate query with two links**; a 3.4 KB legitimate paste with no links; a `node` client outside the relay CIDR; relay rows (UA `node`, `152.55.178.126`) carrying the spam body, a *non*-spam issue body, and a zero-result body; plus a self-declared `relay`-tagged row.

**RED** (implementation absent, `2708dbb`) — 7 failed / 6 passed:

```
× keeps relayed bodies out of Top Queries
   AssertionError: expected [ …(7) ] to not include 'Why 1Rank.app Belongs in Your SEO Gro…'
× keeps relayed bodies out of the Empty-Result panel
× keeps relay rows out of the summary counts        expected 5 to be 4   (unique IPs)
× keeps relay rows out of the tool counts and breakdown   expected 15 to be 7
× keeps relay rows out of the Atlas user-query denominator expected 16 to be 7
× renders no relayed body into the weekly Notion report
   AssertionError: expected '# Pathfinder Search Query Report — We…' not to contain '1rank.app'
× puts no relayed body into the gap-analysis LLM prompt
   AssertionError: expected 'You are analyzing usage of Pathfinder…' not to contain '1rank.app'
  Tests  7 failed | 6 passed (13)
```

**GREEN** (same fixtures, `6a9dff1`): `Tests 13 passed (13)`, now 23 with the visibility tests.

### Negative assertions

All five pass in green and are the point of the design: the 7,548-char legitimate query survives on every surface (reader *and* rendered report); the long link-poor paste survives; ordinary short queries survive; a `node` client outside the declared CIDR survives; and with no rules declared, nothing at all is excluded.

### Mutation-tested, so the negatives are not vacuous

Two mutations of the predicate builder, cache cleared, same fixtures:

1. **`length >= 3000 AND urls >= 6`** (the rule the investigation measured) → 4 failures. The relay's *short*, non-spam issue body and the relay's IP/session survive: a content rule catches this campaign and misses the source.
2. **`length >= 3000`** (length-only) → **8 failures, including the decisive ones**:

```
× does NOT exclude the 7,520-char legitimate query
× does NOT exclude a long legitimate paste with few links
× still renders the 7,548-char legitimate query in the weekly report
```

The long-legitimate-query assertions fail the moment the rule goes length-shaped, so they are load-bearing, not decorative.

## Also in here

`npm test` now runs `scripts/**/*.test.ts`. The weekly-report and gap-analysis suites — the two surfaces that publish to Notion — were only ever type-checked, never executed by CI. 159 pre-existing tests there pass unchanged.

## Local gate

`npm run build` ✓ · `npx tsc --noEmit` ✓ · `npx tsc --noEmit -p tsconfig.scripts.json` ✓ · `npm test` → **3,918 passed, 1 skipped, 0 failed** ✓ · `node scripts/check-test-shapes.mjs --self-test` and the ratchet ✓ · `./scripts/check-version-sync.sh` ✓ · `npx prettier --check` over the CI globs ✓.

One flake observed and not reproduced: `atlas-ratification-endpoints.test.ts > returns 409 …` failed once in a full run and passed on its own and on the next full run. Untouched by this change.

## Deploy note

The exclusion is live the moment this merges **and deploys** — the fingerprint rule ships in `deploy/copilotkit-docs.yaml`, no data migration, no relay cooperation required. If that lands before 09:07 UTC Sunday, the weekly report is clean.
