### PR TITLE
Recognize outpost's X-Pathfinder-Source tag so relay rows stop logging as user

### DIFF
--- a/pathfinder.example.yaml
+++ b/pathfinder.example.yaml
@@ -180,9 +180,13 @@ indexing:
 #   # enumerated in the dashboard's "Excluded Machine-Relay Traffic" panel.
 #   # A rule matches when EVERY predicate it declares matches.
 #   #
-#   # Prefer having the relay send `X-Pathfinder-Source: github-triage` at MCP
-#   # session init — that tags its rows directly and needs no rule here. These
-#   # fingerprints are for relays you do not control.
+#   # Prefer having the relay send `X-Pathfinder-Source: relay` at MCP session
+#   # init — that tags its rows directly and needs no rule here. A relay that
+#   # would rather send its own service name can, but only if that name is
+#   # added to REQUEST_SOURCE_ALIASES in src/db/analytics.ts first: an
+#   # unrecognized value is tagged 'user' like any other traffic (the server
+#   # logs a warning naming it). These fingerprints are for relays you do not
+#   # control, or have not taught to tag themselves yet.
 #   machine_relays:
 #     - name: github-issue-triage
 #       reason: Forwards GitHub issue bodies verbatim into search

--- a/src/__tests__/analytics-endpoints.test.ts
+++ b/src/__tests__/analytics-endpoints.test.ts
@@ -63,6 +63,7 @@ import {
   parseAnalyticsFilter,
   requestSourceFromHeaders,
   __resetAnalyticsTokenForTesting,
+  __resetWarnedRequestSourcesForTesting,
   MAX_DAYS,
 } from "../server.js";
 
@@ -577,6 +578,63 @@ describe("requestSourceFromHeaders", () => {
         mkReq({ "x-pathfinder-source": ["analysis", "user"] }),
       ),
     ).toBe("analysis");
+  });
+
+  // ── The unrecognized-value warning ──────────────────────────────────────
+  //
+  // An unknown origin and an absent header both persist as 'user', so a
+  // cross-service vocabulary mismatch is invisible in the data. These tests
+  // pin the one place it IS visible.
+
+  describe("warns about an unrecognized value", () => {
+    let warn: ReturnType<typeof vi.spyOn>;
+
+    beforeEach(() => {
+      __resetWarnedRequestSourcesForTesting();
+      warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    });
+
+    afterEach(() => {
+      warn.mockRestore();
+      __resetWarnedRequestSourcesForTesting();
+    });
+
+    it("names the unrecognized value in the log line", () => {
+      requestSourceFromHeaders(mkReq({ "x-pathfinder-source": "crawler" }));
+      expect(warn).toHaveBeenCalledTimes(1);
+      const line = String(warn.mock.calls[0][0]);
+      expect(line).toContain("x-pathfinder-source");
+      expect(line).toContain("crawler");
+    });
+
+    it("warns once per distinct value, not once per session", () => {
+      for (let i = 0; i < 5; i++) {
+        requestSourceFromHeaders(mkReq({ "x-pathfinder-source": "crawler" }));
+      }
+      expect(warn).toHaveBeenCalledTimes(1);
+      requestSourceFromHeaders(mkReq({ "x-pathfinder-source": "scraper" }));
+      expect(warn).toHaveBeenCalledTimes(2);
+    });
+
+    it("strips control characters and truncates the logged value", () => {
+      requestSourceFromHeaders(
+        mkReq({ "x-pathfinder-source": `evil\n\r${"z".repeat(200)}` }),
+      );
+      const line = String(warn.mock.calls[0][0]);
+      expect(line).not.toContain("\n\r");
+      expect(line).not.toContain("z".repeat(65));
+    });
+
+    it("stays silent for recognized values and for an absent header", () => {
+      // Including the aliases: a client using its declared wire word is
+      // configured correctly and must not generate operator noise.
+      for (const v of ["user", "synthetic", "analysis", "outpost"]) {
+        requestSourceFromHeaders(mkReq({ "x-pathfinder-source": v }));
+      }
+      requestSourceFromHeaders(mkReq({}));
+      requestSourceFromHeaders(mkReq({ "x-pathfinder-source": "   " }));
+      expect(warn).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/src/__tests__/request-source-wire-contract.test.ts
+++ b/src/__tests__/request-source-wire-contract.test.ts
@@ -1,0 +1,211 @@
+/**
+ * The `X-Pathfinder-Source` header is a CROSS-SERVICE CONTRACT, and this file
+ * is the place where our side of it is pinned to the words our clients
+ * actually put on the wire.
+ *
+ * It exists because the contract broke silently. Two PRs shipped on the same
+ * day: outpost started sending `X-Pathfinder-Source: outpost` on the MCP
+ * `initialize` request, and pathfinder started recognizing exactly one
+ * non-canonical value, `github-triage`. Neither knew about the other's word.
+ * `normalizeRequestSource` has no failure mode for an unrecognized value — it
+ * returns the default, `user` — so every relayed row landed in the operator
+ * dashboard as a real user query and the `request_source = 'relay'` half of
+ * the exclusion counted zero forever. Nothing failed; the number was just
+ * wrong.
+ *
+ * So the assertions below are deliberately written as LITERAL wire strings,
+ * not as references to REQUEST_SOURCE_ALIASES. A test that reads the map it
+ * is checking cannot fail when the map is missing an entry. The next client
+ * that picks a new word for itself has to come here and add it, and until it
+ * does, the mismatch is a red CI run instead of a silently mis-attributed
+ * quarter of the dashboard.
+ */
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "vitest";
+import { PGlite } from "@electric-sql/pglite";
+import { __setPoolForTesting, __resetPoolForTesting } from "../db/client.js";
+import {
+  getAnalyticsSummary,
+  getRelayExclusions,
+  getTopQueries,
+  normalizeRequestSource,
+  DEFAULT_REQUEST_SOURCE,
+  RELAY_TAG_EXCLUSION_NAME,
+  __setMachineRelayRulesForTesting,
+} from "../db/analytics.js";
+import { generatePostSchemaMigration } from "../db/schema.js";
+
+// ---------------------------------------------------------------------------
+// The pinned wire vocabulary
+// ---------------------------------------------------------------------------
+
+/**
+ * Every value a real client is known to send in `X-Pathfinder-Source`, and the
+ * analytics audience it must resolve to.
+ *
+ * - `outpost` — the shared pathfinder MCP client in CopilotKit's outpost
+ *   service. One client, several relays: GitHub issue triage AND the
+ *   Discord/Slack/Teams bots all initialize through it, which is why the tag
+ *   is the generic service name and maps to the generic `relay` audience
+ *   rather than to anything GitHub-shaped.
+ * - `github-triage` — the name the triage relay was originally specced to
+ *   send. Kept pinned because retiring a wire word needs the sender to stop
+ *   sending it first, and we cannot see the senders from here.
+ */
+const WIRE_SOURCE_TAGS: ReadonlyArray<readonly [string, string]> = [
+  ["outpost", "relay"],
+  ["github-triage", "relay"],
+];
+
+describe("X-Pathfinder-Source wire contract", () => {
+  it.each(WIRE_SOURCE_TAGS)(
+    "maps the wire value %s to the %s audience",
+    (wireValue, audience) => {
+      expect(normalizeRequestSource(wireValue)).toBe(audience);
+    },
+  );
+
+  it("maps the wire values case- and whitespace-insensitively", () => {
+    // Header values pass through proxies and hand-written config; a client
+    // that sends " Outpost " is still that client.
+    expect(normalizeRequestSource(" Outpost ")).toBe("relay");
+    expect(normalizeRequestSource("GitHub-Triage")).toBe("relay");
+  });
+
+  // ── Negatives: the map must not become permissive ────────────────────────
+
+  it("still defaults an unrecognized client to 'user'", () => {
+    // The whole point of an alias map is that it is a CLOSED set. If a typo
+    // or an unknown service could land in `relay`, the exclusion would start
+    // deleting real traffic from the dashboard instead of relay noise.
+    expect(normalizeRequestSource("totally-unknown-client")).toBe("user");
+    expect(normalizeRequestSource("totally-unknown-client")).not.toBe("relay");
+    expect(normalizeRequestSource("outpos")).toBe("user");
+    expect(normalizeRequestSource("outpost-staging")).toBe("user");
+  });
+
+  it("does not resolve Object.prototype keys through the alias map", () => {
+    // `REQUEST_SOURCE_ALIASES[v]` is an object index. Without a
+    // null-prototype map (or an own-property check) a client sending
+    // `X-Pathfinder-Source: constructor` gets Object itself back from the
+    // lookup, and `?? DEFAULT_REQUEST_SOURCE` does not catch a function.
+    for (const key of ["constructor", "toString", "__proto__", "valueOf"]) {
+      expect(normalizeRequestSource(key)).toBe(DEFAULT_REQUEST_SOURCE);
+      expect(typeof normalizeRequestSource(key)).toBe("string");
+    }
+  });
+
+  it("leaves ordinary user traffic alone", () => {
+    expect(normalizeRequestSource("user")).toBe("user");
+    expect(normalizeRequestSource(undefined)).toBe("user");
+    expect(normalizeRequestSource("")).toBe("user");
+    expect(normalizeRequestSource("synthetic")).toBe("synthetic");
+    expect(normalizeRequestSource("analysis")).toBe("analysis");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End-to-end: a row tagged with the wire value is actually excluded
+// ---------------------------------------------------------------------------
+
+const QUERY_LOG_DDL_MARKER =
+  "-- Analytics: query_log table for tracking tool usage";
+
+function extractAnalyticsDdl(): string {
+  const full = generatePostSchemaMigration();
+  const idx = full.indexOf(QUERY_LOG_DDL_MARKER);
+  if (idx < 0) {
+    throw new Error(`Could not locate "${QUERY_LOG_DDL_MARKER}" in schema`);
+  }
+  return full.slice(idx);
+}
+
+function poolFromPglite(db: PGlite) {
+  return {
+    query: (text: string, params?: unknown[]) => db.query(text, params),
+    connect: async () => ({
+      query: (text: string, params?: unknown[]) => db.query(text, params),
+      release: () => {},
+    }),
+    end: async () => db.close(),
+  };
+}
+
+/** The body outpost relays: an issue/message text, verbatim. */
+const RELAYED_BODY = "Bug: useCopilotAction does not fire on first render";
+const USER_QUERY = "how do I install copilotkit";
+
+describe("a row tagged by the outpost wire value is excluded", () => {
+  let db: PGlite;
+
+  beforeAll(async () => {
+    db = new PGlite();
+    await db.waitReady;
+    await db.exec(extractAnalyticsDdl());
+    __setPoolForTesting(poolFromPglite(db));
+  });
+
+  afterAll(async () => {
+    __resetPoolForTesting();
+    __setMachineRelayRulesForTesting(null);
+    await db.close();
+  });
+
+  beforeEach(async () => {
+    await db.query("DELETE FROM query_log");
+    // NO fingerprint rules: this suite proves the TAG path on its own, so a
+    // passing run cannot be an artifact of the User-Agent + CIDR rule that is
+    // currently doing all the work in production.
+    __setMachineRelayRulesForTesting([]);
+
+    // Both rows are written the way the server writes them: whatever the
+    // client put in the header, through normalizeRequestSource, into the
+    // column. The relay row's IP and User-Agent are deliberately ordinary.
+    await insert(db, USER_QUERY, normalizeRequestSource(undefined));
+    await insert(db, RELAYED_BODY, normalizeRequestSource("outpost"));
+  });
+
+  async function insert(
+    pg: PGlite,
+    queryText: string,
+    requestSource: string,
+  ): Promise<void> {
+    await pg.query(
+      `INSERT INTO query_log
+        (tool_name, query_text, result_count, top_score, score_kind,
+         latency_ms, source_name, session_id, request_source, client_ip,
+         user_agent)
+       VALUES ('search-docs',$1,4,0.4,'cosine',25,'docs',$2,$3,'10.20.30.40','undici')`,
+      [queryText, `sess-${requestSource}`, requestSource],
+    );
+  }
+
+  it("keeps the relayed body out of Top Queries", async () => {
+    const texts = (await getTopQueries(7, 200)).map((r) => r.query_text);
+    expect(texts).not.toContain(RELAYED_BODY);
+    // Negative control in the same assertion: the real query survives, so a
+    // green run cannot come from an empty result set.
+    expect(texts).toContain(USER_QUERY);
+  });
+
+  it("keeps the relayed body out of the summary counts", async () => {
+    const s = await getAnalyticsSummary({}, 7);
+    expect(s.total_queries_window).toBe(1);
+  });
+
+  it("counts the relayed body as a tag exclusion, visibly", async () => {
+    const rows = await getRelayExclusions(7, {});
+    const tagged = rows.find((r) => r.name === RELAY_TAG_EXCLUSION_NAME);
+    expect(tagged?.kind).toBe("tag");
+    expect(tagged?.count).toBe(1);
+  });
+
+  it("surfaces the relayed body under ?request_source=relay", async () => {
+    // Excluded from the default audience is not the same as deleted — the
+    // operator must still be able to see what was held back.
+    const texts = (
+      await getTopQueries(7, 200, { request_source: "relay" })
+    ).map((r) => r.query_text);
+    expect(texts).toContain(RELAYED_BODY);
+    expect(texts).not.toContain(USER_QUERY);
+  });
+});

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -193,25 +193,71 @@ export function getMachineRelayRules(): MachineRelayRule[] {
 }
 
 /**
- * Normalize an arbitrary `X-Pathfinder-Source` header value to a known
- * {@link RequestSource}. Unknown/empty/missing values fall back to
- * {@link DEFAULT_REQUEST_SOURCE}. Case-insensitive and whitespace-trimmed so
- * `"Synthetic"` / `" analysis "` still tag correctly.
- */
-/**
  * Non-canonical `X-Pathfinder-Source` values that map onto a canonical
  * {@link RequestSource}. This is how a relay declares itself with a name that
- * says WHICH relay it is ("github-triage") while the analytics layer keeps a
- * single `relay` audience: the relay does not need to know our taxonomy, and
- * we do not need a new audience per relay.
+ * says WHICH relay it is ("outpost") while the analytics layer keeps a single
+ * `relay` audience: the relay does not need to know our taxonomy, and we do
+ * not need a new audience per relay.
  *
- * Keys are lower-cased; {@link normalizeRequestSource} trims and lower-cases
- * before the lookup.
+ * This map is a CROSS-SERVICE CONTRACT, and the only thing that makes it one
+ * is that the sender's literal word appears here. Nothing downstream can tell
+ * an unknown word from an absent header — both become `user` — so a client
+ * whose word is missing here is not mis-tagged loudly, it is mis-tagged
+ * silently. That already happened once: outpost shipped
+ * `X-Pathfinder-Source: outpost` the same day this map shipped knowing only
+ * `github-triage`, and every relayed row logged as real user traffic while
+ * the `relay` audience counted zero. The wire values are therefore pinned in
+ * src/__tests__/request-source-wire-contract.test.ts as literal strings, so
+ * the next client that picks a new word fails CI instead of the dashboard.
+ *
+ * `outpost` is the shared pathfinder MCP client in CopilotKit's outpost
+ * service, which fronts GitHub issue triage AND the Discord/Slack/Teams bots
+ * — hence the generic service name mapping to the generic `relay` audience,
+ * not to anything GitHub-shaped.
+ *
+ * Null-prototype so a client sending `constructor` or `toString` cannot pull
+ * an inherited member out of the lookup in {@link normalizeRequestSource}.
+ * Keys are lower-cased; that function trims and lower-cases before looking up.
  */
-export const REQUEST_SOURCE_ALIASES: Readonly<Record<string, RequestSource>> = {
-  "github-triage": "relay",
-};
+export const REQUEST_SOURCE_ALIASES: Readonly<Record<string, RequestSource>> =
+  Object.freeze(
+    Object.assign(Object.create(null) as Record<string, RequestSource>, {
+      outpost: "relay",
+      "github-triage": "relay",
+    } satisfies Record<string, RequestSource>),
+  );
 
+/**
+ * True when `value` is a word this server RECOGNIZES — a canonical
+ * {@link RequestSource} or a declared alias. Exported so the request edge can
+ * tell "the client said nothing" (fine, default to `user`) apart from "the
+ * client said something we have never heard of" (a contract gap worth a log
+ * line); {@link normalizeRequestSource} answers `user` to both.
+ */
+export function isRecognizedRequestSource(
+  value: string | null | undefined,
+): boolean {
+  if (typeof value !== "string") return false;
+  const v = value.trim().toLowerCase();
+  if (v === "") return false;
+  return (
+    (REQUEST_SOURCE_VALUES as readonly string[]).includes(v) ||
+    v in REQUEST_SOURCE_ALIASES
+  );
+}
+
+/**
+ * Normalize an arbitrary `X-Pathfinder-Source` header value to a known
+ * {@link RequestSource}, via {@link REQUEST_SOURCE_ALIASES} for the
+ * non-canonical names relays declare. Unknown/empty/missing values fall back
+ * to {@link DEFAULT_REQUEST_SOURCE}. Case-insensitive and whitespace-trimmed
+ * so `"Synthetic"` / `" analysis "` still tag correctly.
+ *
+ * Kept total and silent by design — it runs in readers, scripts and tests as
+ * well as at the request edge. The operator-visible warning for an
+ * unrecognized value belongs at that edge, where a request is in hand; see
+ * `requestSourceFromHeaders` in src/server.ts.
+ */
 export function normalizeRequestSource(
   value: string | null | undefined,
 ): RequestSource {
@@ -730,8 +776,9 @@ function buildMachineRelayPredicate(
 
 /**
  * SQL that is TRUE for a row the relay TAGGED itself with, i.e. one that
- * arrived with `X-Pathfinder-Source: github-triage` (normalized to the
- * `relay` request source). Kept as a named constant so the fingerprint path
+ * arrived with an `X-Pathfinder-Source` a relay declares itself by
+ * (`outpost`, `github-triage`) and so normalized to the `relay` request
+ * source. Kept as a named constant so the fingerprint path
  * and the tag path read as the same concept in every query.
  */
 const RELAY_TAG_SQL = "request_source = 'relay'";

--- a/src/server.ts
+++ b/src/server.ts
@@ -96,6 +96,7 @@ import {
   getToolCounts,
   getToolBreakdown,
   normalizeRequestSource,
+  isRecognizedRequestSource,
   REQUEST_SOURCE_HEADER,
   REQUEST_SOURCE_VALUES,
 } from "./db/analytics.js";
@@ -1540,13 +1541,68 @@ export async function handleExistingSessionRequest<TReq, TRes>(opts: {
  * absent/unknown values to the default ('user'). An array-shaped value (only
  * possible for set-cookie under Express) is defensively ignored.
  *
+ * A value we do not RECOGNIZE is still tagged 'user', but it is no longer
+ * silent — see the warning below.
+ *
  * Exported for tests so the header→source mapping is verified without spinning
  * up the full Express app.
  */
 export function requestSourceFromHeaders(req: Request): RequestSource {
   const raw = req.headers[REQUEST_SOURCE_HEADER];
   const value = Array.isArray(raw) ? raw[0] : raw;
+  if (typeof value === "string" && value.trim() !== "") {
+    warnUnrecognizedRequestSource(value);
+  }
   return normalizeRequestSource(value);
+}
+
+/**
+ * Distinct unrecognized `X-Pathfinder-Source` values already warned about in
+ * this process. The header is read once per MCP session init, so an unbounded
+ * warn would still be bounded by session rate — but a misconfigured client
+ * reconnecting in a loop would bury the line it is supposed to surface, and a
+ * client sending a per-request identifier would grow this set without limit.
+ * One line per distinct word, capped, is enough: the point is to name the
+ * word, once, early.
+ */
+const warnedRequestSources = new Set<string>();
+const WARNED_REQUEST_SOURCES_MAX = 50;
+
+/** @internal — test seam for {@link warnUnrecognizedRequestSource}. */
+export function __resetWarnedRequestSourcesForTesting(): void {
+  warnedRequestSources.clear();
+}
+
+/**
+ * Say so when a client declares an origin this server has never heard of.
+ *
+ * This is the compensation for a normalization that cannot fail: an unknown
+ * `X-Pathfinder-Source` is indistinguishable downstream from no header at all
+ * — both persist as 'user' — so a cross-service vocabulary mismatch shows up
+ * only as an audience that quietly counts zero. That is exactly how outpost's
+ * `outpost` tag went unnoticed against an alias map that knew only
+ * `github-triage`. The fix for the word is in REQUEST_SOURCE_ALIASES; this
+ * line is what makes the NEXT one take minutes instead of a quarter.
+ *
+ * The raw value is truncated and stripped of control characters before it is
+ * logged: it is attacker-controlled input going into an operator's log.
+ */
+function warnUnrecognizedRequestSource(value: string): void {
+  if (isRecognizedRequestSource(value)) return;
+  const key = value.trim().toLowerCase();
+  if (warnedRequestSources.has(key)) return;
+  // At the cap, stop warning rather than warning forever about words we can
+  // no longer remember. Fifty distinct unknown origins is already a louder
+  // signal than any one of them.
+  if (warnedRequestSources.size >= WARNED_REQUEST_SOURCES_MAX) return;
+  warnedRequestSources.add(key);
+  const safe = key.replace(/[^\x20-\x7e]/g, "?").slice(0, 64);
+  console.warn(
+    `[analytics] unrecognized ${REQUEST_SOURCE_HEADER}: "${safe}" — ` +
+      `tagging these rows as '${normalizeRequestSource(undefined)}'. If this ` +
+      `is one of ours, add it to REQUEST_SOURCE_ALIASES in ` +
+      `src/db/analytics.ts and to the wire-contract test.`,
+  );
 }
 
 app.post("/mcp", bearerMiddleware, async (req: Request, res: Response) => {


### PR DESCRIPTION
## Every relay row in production is tagged `user`

Two PRs shipped in parallel today and did not share a vocabulary.

- **outpost** (`c9db887`) sends `X-Pathfinder-Source: outpost` on the MCP `initialize` request. `PATHFINDER_SOURCE` is unset in prod, so the literal value on the wire is `outpost`.
- **pathfinder** (`f2bef19`) shipped `REQUEST_SOURCE_ALIASES` knowing exactly one non-canonical word: `github-triage`.

`outpost` is neither a canonical `RequestSource` nor an alias, so `normalizeRequestSource` falls through to `DEFAULT_REQUEST_SOURCE = "user"`. Nothing failed — the number was just wrong.

**Observed in production.** CopilotKit#7107 was created at 19:20:44Z and relayed at 19:20:48.37 / 19:20:48.39 (`search-docs` / `search-code`, UA `node`, IP `152.55.178.12`). Both rows landed as `request_source = user`. `SELECT request_source, count(*) FROM query_log GROUP BY 1` returns exactly one row — `user | 22239`, min date 2026-06-14. **No row in the entire 90-day retention has ever been `relay`, `synthetic`, or `analysis`.** The `request_source = 'relay'` tag rule (`analytics.ts:737`) has counted zero since the day it shipped; the `github-issue-triage` UA+CIDR fingerprint rule is the only thing currently excluding relay traffic.

### ⚠️ Do not delete the fingerprint rule yet

`machine_relays: github-issue-triage` in the server config must **NOT** be removed until tag-based attribution is *observed working in production* — i.e. until `SELECT count(*) FROM query_log WHERE request_source = 'relay'` is non-zero for traffic that arrived after this deploy. Deleting it on the strength of this PR alone would remove the only exclusion that is currently doing anything.

## What changed

1. **`outpost` → `relay` in the alias map.** Smallest correct fix; needs no outpost redeploy. Mapped to the generic `relay` audience, not anything GitHub-shaped, because outpost's pathfinder client also fronts the Discord/Slack/Teams bots.
2. **A wire-contract test** (`src/__tests__/request-source-wire-contract.test.ts`) pinning the literal strings clients send (`outpost`, `github-triage`) to the audience they mean, deliberately written as literals rather than by reading `REQUEST_SOURCE_ALIASES` — a test that reads the map it checks cannot fail when the map is missing an entry. Plus an end-to-end PGlite case proving an `outpost`-tagged row is excluded from the default audience **with the fingerprint rules disabled**, so a green run cannot be an artifact of the UA+CIDR rule.
3. **A warning at the header boundary.** An unrecognized value and an absent header are indistinguishable downstream — both persist as `user` — which is precisely what hid this for a day. `requestSourceFromHeaders` now emits one `console.warn` per distinct unrecognized word (capped at 50, control characters stripped, truncated to 64 chars) naming the value. It stays *out* of `normalizeRequestSource`, which is called by readers, scripts and tests and must remain total and silent — matching the `next_acquire_reason` / `quarantined_items` convention of making a silent-by-construction outcome operator-visible at the one place a request is in hand.
4. **A latent prototype bug, found by the tests.** `REQUEST_SOURCE_ALIASES` was a plain object literal indexed by an attacker-controlled header value, so `X-Pathfinder-Source: constructor` returned `Object` itself from the lookup and sailed past `?? DEFAULT_REQUEST_SOURCE`. The map is now null-prototype and frozen.
5. **`pathfinder.example.yaml`** no longer tells operators to send a service-specific word that would have to be added to our source first; it points at the canonical `relay`.

## Red-green

**RED** — contract test against unmodified code. It fails by returning `"user"`, not by erroring:

```
 ❯ src/__tests__/request-source-wire-contract.test.ts (10 tests | 7 failed)
     × maps the wire value outpost to the relay audience
     × keeps the relayed body out of Top Queries
     × keeps the relayed body out of the summary counts
     × counts the relayed body as a tag exclusion, visibly
     × surfaces the relayed body under ?request_source=relay

 FAIL > maps the wire value outpost to the relay audience
 AssertionError: expected 'user' to be 'relay' // Object.is equality
 Expected: "relay"
 Received: "user"

 FAIL > keeps the relayed body out of Top Queries
 AssertionError: expected [ …(2) ] to not include 'Bug: useCopilotAction does not fire o…'

 FAIL > keeps the relayed body out of the summary counts
 AssertionError: expected 2 to be 1

 FAIL > counts the relayed body as a tag exclusion, visibly
 AssertionError: expected +0 to be 1

 FAIL > does not resolve Object.prototype keys through the alias map
 AssertionError: expected [Function Object] to be 'user'
```

**GREEN** — same test, unchanged:

```
 Test Files  1 passed (1)
      Tests  10 passed (10)
```

### Mutation-tested negatives

The negatives are not vacuous. Mutating `normalizeRequestSource`'s fallback from `DEFAULT_REQUEST_SOURCE` to `"relay"` (making the map permissive) kills three tests:

```
--- MUTANT: unknown values become permissive (relay) ---
 ❯ src/__tests__/request-source-wire-contract.test.ts (10 tests | 3 failed)
     × still defaults an unrecognized client to 'user'
     × does not resolve Object.prototype keys through the alias map
     × leaves ordinary user traffic alone

 AssertionError: expected 'relay' to be 'user'
```

Mutating the warning's recognized-value guard to never fire kills its negative:

```
--- MUTANT: warn fires for recognized values too ---
     × stays silent for recognized values and for an absent header
 AssertionError: expected "warn" to not be called at all, but actually been called 4 times
   1st warn call: "[analytics] unrecognized x-pathfinder-source: "user" — …"
```

## Gates

```
tsc --noEmit           : 0
npm run build          : 0
npm test               : 198 passed | 1 skipped (199 files), 3948 passed | 1 skipped
check-test-shapes.mjs  : ✓ No new test-shape violations (197 files, 6 rules, 318 baselined)
prettier --check       : All matched files use Prettier code style
```

No positive control on bare `main` was needed: the full suite is green with zero failures.

## What this still does NOT prove

**That the header physically arrives on the wire.** Before this fix, a delivered `outpost` header and a completely absent header produced *identical* `user` rows — so the production evidence above is consistent with both "the header arrived and was mis-normalized" and "the header never arrived at all." This PR makes the first case work; it cannot distinguish the two retrospectively. Confirmation is a post-deploy observation, not a test: after this ships, `request_source = 'relay'` must become non-zero for relayed traffic. If it stays at zero, the header is not reaching us (proxy stripping, config drift, a code path that does not read it) and that is a separate bug. The new warning is what will say so — an `outpost` header that arrives but is rejected now logs; one that never arrives stays silent.
